### PR TITLE
Observability: log map, backlog, lessons log — and the first six fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
             tools.tokenserver.test_agent_status \
             tools.tokenserver.test_usage_history \
             tools.tokenserver.test_quota_cache \
-            tools.tokenserver.test_max_tracker -v
+            tools.tokenserver.test_max_tracker \
+            tools.tokenserver.test_smoke -v
 
   firmware:
     name: ESP32-S3 firmware build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,16 @@ exact 480 x 480 output at meaningful stages. Review the static physical AMOLED
 before motion. Studio approval never authorizes a flash; obtain explicit user
 authorization for the physical install.
 
+## Logs, errors, and learning from mistakes
+
+`docs/observability.md` maps every log the system generates (device serial,
+tokenserver stdout/launchd file, `GET /` diagnostics, state files, the screen
+itself) and contains the periodic comb routine — follow it when asked to
+comb, audit, or investigate logs or odd behavior. Findings go to
+`docs/observability-backlog.md`. Read `docs/lessons.md` before touching
+pollers, parsers, staleness logic, or the launchd setup; fixes with a
+root-cause story add an entry there.
+
 ## Hårdvarufällorna i kortform (detaljer i spec/hardware.md)
 
 - `bsp_display_lock()` LJUGER (esp_err_t genom bool, spegelvänt) — använd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,15 @@ exact 480 x 480 output at meaningful stages. Review the static physical AMOLED
 before motion. Studio approval never authorizes a flash; obtain explicit user
 authorization for the physical install.
 
+## Logs, errors, and learning from mistakes
+
+`docs/observability.md` maps every log the system generates and contains the
+periodic comb routine — follow it when asked to comb, audit, or investigate
+logs or odd behavior. Findings go to `docs/observability-backlog.md`. Read
+`docs/lessons.md` before touching pollers, parsers, staleness logic, or the
+launchd setup: most sharp edges here have a story, and fixes with a
+root-cause story add an entry there.
+
 ## Hardware-aware work
 
 Before proposing external hardware, declaring a device limitation, or designing

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -151,6 +151,7 @@ are not arriving:
 | `usage_http_200 + no_mapped_limits` | Authenticated, but nothing in the usage response mapped (a `; fallback_…` suffix records the header-probe outcome) | Plan may not expose limits; Codex half still works |
 | `usage_request_failed: …` | Network/DNS failure from the Mac | Check the Mac's own connectivity |
 | `usage_http_429 + backoff_until_HH:MM` | Rate-limited by the API; the probe rests until the shown time | Wait — it retries by itself |
+| `probe_crashed: <Type>` | The probe itself hit a bug (crash before it could classify the failure) | Read the traceback in `~/Library/Logs/torget-tokenserver.log`; worth filing |
 
 Codex is read separately from its local app-server, so a bad `claudeProbe`
 never explains missing Codex numbers, and vice versa.

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -170,6 +170,23 @@ dedicated PSU; interpret enumeration bouncing as a power symptom first.
 it needs a powered hub or PSU/data split, which also caps how much the
 firmware log can help until solved.
 
+## 2026-08-13 · CI's fresh VM exposed a boot-blind throttle
+
+**What happened:** the first CI run of the new logging failed a test
+that passed everywhere locally: the throttled save-error log never
+fired. Codex's PR review flagged the same line independently. **Root
+cause:** the throttle used `0.0` as "long ago" with `time.monotonic()`
+— which counts from *boot*. On any machine up less than the 5-minute
+window (CI VMs always; a Mac right after restart), `now - 0.0` never
+reaches the threshold, so the **first error after boot is exactly the
+one that gets swallowed** — in production, not just in tests. **The
+rule:** "never happened yet" is a state, not a timestamp zero; with
+monotonic clocks use a `None` sentinel, because monotonic's epoch is
+arbitrary and *recent* on fresh machines. **Guards:** `None` sentinels
+in both error-log throttles; the writer test now exercises the
+first-error path on CI's short-uptime VMs by construction. **Watch
+for:** any new `last_*_logged` / `last_*_at` throttle seeded with `0.0`.
+
 ## 2026-08-13 · Docs drifted from code five times in two days
 
 **What happened:** five separate correction commits: setup steps telling

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -60,9 +60,11 @@ service was quietly running from a different checkout than the one being
 edited. **Root cause:** the plist hardcodes its `WorkingDirectory`; no
 artifact said which code was live. **The rule:** every long-running
 artifact must be able to answer "what revision are you?" in one command.
-**Guards:** `GET /` reports `rev` + `startedAt` (`8f6b8bd`); the smoke
-test compares `rev` to your checkout; the firmware boot banner logs its
-build time and reset reason (OBS-01, done). **Watch for:** the plist's
+**Guards:** `GET /` reports `rev` + `startedAt` (`8f6b8bd`) and a
+startup `srcFingerprint` (content hash — catches dirty worktrees and
+post-start edits that share HEAD with the checkout); the smoke test
+compares both against your checkout; the firmware boot banner logs its
+version and reset reason (OBS-01, done). **Watch for:** the plist's
 hardcoded `WorkingDirectory` is still the root cause waiting to recur —
 the guards make it visible, not impossible.
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -60,9 +60,11 @@ service was quietly running from a different checkout than the one being
 edited. **Root cause:** the plist hardcodes its `WorkingDirectory`; no
 artifact said which code was live. **The rule:** every long-running
 artifact must be able to answer "what revision are you?" in one command.
-**Guards:** `GET /` reports `rev` + `startedAt` (`8f6b8bd`). **Watch
-for:** the firmware has no equivalent yet (OBS-01); comb step 1 exists
-precisely for this.
+**Guards:** `GET /` reports `rev` + `startedAt` (`8f6b8bd`); the smoke
+test compares `rev` to your checkout; the firmware boot banner logs its
+build time and reset reason (OBS-01, done). **Watch for:** the plist's
+hardcoded `WorkingDirectory` is still the root cause waiting to recur —
+the guards make it visible, not impossible.
 
 ## 2026-08-13 · Stale data replayed as breaking news
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,0 +1,187 @@
+# Lessons log
+
+What has bitten this project, why, and the rule each bite taught. The
+full narratives live in the commit messages (keep writing them there —
+that practice is the best thing this repo does); this file is the index
+that makes them findable without `git log -p`, so the same mistake
+doesn't need to be paid for twice.
+
+**When to add an entry:** any fix whose commit message tells a
+root-cause story, any comb finding (see
+[observability.md](observability.md)) that turned into an "oh, *that's*
+why", any physical-hardware surprise. Format:
+
+```
+## YYYY-MM-DD · Title that names the mistake
+What happened · Root cause · The rule now · Guards (commits, tests, fixtures) · Watch for
+```
+
+Keep entries under ~12 lines. If a guard doesn't exist yet, say so and
+point at the backlog item.
+
+---
+
+## 2026-08-13 · The expired token that outranked a fresh login
+
+**What happened:** the screen sat on `usage_http_401` for hours after a
+perfectly good re-login. **Root cause:** the probe read the OAuth token
+from a running process's environment — which reflects launch time, not
+now. A Claude Desktop child process outlived its token and kept
+"winning" over the fresh keychain credential. A second bug compounded
+it: the probe demanded an active session window, so between windows it
+discarded valid weekly data and reported the *fallback's* 401 as the
+whole story — blaming auth while auth was fine. **The rule:** report
+the status of the source that actually decided, and never require more
+data than the answer needs. **Guards:** keychain fallback + candidate
+ordering (`7d213ec`), probe succeeds without a session window
+(`8d3b4b3`), runbook row updated (`2002725`). **Watch for:** any new
+credential source silently outranking a fresher one.
+
+## 2026-08-13 · The 429 night: the probe fed its own penalty
+
+**What happened:** a debugging evening ended rate-limited, repeatedly.
+**Root cause:** on 429 the probe fell through to the header fallback
+(one more request) and retried the full multi-request cycle two minutes
+later — each retry extending the penalty it was caught in. A dead token
+had the same shape: two doomed requests every 120 s for hours. **The
+rule: failure must slow you down.** Every poller needs backoff, and a
+rate-limit response is an instruction, not an error to retry. **Guards:**
+10-min cooldown honoring `Retry-After`, cycle aborts on 429
+(`c5510b5`); failure-streak slowdown 120→240→480 s (`8f6b8bd`); tests in
+`test_tokenserver.py`. **Watch for:** the firmware pollers, which never
+got this medicine — fixed cadences, agent-status at 1 Hz (OBS-13). Also:
+don't restart the server to "fix" a 429 — that resets the cooldown and
+repeats the mistake.
+
+## 2026-08-13 · A stale worktree served old code for an hour
+
+**What happened:** an hour of process archaeology because the launchd
+service was quietly running from a different checkout than the one being
+edited. **Root cause:** the plist hardcodes its `WorkingDirectory`; no
+artifact said which code was live. **The rule:** every long-running
+artifact must be able to answer "what revision are you?" in one command.
+**Guards:** `GET /` reports `rev` + `startedAt` (`8f6b8bd`). **Watch
+for:** the firmware has no equivalent yet (OBS-01); comb step 1 exists
+precisely for this.
+
+## 2026-08-13 · Stale data replayed as breaking news
+
+**What happened:** after a tokenserver outage, the revived agent feed's
+hours-old "waiting for you" states each seized the whole screen as
+full-screen alerts. Separately, stale waiting/error records displaced
+newly observed work. **Root cause:** alerting and eviction logic trusted
+*content* without checking *age*. **The rule:** freshness is part of the
+data, and anything that interrupts the user must prove it first.
+**Guards:** alerts gated on freshness incl. post-boot (`89f161f`),
+cached quotas rendered stale (`ca55c30`), expired records evicted first
+(`ef85bf3`). **Watch for:** the device's freshness clock is fed by one
+endpoint only — other feeds can still show `LIVE` while dead (OBS-09).
+
+## 2026-08-13 · Upstream data is hostile: the NUL-truncation escalation
+
+**What happened:** four commits in one arc as each fix revealed the next
+hole: quota labels arriving NUL-truncated could confuse parsing, then
+detection, then forecast trust, then key matching. **Root cause:** the
+JSONL and API payloads are *someone else's* output format, unversioned,
+and they change and break mid-write; anything not explicitly validated
+will eventually lie. **The rule:** parsers are contract-strict — reject
+the whole payload on any violation, keep last-known-good, and when a
+value can't be trusted, don't display a "probably". **Guards:**
+`bbcd5ec` → `254f774` → `3d3825c` → `1d371dc`; empty Codex limit names
+(`fa44802`); named vs general quota separation so Spark can never
+replace WEEK (`0a0e98e`); hostile-input C tests in `test/test_tokens.c`.
+**Watch for:** strictness without diagnostics — a rejection today logs
+nothing about *what* offended (OBS-22).
+
+## 2026-08-13 · One byte over budget froze the display
+
+**What happened:** the screen went permanently stale against a healthy
+server. **Root cause:** the worst-case v2 payload was 1 058 bytes; the
+firmware's all-or-nothing body cap was 1 024. Nobody had ever computed
+the worst case. **The rule:** an all-or-nothing contract needs a
+capacity gate — a test that constructs the worst-case payload and proves
+it fits, so growth fails in CI, not on the shelf. **Guards:** headroom
+raised + capacity gate (`c0016d9`, `a90b6f2`,
+`test/test_token_body_capacity.py`). **Watch for:** adding any payload
+field without touching the capacity test.
+
+## 2026-08-13 · Round before you serialize
+
+**What happened:** the device rejected entire max-tracker responses.
+**Root cause:** the server emitted float day-peaks; the device parses
+them into `int8_t` and — correctly, per contract — rejected the whole
+payload. Truth must be shaped *before* the wire, not after. **Guards:**
+server rounds day peaks (`97dd531`); the recorded-live-shape fixture
+`sim-fixtures/max-tracker-live-shape.json` locks the real contract into
+the sim and tests. **The rule:** when a bug comes from real recorded
+data, freeze that data as a fixture forever.
+
+## 2026-08-13 · The log-tail state machine took four rounds
+
+**What happened:** the max-tracker backfill (offsets, watermarks,
+carried lines) was "fixed" four times; round 2's fix was rejected by two
+new empirical repros. Failure modes included permanent starvation
+(oversized line never consumed, offset frozen) and double-counting
+(keying on `(inode, size)`). **The rule:** incremental-file-reader state
+is the hardest state in this codebase — every claimed fix needs a
+reproducing test *before* the fix, and reviewers should assume the next
+hole exists. **Guards:** `6e8ebba`/`733bf9c`, `c5eae88`, `09badc2`,
+`c7c95e5` → `4a5d761`, each with its repro test. **Watch for:** the
+backfill loop still swallows runtime exceptions at 2 Hz (OBS-19).
+
+## 2026-08-13 · Threads shared a list without a story
+
+**What happened:** `ThreadingHTTPServer` request threads shared the
+usage-history store with unguarded swap/sort/rollback. **The rule:**
+every store touched by the HTTP threads needs an explicit lock story,
+and slow work (disk, recompute) moves off the request path. **Guards:**
+thread-safe history (`6966957`), nonblocking cache reads (`c0fddcf`),
+async persistence (`4041f16`). **Watch for:** `_probe_status` is still
+read torn-able without its lock (OBS-18c).
+
+## 2026-08-13 · Inverted defaults shipped a stranger someone else's app
+
+**What happened:** an outside user flashed "VibePulse" and got Swedish
+electricity prices — and their board began polling the maintainer's
+other project's website every 30 s (~2 880 req/day per device). **Root
+cause:** companion apps were opt-out instead of opt-in; the governance
+test passed both ways, so it guarded nothing. **The rule: the defaults
+are the product.** A fresh clone must build exactly one app, and any
+test guarding a default must *fail* on the harmful configuration —
+tighten the test in the same commit as the fix. **Guards:** `57e00ba`
+(defaults flipped + registry test tightened), `2ec791d` (the two-pass
+CMake guard divergence that made "macro on, include dir off" possible).
+**Watch for:** any new build-time gate needs both halves guarded — the
+compile definition *and* the sources it implies.
+
+## 2026-08-13 · A computer USB port cannot run this panel
+
+**What happened:** flashing worked but the running board bounced off the
+USB bus or hung; it looked exactly like a flaky cable or bad firmware.
+**Root cause:** the AMOLED draw exceeds what a computer port reliably
+supplies. **The rule:** flash in download mode (screen dark), run from a
+dedicated PSU; interpret enumeration bouncing as a power symptom first.
+**Guards:** documented in `docs/agent-setup.md` and README
+(`9ddf387`); full narrative in
+`docs/superpowers/reviews/2026-08-13-max-tracker-physical-static.md`.
+**Watch for:** serial-monitoring a *running* board is still unverified —
+it needs a powered hub or PSU/data split, which also caps how much the
+firmware log can help until solved.
+
+## 2026-08-13 · Docs drifted from code five times in two days
+
+**What happened:** five separate correction commits: setup steps telling
+users to uncomment a block that ships active (at the most expensive
+possible step), a README advertising a page that didn't exist, an
+under-claimed privacy surface, stale AGENTS.md claims confusing a
+stranger's agent, and a verification step that "always passes and proves
+nothing". **Root cause:** prose claims have no failure mode — nothing
+red happens when they rot. **The rule:** prefer doc claims a command can
+verify; when code changes behavior, grep the docs for the old claim in
+the same commit; a verification that cannot fail is not a verification.
+**Guards:** `439481a`, `3e2eb3c`, `289fea1`, `e353371`, `668f4c0`; the
+two doc-content tests (`test_shared_amoled_skill.py`,
+`tools/test_hardware_registry.py`) are the only mechanical ones — and
+`design-qa.md` has already drifted again (OBS-26). **Watch for:** every
+new doc in this observability set is prose too; comb step 7 includes
+checking that these files still tell the truth.

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -109,9 +109,10 @@ whenever a 500 is served.
 ### OBS-06 · Move the launchd log out of /tmp, cap it
 `server · S · done (2026-08-13)` — plist now logs to
 `~/Library/Logs/torget-tokenserver.log`; the server self-rotates it at
-startup past 5 MB with the last 256 KB preserved in `.old`, guarded by
-an fstat/stat identity check so terminal runs never touch it. Original
-problem:
+startup and hourly while running (a long-lived process must not outgrow
+the cap between restarts), 5 MB threshold with the last 256 KB preserved
+in `.old`, guarded by an fstat/stat identity check so terminal runs
+never touch it. Original problem:
 `se.torget.tokenserver.plist` sends both streams to
 `/tmp/torget-tokenserver.log`: unrotated and uncapped within a boot, yet
 erased by macOS reboot//tmp-cleaning — unbounded *and* unavailable for

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -135,7 +135,13 @@ appearing later is the normal case on a fresh Mac), plus
 `ThrottleInterval` in the plist as a backstop for any other fatal error.
 
 ### OBS-08 · A crashed usage recompute freezes the numbers forever, silently
-`server · S · open`
+`server · S · done (2026-08-13)` — a crash now logs (throttled to one
+per 5 min), recovery logs as a transition, `GET /` exposes
+`usageComputeOk`/`usageComputeFailingForS`, and the smoke test FAILs on
+it. Deliberately not done: pushing a stale flag into `/api/tokens`
+itself — the firmware parser is contract-strict, so new fields there
+are OBS-09-scale contract work; until then the *screen* still can't see
+this, only `GET /` and the smoke test can. Original problem:
 `_refresh_usage_totals` swallows any `_compute` exception and keeps
 serving the previous snapshot — while still bumping `_last_computed`, so
 the refresh never retries eagerly and nothing is ever printed

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -34,10 +34,11 @@ Tiers:
 ## P1 — stop flying blind
 
 ### OBS-01 · Boot banner: version, git rev, and reset reason
-`firmware · S · done (2026-08-13)` — `app_main` now logs `boot: byggd
-<datum> <tid>, IDF <ver>, omstartsorsak <namn> (<kod>)` as its first
-line, with PANIK/TASKVAKTHUND/BROWNOUT decoded loudly. Takes effect on
-the next flash. Original problem, for the record:
+`firmware · S · done (2026-08-13)` — `app_main` now logs `boot: <namn>
+<version> (byggd <datum> <tid>, IDF <ver>), omstartsorsak <namn> (<kod>)`
+as its first line: the version is git describe via ESP-IDF's app
+descriptor, and PANIK/TASKVAKTHUND/BROWNOUT are decoded loudly. Takes
+effect on the next flash. Original problem, for the record:
 The firmware never announces what it is or why it started:
 `esp_reset_reason()` is called nowhere in the repo, and boot logs carry
 no version or rev. A board that panicked and rebooted overnight is

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -1,0 +1,374 @@
+# Observability backlog
+
+The queue of "things we know we can't see, and things that fail silently"
+— found by a full audit of the firmware, the tokenserver, and the process
+around them (2026-08-13). How these get found and worked is described in
+[observability.md](observability.md); stories behind them live in
+[lessons.md](lessons.md).
+
+**Last combed: 2026-08-13 (initial audit — this document is its result).**
+
+Rules of the file:
+
+- IDs are stable; never renumber. New items append to the matching tier.
+- `Status:` is `open`, `in progress`, or `done (commit)`. Done items keep
+  their entry (they document why the code looks the way it does).
+- An item is one coherent fix, small enough to land in one sitting where
+  possible. Evidence refs are the audit's receipts — verify against
+  current code before building on them.
+- Firmware items that change what's on the glass go through
+  `.claude/skills/iterating-esp32-amoled-ui/SKILL.md` like any visual
+  work. Nothing here authorizes a flash.
+
+Tiers:
+
+- **P1 — stop flying blind.** Failures that today leave no evidence at
+  all, or evidence that lies.
+- **P2 — stop making it worse.** Behavior that amplifies a failure once
+  it starts (hammering, blocking, aborting) or loses data.
+- **P3 — process & hygiene.** Docs, CI, lint, and turning telemetry into
+  alerts.
+
+---
+
+## P1 — stop flying blind
+
+### OBS-01 · Boot banner: version, git rev, and reset reason
+`firmware · S · open`
+The firmware never announces what it is or why it started:
+`esp_reset_reason()` is called nowhere in the repo, and boot logs carry
+no version or rev. A board that panicked and rebooted overnight is
+indistinguishable from one that never did, and "is this board running
+what I just flashed?" is unanswerable — the exact stale-artifact problem
+the server already solved with `rev`/`startedAt` after it cost an hour
+(`tools/tokenserver/tokenserver.py:1510-1512`, commit `8f6b8bd`).
+**Fix:** one `ESP_LOGI` at `app_main` start (`main/main.c`) with
+`esp_app_get_description()` (version, idf ver, build time) +
+`esp_reset_reason()` decoded to text. Cheapest line in this backlog.
+
+### OBS-02 · Enable coredump to flash
+`firmware · M · open`
+No `CONFIG_ESP_COREDUMP_*` anywhere, no coredump row in `partitions.csv`
+— a panic prints a backtrace to a console that is almost never attached,
+then reboots. The evidence never existed. `partitions.csv` documents 16 MB
+flash with deliberate headroom ("marginalen är gratis"), so a 64 K
+coredump partition is free.
+**Fix:** add coredump partition + `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y`
+(+ pin `CONFIG_ESP_SYSTEM_PANIC_PRINT_REBOOT` explicitly, see OBS-28);
+document `idf.py coredump-info` retrieval in the runbook.
+
+### OBS-03 · Reboot ledger in NVS
+`firmware · S · open`
+NVS is initialized (`main/main.c:378-383`) but never used for a single
+key. Persist per-reason reset counters + a boot counter, log them in the
+OBS-01 banner. Turns "did it reboot while I was away?" from unanswerable
+into one serial line — and later feeds a diagnostics view (OBS-27).
+
+### OBS-04 · Give the tokenserver a real logger
+`server · M · open`
+The service has no logging framework: four `print()` sites, no
+timestamps, no levels (`tokenserver.py:656,1574,1605`;
+`agent_status.py:929`). Meanwhile its most important events — probe
+status transitions (401 appears/clears, 429 backoff entered, keychain
+fallback engaged, network errors) — update internal state without
+printing anything, so the log file cannot reconstruct when things
+happened.
+**Fix:** stdlib `logging` to stderr with timestamps + levels; log
+**state transitions, not steady state** (probe status changes, first
+success after failure, store save failures) so volume stays near zero.
+Keep the agent-status privacy sanitization exactly as is
+(`test_agent_status.py` asserts message shape — content-free stays
+content-free).
+
+### OBS-05 · Un-silence the HTTP layer
+`server · S · open`
+`Handler.log_message` is overridden to `pass` to keep 30 s polls out of
+the log (`tokenserver.py:1523-1524`) — but `BaseHTTPRequestHandler`
+routes `log_error` through `log_message`, so *error* logging died with
+it. The two guarded routes swallow their exceptions entirely
+(`:1500-1501`, `:1507-1508`: 500 sent, cause discarded), and
+`/api/agent-status` has no guard at all (`:1502-1503`) — the one route
+that can dump a raw traceback and break the documented
+`{"error": ...}` contract.
+**Fix:** keep access logs muted but restore `log_error`; guard the
+agent-status route like its siblings; log the exception (with traceback)
+whenever a 500 is served.
+
+### OBS-06 · Move the launchd log out of /tmp, cap it
+`server · S · open`
+`se.torget.tokenserver.plist` sends both streams to
+`/tmp/torget-tokenserver.log`: unrotated and uncapped within a boot, yet
+erased by macOS reboot//tmp-cleaning — unbounded *and* unavailable for
+post-mortems at the same time.
+**Fix:** `~/Library/Logs/VibePulse/tokenserver.log` (surfaces in
+Console.app, survives reboot), plus a startup size check that rotates the
+file once past a few MB (stdlib, no logrotate dependency). Update plist,
+`tools/tokenserver/README.md`, and the runbook.
+
+### OBS-07 · Fatal boot error + KeepAlive = silent crash loop
+`server · S · open`
+Missing `~/.claude/projects` raises `SystemExit`
+(`tokenserver.py:1570`); the plist has `KeepAlive` with no
+`ThrottleInterval`, so launchd respawns every ~10 s forever, appending
+the same line ≈8 600×/day to an unrotated file. Nothing distinguishes
+this from healthy except reading the file.
+**Fix:** wait-and-retry with backoff instead of exiting (the directory
+appearing later is the normal case on a fresh Mac), plus
+`ThrottleInterval` in the plist as a backstop for any other fatal error.
+
+### OBS-08 · A crashed usage recompute freezes the numbers forever, silently
+`server · S · open`
+`_refresh_usage_totals` swallows any `_compute` exception and keeps
+serving the previous snapshot — while still bumping `_last_computed`, so
+the refresh never retries eagerly and nothing is ever printed
+(`tokenserver.py:1283-1293`). Token totals silently stop advancing while
+the API keeps answering 200 with confident numbers; the `*Stale` flags
+cover quota percentages only, so the screen cannot detect it. Violates
+the honesty invariant ("never makes numbers up").
+**Fix:** log the exception (throttled), expose
+`lastComputeOk`/`lastComputeAge` on `GET /`, and mark the snapshot stale
+when recomputes keep failing.
+
+### OBS-09 · Staleness is one clock fed by one endpoint
+`firmware · M · open`
+`last_success_us` is written only by `/api/tokens` successes
+(`components/app_tokens/app.c:34`) but the derived `stale` flag is OR-ed
+into every page (`usage_screen.c:450,458`). If `/api/max-tracker`
+(5 min) or `/api/agent-status` (1 s) dies while `/api/tokens` keeps
+succeeding, their pages show hours-old data under a `LIVE` header. Same
+honesty-invariant violation as OBS-08, on the device side.
+**Fix:** per-feed `last_success` timestamps; each page goes stale on its
+*own* feed. Visual change → AMOLED skill gate applies.
+
+### OBS-10 · Failed max-tracker save loses the dirty flag
+`server · S · open`
+The background writer clears `_max_tracker_dirty` *before* calling
+`store.save()` and swallows the exception (`tokenserver.py:1195-1199`);
+the shutdown flush swallows too (`:1616`). One disk-full or permissions
+error and observed day-peaks are silently discarded until an unrelated
+event happens to re-mark dirty.
+**Fix:** re-mark dirty on failure, log it (throttled), and let the next
+cycle retry.
+
+### OBS-11 · Corrupt state files are silently wiped — quarantine them instead
+`server · S · open`
+All three state stores respond to a corrupt file by starting empty with
+no message: `max_tracker.py:1095-1102` (up to **400 days** of history
+plus backfill watermarks), `quota_cache.py:112`, `usage_history.py:81`.
+Recovery is impossible because the corrupt bytes get overwritten by the
+next save.
+**Fix:** on parse failure, rename the file to `<name>.corrupt-<ts>` and
+log loudly before starting fresh. The data is usually 99 % intact —
+quarantining preserves the forensics and the option to hand-repair.
+
+### OBS-12 · Fetch failures discard their own diagnosis
+`firmware · S · open`
+Three related holes in the device's network error reporting:
+(a) `agent_net.c:120` collapses the three-valued fetch result to
+`ESP_OK/ESP_FAIL` before logging, so the log can only ever say
+`transportfel ESP_FAIL` — IO-error vs overflow is computed and thrown
+away. (b) When the HTTP client can't even be created the task logs once
+and `vTaskDelete`s itself (`agent_net.c:110-114`): the agent feed is dead
+until reboot with nothing on screen. (c) `torget_http.c:48-49` returns
+false on client-init failure with no log at all — the only silent path in
+an otherwise well-logged function.
+**Fix:** log the real enum + URL; retry instead of task suicide; add the
+missing log line.
+
+---
+
+## P2 — stop making it worse
+
+### OBS-13 · No backoff anywhere in the firmware
+`firmware · M · open`
+Every device poller runs at a fixed cadence no matter what: tokens 30 s,
+max-tracker 300 s (`net.c:62,112`), agent-status **1 000 ms**
+(`agent_net.c:19,136`), WiFi reconnect 2 s (`main.c:165`). A dead
+tokenserver gets 86 400 connect attempts/day from the agent poller
+alone. The server side already learned this lesson the hard way — the
+429 night (commits `c5510b5`, `8f6b8bd`, and [lessons.md](lessons.md))
+ended in streak-based slowdown and cooldowns — but the firmware never
+got the same medicine.
+**Fix:** consecutive-failure backoff with a cap (e.g. agent 1 s → 30 s,
+tokens 30 s → 300 s), reset on success; log transitions only.
+
+### OBS-14 · WiFi retry blocks the system event loop
+`firmware · S · open`
+The 2 s reconnect delay runs *inside* the default event-loop handler
+(`main/main.c:165`), stalling every other system event (IP events
+included) for 2 s per disconnect — worst exactly when the network is
+flapping.
+**Fix:** schedule the retry (timer or the net task) instead of sleeping
+in the handler; this is also where OBS-13's WiFi backoff lands.
+
+### OBS-15 · NET_READY is granted even when time sync failed
+`firmware · S · open`
+The code comment says SNTP is the precondition for `NET_READY`
+(`main/main.c:191-193`) and the timeout log says fetches "får vänta på
+den" — but `net_task` sets `NET_READY` unconditionally
+(`main.c:211-212`). Apps then fetch HTTPS with a 1970 clock and TLS
+fails as *cert-not-yet-valid*, logged only as generic transport errors —
+a misleading trail (the log blames the network, the clock is at fault).
+**Fix:** either honor the stated contract (block until sync, with
+retry + logging) or keep the optimistic start but log the first fetch
+attempts as "clock unset — TLS failures expected" so the trail reads
+true. Decide, then make comment and code agree.
+
+### OBS-16 · Abort is the configured response to survivable failures
+`firmware · S · open`
+Two `ESP_ERROR_CHECK` sites turn tolerable failures into reboots of a
+shelf appliance: `esp_netif_sntp_init` (`main.c:196` — SNTP *failure* is
+tolerated two lines later, but its *init* panics) and `torget_ui_lock()`
+(`main.c:84` — every UI mutation from every task sits behind an abort).
+With OBS-01/02/03 unfixed, these reboots also leave zero evidence.
+**Fix:** downgrade to log-and-degrade where a frozen-but-visible screen
+beats a reboot; keep hard aborts only for true bring-up (display init,
+NVS).
+
+### OBS-17 · The real tasks have no watchdog coverage
+`firmware · M · open`
+No task ever calls `esp_task_wdt_add()`; only the idle tasks are
+watched (IDF default). The one hang ever observed on hardware was caught
+*incidentally* by IDLE0 (`spec/hardware.md:52`). A `tokens` task wedged
+in a socket read renders exactly like a healthy screen with stale data.
+**Fix:** subscribe the long-lived tasks (`tokens`, `max-tracker`,
+`agent-status`, `rotation`) to the TWDT with feed points in their loops;
+pin TWDT config in `sdkconfig.defaults` (OBS-28). With OBS-01, a WDT
+reset then becomes a *diagnosed* event instead of a mystery.
+
+### OBS-18 · Probe backoff state is invisible, and stale probe data lingers
+`server · S · open`
+Three small holes in the probe's observability:
+(a) `_probe_failure_streak` and the slowed interval
+(`tokenserver.py:305,673-679`) appear in no payload — dashes can mean
+"failing every 120 s" or "resting at 480 s" and you cannot tell.
+(b) `_probe_headers`/`_probe_unknown_buckets` are cleared only on
+success (`:607-608`), so `GET /` can show hours-old header names beside
+a current failure. (c) `_probe_status` is built with `+=` on the probe
+thread and read unlocked by HTTP threads (`:1516`) — a torn half-status
+can be served.
+**Fix:** expose streak/interval/cooldown on `GET /`; stamp or clear
+headers on failure; assemble status into a local and publish once.
+
+### OBS-19 · Slow-client and backfill blind spots
+`server · S · open`
+(a) No handler `timeout`/`protocol_version` on the HTTP handler
+(`tokenserver.py:1465`): a half-open LAN connection parks a worker
+thread in `readline()` forever, uncounted and unlogged.
+(b) The max-tracker backfill loop swallows all exceptions at 2 Hz
+(`:1554-1559`): a persistent fault (permissions, pathological file)
+spins silently forever.
+**Fix:** set a socket timeout; log backfill exceptions throttled (same
+one-per-type-per-30 s pattern agent_status already uses).
+
+### OBS-20 · Keychain failure is one undifferentiated shrug
+`server · S · open`
+A blanket `except Exception` around the `security` call
+(`tokenserver.py:357-368`) collapses four distinct situations — binary
+missing, **user clicked Deny on the keychain prompt**, malformed JSON,
+timeout — into `(None, None)`. The README explicitly coaches users
+through that prompt; if they deny it, the only trace is
+`no_claude_oauth_token` on an endpoint the runbook doesn't mention.
+**Fix:** catch narrowly, give each cause its own probe-status suffix and
+one logged transition (OBS-04).
+
+### OBS-21 · Two of three state writers skip the directory fsync
+`server · S · open`
+`quota_cache` does the full atomic dance — file fsync, rename, *parent
+directory fsync*, with rollback (`quota_cache.py:148-154`) — precisely
+because a rename can otherwise evaporate on power loss.
+`usage_history.py:92-113` and `max_tracker.py:1239-1261` stop at the
+file fsync: the exact hole the third sibling was hardened against, and
+max-tracker is the file with 400 days in it.
+**Fix:** port the quota_cache pattern to both.
+
+### OBS-22 · Parser rejections cannot be diagnosed from the device
+`firmware · S · open`
+The three contract-strict parsers reject a whole payload via 33
+`goto done` / 113 `return false` sites, none of which record what
+offended; the caller logs `hämtningen avvisad, värden står kvar`
+(`net.c:57`) with no URL, length, or field. Contract-strictness is the
+right policy (see lessons: NUL-truncation, ambiguous keys) — the
+*silence* is the problem: a server schema drift produces dashes and a
+log line that explains nothing.
+**Fix:** without weakening the reject-everything stance, log payload
+length + a coarse reason code (which parser, which section index) on
+rejection. Enough to aim the next question, cheap enough for an ESP32.
+
+---
+
+## P3 — process & hygiene
+
+### OBS-23 · The best diagnostics are undocumented; one documented one is wrong
+`docs · S · open`
+(a) `GET /` — rev, startedAt, claudeProbe, unknown buckets — appears in
+no runbook; `docs/agent-setup.md` never mentions it even while its
+symptom table depends on `claudeProbe`. (b)
+`tools/tokenserver/README.md` promises the startup log prints the exact
+`anthropic-ratelimit-*` headers on first probe — but that print sits in
+the *fallback* path (`tokenserver.py:656`) and never fires on a healthy
+server. (c) `idf.py monitor` — the only way to see the only firmware log
+— is mentioned in `README.sv.md` only, not in the English runbook that
+repeatedly says "check the serial log".
+**Fix:** add a "reading the logs" section to `docs/agent-setup.md`
+pointing at [observability.md](observability.md); correct the README
+claim; mention the monitor command + power caveat.
+
+### OBS-24 · CI runs a fraction of the local gate
+`ci · M · open`
+CI = five tokenserver unittest modules + an ESP-IDF build. The 11 C test
+binaries, visual landmarks, hardware-registry checks, and skill-contract
+tests in `./test/run.sh` never run in CI — every parser-regression class
+from the lessons log is guarded only on the maintainer's Mac. The
+`ci.yml` header says the full gate "is tracked as a follow-up issue";
+**no such issue exists**.
+**Fix:** run `./test/run.sh` in CI minus the SDL-dependent captures
+(or with `xvfb`), and actually file the lane-3 issue so the claim in
+`ci.yml` is true.
+
+### OBS-25 · No linting anywhere
+`hygiene · S · open`
+No linter config exists for ~10 k lines of Python (the C side at least
+has `-Wall -Wextra -Werror` in the test gate). Several audit findings
+(bare `except`, swallowed exceptions) are exactly what `ruff` rules
+`E722`/`BLE001`/`S110` flag mechanically.
+**Fix:** `ruff` pinned in `requirements-dev.txt`, config in
+`pyproject.toml`, wired into `test/run.sh` and CI. Start with the
+bug-shaped rules, not the style ones.
+
+### OBS-26 · design-qa.md contradicts the physical review
+`docs · S · open`
+`design-qa.md` still says the physical AMOLED gate is outstanding and
+points at `work/design-qa/…`, a path that doesn't exist —
+contradicting `AGENTS.md` and the 2026-08-13 review that marked the
+static gate PASSED. Doc drift is this repo's most-repeated mistake
+(five correction commits in two days — see lessons).
+**Fix:** retire the file or rewrite it to point at
+`docs/superpowers/reviews/` as the live QA record.
+
+### OBS-27 · Telemetry exists but nothing watches it
+`firmware · M · open`
+The 10 s heap line (`main/main.c:227-235`) logs the exact numbers whose
+collapse predicted the 2026-08-06 panel freeze — and does nothing else:
+no threshold, no warning, no on-screen hint. There are also **zero
+counters** in the firmware (no fetch-failure, reconnect, or uptime
+counts), so "how often did WiFi drop this week?" has no answer even with
+a monitor attached.
+**Fix:** low-water `ESP_LOGW` thresholds on the two numbers that
+mattered (internal free, largest DMA block); a handful of counters
+(reboots via OBS-03, WiFi drops, fetch failures) logged periodically —
+groundwork for a later on-device diagnostics view (which would go
+through the AMOLED gate).
+
+### OBS-28 · Pin logging config on purpose
+`firmware · S · open`
+`sdkconfig.defaults` deliberately pins flash, PSRAM, LVGL, and mbedTLS
+with reasoned comments — but nothing about logging: default level,
+console routing, panic behavior, TWDT are all inherited IDF defaults
+that an IDF bump can silently change. `LV_USE_LOG` is off, which
+compiles out the launcher's only report when an app is skipped for an
+API-version mismatch (`platform/torget_ui.c:182-186`) — that safety
+valve currently fails silently.
+**Fix:** pin `CONFIG_LOG_DEFAULT_LEVEL`, console, panic + TWDT choices
+(with the same style of comment the file already uses), enable
+`LV_USE_LOG` routed to `ESP_LOG`.

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -386,6 +386,18 @@ mattered (internal free, largest DMA block); a handful of counters
 groundwork for a later on-device diagnostics view (which would go
 through the AMOLED gate).
 
+### OBS-29 · An agent-status tailer test is load-flaky
+`test · S · open`
+During this branch's runs, `test_inode_churn_enforces_identity_cap_before_next_discovery`
+(`test_agent_status.py`) failed once in six full-suite runs on a loaded
+Linux container — `base-secret` survived in `tailer._identities` past the
+identity cap — then passed five-for-five in isolation immediately after.
+Suspect: timing-sensitive eviction/verify scheduling stretching under CPU
+load. Platform-dependent test assumptions are an established theme
+(`3743042`, and the lessons entry on CI's fresh VM).
+**Fix:** drive the eviction deterministically in the test (injected clock
+or forced verify schedule) instead of relying on wall-clock behavior.
+
 ### OBS-28 · Pin logging config on purpose
 `firmware · S · open`
 `sdkconfig.defaults` deliberately pins flash, PSRAM, LVGL, and mbedTLS

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -34,7 +34,10 @@ Tiers:
 ## P1 — stop flying blind
 
 ### OBS-01 · Boot banner: version, git rev, and reset reason
-`firmware · S · open`
+`firmware · S · done (2026-08-13)` — `app_main` now logs `boot: byggd
+<datum> <tid>, IDF <ver>, omstartsorsak <namn> (<kod>)` as its first
+line, with PANIK/TASKVAKTHUND/BROWNOUT decoded loudly. Takes effect on
+the next flash. Original problem, for the record:
 The firmware never announces what it is or why it started:
 `esp_reset_reason()` is called nowhere in the repo, and boot logs carry
 no version or rev. A board that panicked and rebooted overnight is
@@ -65,7 +68,11 @@ OBS-01 banner. Turns "did it reboot while I was away?" from unanswerable
 into one serial line — and later feeds a diagnostics view (OBS-27).
 
 ### OBS-04 · Give the tokenserver a real logger
-`server · M · open`
+`server · M · done (2026-08-13)` — stdlib `logging` to stderr with
+timestamps; probe status changes log as `claude-probe: X -> Y`
+transitions (one line per change, silence in steady state); store-save
+failures log throttled; agent-status sanitization untouched. Keychain
+cause granularity remains OBS-20. Original problem:
 The service has no logging framework: four `print()` sites, no
 timestamps, no levels (`tokenserver.py:656,1574,1605`;
 `agent_status.py:929`). Meanwhile its most important events — probe
@@ -81,7 +88,11 @@ Keep the agent-status privacy sanitization exactly as is
 content-free).
 
 ### OBS-05 · Un-silence the HTTP layer
-`server · S · open`
+`server · S · done (2026-08-13)` — `log_error` logs again while the
+access log stays muted; all four routes share one guarded `_reply` (the
+agent-status route keeps the `{"error": ...}` contract now); every 500
+logs its traceback; client disconnects are quiet by design. Original
+problem:
 `Handler.log_message` is overridden to `pass` to keep 30 s polls out of
 the log (`tokenserver.py:1523-1524`) — but `BaseHTTPRequestHandler`
 routes `log_error` through `log_message`, so *error* logging died with
@@ -95,7 +106,11 @@ agent-status route like its siblings; log the exception (with traceback)
 whenever a 500 is served.
 
 ### OBS-06 · Move the launchd log out of /tmp, cap it
-`server · S · open`
+`server · S · done (2026-08-13)` — plist now logs to
+`~/Library/Logs/torget-tokenserver.log`; the server self-rotates it at
+startup past 5 MB with the last 256 KB preserved in `.old`, guarded by
+an fstat/stat identity check so terminal runs never touch it. Original
+problem:
 `se.torget.tokenserver.plist` sends both streams to
 `/tmp/torget-tokenserver.log`: unrotated and uncapped within a boot, yet
 erased by macOS reboot//tmp-cleaning — unbounded *and* unavailable for
@@ -106,7 +121,10 @@ file once past a few MB (stdlib, no logrotate dependency). Update plist,
 `tools/tokenserver/README.md`, and the runbook.
 
 ### OBS-07 · Fatal boot error + KeepAlive = silent crash loop
-`server · S · open`
+`server · S · done (2026-08-13)` — a missing `~/.claude/projects` logs
+one warning and waits (30 s poll) instead of exiting; the plist gained
+`ThrottleInterval 30` as the backstop for any other early death.
+Original problem:
 Missing `~/.claude/projects` raises `SystemExit`
 (`tokenserver.py:1570`); the plist has `KeepAlive` with no
 `ThrottleInterval`, so launchd respawns every ~10 s forever, appending
@@ -141,7 +159,9 @@ honesty-invariant violation as OBS-08, on the device side.
 *own* feed. Visual change → AMOLED skill gate applies.
 
 ### OBS-10 · Failed max-tracker save loses the dirty flag
-`server · S · open`
+`server · S · done (2026-08-13)` — a failed save re-marks dirty and logs
+(throttled to one per 5 min) so the next observation retries; the final
+shutdown flush logs its failure too. Original problem:
 The background writer clears `_max_tracker_dirty` *before* calling
 `store.save()` and swallows the exception (`tokenserver.py:1195-1199`);
 the shutdown flush swallows too (`:1616`). One disk-full or permissions

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -49,8 +49,9 @@ Five tags:
 | `tokens` | `components/app_tokens/net.c` | /api/tokens + /api/max-tracker polls |
 | `agent-net` | `components/app_tokens/agent_net.c` | /api/agent-status poll (1 Hz, log rate-limited to 30 s) |
 
-A healthy boot shows: the `boot:` banner (build date/time, IDF version,
-and the decoded reset reason — `strömpåslag` is normal; `PANIK`,
+A healthy boot shows: the `boot:` banner (project name and git-describe
+version from the app descriptor, build date/time, IDF version, and the
+decoded reset reason — `strömpåslag` is normal; `PANIK`,
 `TASKVAKTHUND` or `BROWNOUT` mean the previous run died and this line is
 your only witness), the WiFi scan table (deliberately permanent — it is
 the ground truth for "which networks can the 2.4 GHz-only S3 actually

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -25,11 +25,15 @@ backlog IDs in parentheses track closing them.
 | # | Source | Where it lives | Survives |
 |---|--------|----------------|----------|
 | 1 | Firmware serial console | USB, only while a monitor is attached | nothing — not even a reboot |
-| 2 | Tokenserver stdout/stderr | terminal, or `/tmp/torget-tokenserver.log` under launchd | until reboot or `/tmp` cleaning |
+| 2 | Tokenserver stderr | terminal, or `~/Library/Logs/torget-tokenserver.log` under launchd | durable; self-rotated at ~5 MB (tail kept in `.old`) |
 | 3 | `GET /` diagnostic endpoint | `http://<mac>:8737/`, live state | process lifetime |
 | 4 | Server state files | `~/Library/Application Support/VibePulse/` | durable (8 d / 400 d retention) |
 | 5 | The screen itself | dashes, `STALE`, `NO DATA` | live only |
 | 6 | CI logs | GitHub Actions | per-run |
+
+Fastest health check: the **smoke test** automates comb steps 1–4 in one
+command — `python3 tools/tokenserver/smoke.py` (exit 0 ok / 1 warnings /
+2 failures).
 
 ### 1. Firmware serial console
 
@@ -45,7 +49,10 @@ Five tags:
 | `tokens` | `components/app_tokens/net.c` | /api/tokens + /api/max-tracker polls |
 | `agent-net` | `components/app_tokens/agent_net.c` | /api/agent-status poll (1 Hz, log rate-limited to 30 s) |
 
-A healthy boot shows: the WiFi scan table (deliberately permanent — it is
+A healthy boot shows: the `boot:` banner (build date/time, IDF version,
+and the decoded reset reason — `strömpåslag` is normal; `PANIK`,
+`TASKVAKTHUND` or `BROWNOUT` mean the previous run died and this line is
+your only witness), the WiFi scan table (deliberately permanent — it is
 the ground truth for "which networks can the 2.4 GHz-only S3 actually
 see"), `WiFi uppe ("...")`, `tid synkad`, then steady-state `hämtning ok`
 lines every 30 s and a `heap:` line every 10 s.
@@ -53,8 +60,9 @@ lines every 30 s and a `heap:` line every 10 s.
 **Blind spots to know about:**
 
 - Nothing persists. A panic prints a backtrace and reboots; if no monitor
-  was attached at that second, the evidence never existed. No coredump
-  partition, no reset-reason readout, no boot counter (OBS-01…OBS-03).
+  was attached at that second, the evidence never existed. The boot
+  banner names the *reason* for the last restart, but there is still no
+  coredump partition and no reboot counter (OBS-02, OBS-03).
 - The log level and console routing are inherited IDF defaults, not
   pinned in `sdkconfig.defaults` like everything else is (OBS-28).
 - Serial-monitoring a *running* board is physically unverified: the panel
@@ -63,35 +71,46 @@ lines every 30 s and a `heap:` line every 10 s.
   Expect to need a powered hub or a PSU/data split; treat a monitor
   session that keeps disconnecting as a power symptom, not a firmware one.
 
-### 2. Tokenserver stdout/stderr
+### 2. Tokenserver stderr
 
-There is no logging framework — a handful of `print()` lines, no
-timestamps (OBS-04). What exists:
+Timestamped `logging` output on stderr. The rule is **transitions, not
+state**: a probe status change logs one line, then silence until it
+changes again — so a healthy week is a handful of lines and anything
+repeating deserves attention. What a healthy boot looks like:
 
-- **stdout, once at boot:** `förstaskanning … s: … Mtok` (first scan
-  summary) and `serverar http://0.0.0.0:8737/api/tokens, …`. If either is
-  missing, the process did not finish starting.
-- **stderr, throttled:** `agent-status <context>: <ErrorName>` — at most
-  one per error type per 30 s, deliberately content-free (privacy: never
-  a path or message from your sessions).
-- **stderr, unthrottled:** Python tracebacks. Today only the
-  `/api/agent-status` route can produce one (it lacks the try/except its
-  sibling routes have, OBS-05); any traceback here is a bug worth filing.
+```
+2026-08-13 21:21:47 INFO startar: rev 7385cb3
+2026-08-13 21:21:47 INFO förstaskanning 2.3 s: … tokens idag, …
+2026-08-13 21:21:47 INFO serverar http://0.0.0.0:8737/api/tokens, …
+2026-08-13 21:23:47 INFO claude-probe: start -> usage_http_200 + ok
+```
+
+- **`claude-probe: X -> Y`** — every probe status transition: a 401
+  appearing, a 429 backoff starting, and the recovery back to ok.
+- **`agent-status <context>: <ErrorName>`** — throttled to one per error
+  type per 30 s, deliberately content-free (privacy: never a path or
+  message from your sessions).
+- **`500 på /api/…` + traceback** — any route serving a 500 now logs its
+  cause; the LAN response stays the sanitized `{"error": ...}` contract.
+  A traceback in this log is a server bug worth filing.
+- Access logging stays muted (a 30 s poll must not fill the file), but
+  HTTP-level *errors* log again — the old mute silenced both.
 
 Under launchd (`se.torget.tokenserver.plist`) both streams append to
-**`/tmp/torget-tokenserver.log`** — unrotated, uncapped, and cleared by
-macOS at reboot or periodic `/tmp` cleaning, so it is simultaneously
-unbounded and useless for post-mortems (OBS-06). The plist hardcodes
+**`~/Library/Logs/torget-tokenserver.log`** — visible in Console.app,
+survives reboot, and the server self-rotates it at startup past ~5 MB
+(tail preserved in `.old`). A missing `~/.claude/projects` no longer
+crash-loops: the server logs one warning and waits for the directory,
+with `ThrottleInterval` as the backstop. The plist hardcodes
 `WorkingDirectory` to `~/Torget/tools/tokenserver`; if the repo lives
 elsewhere, launchd is silently running *different code than you're
 editing* — that exact trap cost an hour once and is why `GET /` reports
-`rev` ([lessons.md](lessons.md)).
+`rev` ([lessons.md](lessons.md)) and why the smoke test compares it to
+your checkout.
 
-Most failures are **silent by design or by accident**: HTTP request
-logging is muted (which also mutes the error path), 401/429/keychain/
-network failures update probe state without printing, and 500 responses
-swallow their exception (OBS-04, OBS-05). Until that changes, absence of
-output proves nothing — read source 3 instead.
+Still invisible from the log: per-request keychain nuance (OBS-20) and
+the probe's backoff-streak value (OBS-18) — those live only on `GET /`
+or nowhere yet.
 
 ### 3. `GET /` — the richest diagnostic surface
 
@@ -155,7 +174,7 @@ succeeding, their pages keep reading as live (OBS-09). Until fixed, a
 
 ### 6. CI logs
 
-GitHub Actions, two lanes: the five tokenserver unittest modules, and an
+GitHub Actions, two lanes: the six tokenserver unittest modules, and an
 ESP-IDF firmware build. **The local gate `./test/run.sh` is much bigger**
 (11 C test binaries, visual landmarks, hardware registries, skill
 contracts) and none of that extra coverage runs in CI (OBS-24). Green CI
@@ -177,8 +196,9 @@ Verbatim strings worth grepping for, and what they mean:
 | `heap: internt … DMA största …` | fw `torget` | every 10 s. Watch the DMA largest block: its collapse predicted the 2026-08-06 panel freeze. Nothing alerts on it yet (OBS-27). |
 | `Guru Meditation` / `abort()` / backtrace | fw | panic. Capture the whole backtrace *now* — it will not survive the reboot (OBS-02). |
 | `Task watchdog got triggered` | fw | a task starved IDLE — the only hang ever seen on hardware surfaced this way. |
-| `hittar inte … — finns Claude Code på den här maskinen?` | server | fatal at boot. Under launchd this respawns ~every 10 s forever, growing the log (OBS-07). Repeated boot lines = this loop. |
-| `Traceback (most recent call last)` | server log | only the agent-status route can throw one today (OBS-05). File it. |
+| `omstartsorsak PANIK` / `TASKVAKTHUND` / `BROWNOUT` | fw boot banner | the previous run died and this line is the only witness. BROWNOUT → suspect the power supply first. |
+| `hittar inte … — finns Claude Code på den här maskinen?` | server | logged once at boot; the server waits for the directory instead of crash-looping. Seeing it repeatedly means something else is killing the process. |
+| `500 på /api/…` + `Traceback` | server log | a route served the sanitized error-form and this is its cause — a server bug, file it. Any traceback *without* a `500 på` line above it is doubly interesting. |
 | `ratelimit-header: …` | server stdout | the *fallback* probe engaged — the primary usage endpoint returned nothing mappable. Not part of a healthy boot despite what the README implies (OBS-23). |
 | `claudeProbe: usage_http_429 + backoff_until_…` | `GET /` | rate-limited; probe is resting ≥10 min. Do not restart the server to "fix" it — that resets the backoff and feeds the penalty (see lessons: the 429 night). |
 
@@ -190,6 +210,11 @@ top to bottom and reports findings against the backlog. With the
 tokenserver on the Mac and the board on its shelf, steps 1–5 need no
 hardware handling at all.
 
+Steps 1–4 are automated: **`python3 tools/tokenserver/smoke.py`** runs
+them as one command (exit 0/1/2 = ok/warnings/failures). Start there;
+the manual detail below is for interpreting what it flags — and steps
+5–7 are judgment calls no script makes for you.
+
 1. **Identity.** `curl -s http://localhost:8737/ | python3 -m json.tool`.
    Does `rev` match `git rev-parse --short HEAD` in the repo launchd runs
    from (check `WorkingDirectory` in the plist — not necessarily this
@@ -199,12 +224,14 @@ hardware handling at all.
    `usage_http_200 + ok`. Anything else → the table in
    [agent-setup.md](agent-setup.md). `unknownRateLimitBuckets` non-empty
    → new upstream bucket, file a backlog item.
-3. **The log file.** `wc -c /tmp/torget-tokenserver.log` (missing file
-   under launchd is itself a finding — /tmp was cleaned).
+3. **The log file.** `wc -c ~/Library/Logs/torget-tokenserver.log`
+   (missing file under launchd means the service never started).
    `grep -c serverar` — more than one per intended restart means
-   crash-looping. `grep -n Traceback` — any hit is a bug.
-   `grep -c 'agent-status'` — a large count means a persistent throttled
-   error has been repeating every 30 s.
+   crash-looping. `grep -n Traceback` — any hit is a bug; the `500 på`
+   line above it names the route. `grep -c 'agent-status'` — a large
+   count means a persistent throttled error has been repeating every
+   30 s. `grep 'claude-probe:'` — the transition history: when did
+   things break, when did they recover.
 4. **State files.** For each file in
    `~/Library/Application Support/VibePulse/`: does it parse
    (`python3 -m json.tool < f > /dev/null`)? Is the mtime recent for

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -129,7 +129,8 @@ Returns live server state, added after real debugging nights:
   [agent-setup.md](agent-setup.md); headline values:
   `usage_http_200 + ok` (healthy), `no_claude_oauth_token`,
   `usage_http_401`, `usage_http_429 + backoff_until_HH:MM`,
-  `usage_request_failed: <Type>`.
+  `usage_request_failed: <Type>`, `probe_crashed: <Type>` (the probe
+  itself hit a bug — the log has the traceback).
 - `ratelimitHeaders` / `unknownRateLimitBuckets` — header names seen by
   the fallback probe. A non-empty `unknownRateLimitBuckets` means
   Anthropic added a bucket we don't map yet: file it.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -132,6 +132,11 @@ Returns live server state, added after real debugging nights:
 - `ratelimitHeaders` / `unknownRateLimitBuckets` — header names seen by
   the fallback probe. A non-empty `unknownRateLimitBuckets` means
   Anthropic added a bucket we don't map yet: file it.
+- `usageComputeOk` / `usageComputeFailingForS` — whether the recompute
+  behind `/api/tokens` is healthy. `false` means the served token totals
+  are frozen at their last good value while *looking* fresh; the smoke
+  test turns this into a FAIL, and the log has the cause
+  (`usage-omräkningen kraschade`).
 
 Not exposed yet, so invisible from outside: the probe's failure streak
 and slowed interval, and any Codex-side probe status (OBS-18). This
@@ -199,6 +204,7 @@ Verbatim strings worth grepping for, and what they mean:
 | `omstartsorsak PANIK` / `TASKVAKTHUND` / `BROWNOUT` | fw boot banner | the previous run died and this line is the only witness. BROWNOUT → suspect the power supply first. |
 | `hittar inte … — finns Claude Code på den här maskinen?` | server | logged once at boot; the server waits for the directory instead of crash-looping. Seeing it repeatedly means something else is killing the process. |
 | `500 på /api/…` + `Traceback` | server log | a route served the sanitized error-form and this is its cause — a server bug, file it. Any traceback *without* a `500 på` line above it is doubly interesting. |
+| `usage-omräkningen kraschade` | server log | `/api/tokens` is serving frozen totals that look fresh. `usage-omräkningen frisk igen` closes the episode; until it appears, distrust the day/month numbers. |
 | `ratelimit-header: …` | server stdout | the *fallback* probe engaged — the primary usage endpoint returned nothing mappable. Not part of a healthy boot despite what the README implies (OBS-23). |
 | `claudeProbe: usage_http_429 + backoff_until_…` | `GET /` | rate-limited; probe is resting ≥10 min. Do not restart the server to "fix" it — that resets the backoff and feeds the penalty (see lessons: the 429 night). |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -121,9 +121,13 @@ curl -s http://localhost:8737/ | python3 -m json.tool
 
 Returns live server state, added after real debugging nights:
 
-- `rev` + `startedAt` — which code is actually serving, since when.
-  `rev` should equal `git -C <repo> rev-parse --short HEAD`. A recent
-  `startedAt` you didn't cause means crash-looping (see comb step 2).
+- `rev` + `srcFingerprint` + `startedAt` — which code is actually
+  serving, since when. `rev` should equal
+  `git -C <repo> rev-parse --short HEAD`; `srcFingerprint` is a content
+  hash of the loaded source taken at startup, which catches what rev
+  cannot — a dirty worktree, or files edited after the process started
+  (the smoke test compares both). A recent `startedAt` you didn't cause
+  means crash-looping (see comb step 2).
 - `claudeProbe` — the quota probe's status string. The full
   value→meaning→action table lives in
   [agent-setup.md](agent-setup.md); headline values:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,246 @@
+# Observability: every log this system generates
+
+VibePulse spans two machines — a screen with no persistent storage and a
+Python service on a Mac — and each produces evidence in a different place,
+with a different lifetime, in a different language. This doc maps all of
+it: where each log lives, how long it survives, what a healthy one looks
+like, and a periodic **comb routine** for reading through them to catch
+problems before they become symptoms on the screen.
+
+Companion docs:
+
+- **[observability-backlog.md](observability-backlog.md)** — the known
+  gaps and the queue of fixes. Anything odd you find during a comb that
+  isn't already there gets added there.
+- **[lessons.md](lessons.md)** — what has already bitten us and what it
+  taught. Read it before touching pollers, parsers, staleness logic, or
+  the launchd setup: most of this system's sharp edges have a story.
+
+This doc describes the system **as it is**, including what is *not*
+logged. Several sources below are honest about being blind spots; the
+backlog IDs in parentheses track closing them.
+
+## The log map
+
+| # | Source | Where it lives | Survives |
+|---|--------|----------------|----------|
+| 1 | Firmware serial console | USB, only while a monitor is attached | nothing — not even a reboot |
+| 2 | Tokenserver stdout/stderr | terminal, or `/tmp/torget-tokenserver.log` under launchd | until reboot or `/tmp` cleaning |
+| 3 | `GET /` diagnostic endpoint | `http://<mac>:8737/`, live state | process lifetime |
+| 4 | Server state files | `~/Library/Application Support/VibePulse/` | durable (8 d / 400 d retention) |
+| 5 | The screen itself | dashes, `STALE`, `NO DATA` | live only |
+| 6 | CI logs | GitHub Actions | per-run |
+
+### 1. Firmware serial console
+
+The only log the device has. ESP-IDF `ESP_LOGx` over the USB console —
+attach with `idf.py monitor -p /dev/cu.usbmodem101` (ESP-IDF env sourced).
+Five tags:
+
+| Tag | Owner | Talks about |
+|-----|-------|-------------|
+| `torget` | `main/main.c` | boot, WiFi, SNTP, heap, brightness, MADCTL |
+| `rotation` | `main/rotation.c` | IMU reads, display rotation |
+| `torget-http` | `components/torget_net/torget_http.c` | every GET: error name, status, cap, URL |
+| `tokens` | `components/app_tokens/net.c` | /api/tokens + /api/max-tracker polls |
+| `agent-net` | `components/app_tokens/agent_net.c` | /api/agent-status poll (1 Hz, log rate-limited to 30 s) |
+
+A healthy boot shows: the WiFi scan table (deliberately permanent — it is
+the ground truth for "which networks can the 2.4 GHz-only S3 actually
+see"), `WiFi uppe ("...")`, `tid synkad`, then steady-state `hämtning ok`
+lines every 30 s and a `heap:` line every 10 s.
+
+**Blind spots to know about:**
+
+- Nothing persists. A panic prints a backtrace and reboots; if no monitor
+  was attached at that second, the evidence never existed. No coredump
+  partition, no reset-reason readout, no boot counter (OBS-01…OBS-03).
+- The log level and console routing are inherited IDF defaults, not
+  pinned in `sdkconfig.defaults` like everything else is (OBS-28).
+- Serial-monitoring a *running* board is physically unverified: the panel
+  draw can bounce the board off a computer USB port
+  (`docs/superpowers/reviews/2026-08-13-max-tracker-physical-static.md`).
+  Expect to need a powered hub or a PSU/data split; treat a monitor
+  session that keeps disconnecting as a power symptom, not a firmware one.
+
+### 2. Tokenserver stdout/stderr
+
+There is no logging framework — a handful of `print()` lines, no
+timestamps (OBS-04). What exists:
+
+- **stdout, once at boot:** `förstaskanning … s: … Mtok` (first scan
+  summary) and `serverar http://0.0.0.0:8737/api/tokens, …`. If either is
+  missing, the process did not finish starting.
+- **stderr, throttled:** `agent-status <context>: <ErrorName>` — at most
+  one per error type per 30 s, deliberately content-free (privacy: never
+  a path or message from your sessions).
+- **stderr, unthrottled:** Python tracebacks. Today only the
+  `/api/agent-status` route can produce one (it lacks the try/except its
+  sibling routes have, OBS-05); any traceback here is a bug worth filing.
+
+Under launchd (`se.torget.tokenserver.plist`) both streams append to
+**`/tmp/torget-tokenserver.log`** — unrotated, uncapped, and cleared by
+macOS at reboot or periodic `/tmp` cleaning, so it is simultaneously
+unbounded and useless for post-mortems (OBS-06). The plist hardcodes
+`WorkingDirectory` to `~/Torget/tools/tokenserver`; if the repo lives
+elsewhere, launchd is silently running *different code than you're
+editing* — that exact trap cost an hour once and is why `GET /` reports
+`rev` ([lessons.md](lessons.md)).
+
+Most failures are **silent by design or by accident**: HTTP request
+logging is muted (which also mutes the error path), 401/429/keychain/
+network failures update probe state without printing, and 500 responses
+swallow their exception (OBS-04, OBS-05). Until that changes, absence of
+output proves nothing — read source 3 instead.
+
+### 3. `GET /` — the richest diagnostic surface
+
+```
+curl -s http://localhost:8737/ | python3 -m json.tool
+```
+
+Returns live server state, added after real debugging nights:
+
+- `rev` + `startedAt` — which code is actually serving, since when.
+  `rev` should equal `git -C <repo> rev-parse --short HEAD`. A recent
+  `startedAt` you didn't cause means crash-looping (see comb step 2).
+- `claudeProbe` — the quota probe's status string. The full
+  value→meaning→action table lives in
+  [agent-setup.md](agent-setup.md); headline values:
+  `usage_http_200 + ok` (healthy), `no_claude_oauth_token`,
+  `usage_http_401`, `usage_http_429 + backoff_until_HH:MM`,
+  `usage_request_failed: <Type>`.
+- `ratelimitHeaders` / `unknownRateLimitBuckets` — header names seen by
+  the fallback probe. A non-empty `unknownRateLimitBuckets` means
+  Anthropic added a bucket we don't map yet: file it.
+
+Not exposed yet, so invisible from outside: the probe's failure streak
+and slowed interval, and any Codex-side probe status (OBS-18). This
+endpoint is also absent from the runbook (OBS-23) — this section is
+currently its only documentation.
+
+### 4. Server state files
+
+`~/Library/Application Support/VibePulse/`:
+
+| File | Content | Retention |
+|------|---------|-----------|
+| `usage-history.json` | quota trend points, ≥15 min apart | 8 days |
+| `quota-cache.json` | last-known quota truths + reset times | until reset passes |
+| `max-tracker.json` | daily peaks, streaks, backfill watermarks | 400 days |
+
+All three are written atomically (temp + fsync + rename). All three
+**silently start over from empty if corrupt** — a bad `max-tracker.json`
+discards up to 400 days of history with no message and no backup
+(OBS-11). During a comb, validating these files is cheap insurance;
+`python3 -m json.tool < file > /dev/null` is enough to know they parse.
+
+### 5. The screen itself
+
+The display is a diagnostic surface with exactly three words, all
+governed by the honesty invariant (never invented zeros):
+
+- **Dashes** — no data ever received for that field. Before first fetch,
+  or the source is genuinely absent. Persistent dashes = fetch/config
+  problem, use the symptom table in [agent-setup.md](agent-setup.md).
+- **`STALE`** — data exists but the last `/api/tokens` success is >120 s
+  old, or the server marked its own numbers stale. Freeze-frame, not
+  live.
+- **`NO DATA` / `USAGE UNAVAILABLE`** — the per-field honest absence.
+
+Caveat: the 120 s freshness clock is fed **only by `/api/tokens`**. If
+the max-tracker or agent-status feed dies while `/api/tokens` keeps
+succeeding, their pages keep reading as live (OBS-09). Until fixed, a
+"LIVE" header is not proof for those two feeds.
+
+### 6. CI logs
+
+GitHub Actions, two lanes: the five tokenserver unittest modules, and an
+ESP-IDF firmware build. **The local gate `./test/run.sh` is much bigger**
+(11 C test binaries, visual landmarks, hardware registries, skill
+contracts) and none of that extra coverage runs in CI (OBS-24). Green CI
++ red `./test/run.sh` is possible; the local gate is the authority.
+
+## Known bad signatures
+
+Verbatim strings worth grepping for, and what they mean:
+
+| Signature | Source | Meaning / action |
+|-----------|--------|------------------|
+| `WiFi tappat ("…", orsak 201)` | fw `torget` | network invisible: wrong SSID or 5 GHz-only. 15/204 = bad password. |
+| `ingen tid från SNTP ännu` | fw `torget` | clock unset — but fetches proceed anyway and TLS fails as generic transport errors (OBS-15). Treat later cert/transport noise as *this*. |
+| `hämtning misslyckades: ESP_ERR_… (http://…)` | fw `torget-http` | transport failure, with URL. Wrong hostname shows up here. |
+| `kroppen större än … byte, avvisad` | fw `torget-http` | payload over cap — server-side schema growth. See lessons: the 1058-byte incident. |
+| `hämtningen avvisad, värden står kvar` | fw `tokens` | fetch rejected. If no `torget-http` line explains it, the parser rejected the schema — suspect server/firmware version skew (OBS-22). |
+| `agentstatus avvisad: transportfel ESP_FAIL` | fw `agent-net` | always literally `ESP_FAIL` — the real cause is discarded before logging (OBS-12). Only says "agent feed unhappy". |
+| `agentstatus kunde inte skapa HTTP-klient` | fw `agent-net` | agent feed **dead until reboot**; screen shows a frozen header meanwhile (OBS-12). |
+| `heap: internt … DMA största …` | fw `torget` | every 10 s. Watch the DMA largest block: its collapse predicted the 2026-08-06 panel freeze. Nothing alerts on it yet (OBS-27). |
+| `Guru Meditation` / `abort()` / backtrace | fw | panic. Capture the whole backtrace *now* — it will not survive the reboot (OBS-02). |
+| `Task watchdog got triggered` | fw | a task starved IDLE — the only hang ever seen on hardware surfaced this way. |
+| `hittar inte … — finns Claude Code på den här maskinen?` | server | fatal at boot. Under launchd this respawns ~every 10 s forever, growing the log (OBS-07). Repeated boot lines = this loop. |
+| `Traceback (most recent call last)` | server log | only the agent-status route can throw one today (OBS-05). File it. |
+| `ratelimit-header: …` | server stdout | the *fallback* probe engaged — the primary usage endpoint returned nothing mappable. Not part of a healthy boot despite what the README implies (OBS-23). |
+| `claudeProbe: usage_http_429 + backoff_until_…` | `GET /` | rate-limited; probe is resting ≥10 min. Do not restart the server to "fix" it — that resets the backoff and feeds the penalty (see lessons: the 429 night). |
+
+## The comb routine
+
+Run every week or two, and after any incident. Every step is a command
+plus a question; an agent asked to **"comb the logs"** follows this list
+top to bottom and reports findings against the backlog. With the
+tokenserver on the Mac and the board on its shelf, steps 1–5 need no
+hardware handling at all.
+
+1. **Identity.** `curl -s http://localhost:8737/ | python3 -m json.tool`.
+   Does `rev` match `git rev-parse --short HEAD` in the repo launchd runs
+   from (check `WorkingDirectory` in the plist — not necessarily this
+   checkout)? Is `startedAt` older than the last reboot, i.e. no silent
+   crash-looping?
+2. **Probe health.** Same payload: `claudeProbe` should be
+   `usage_http_200 + ok`. Anything else → the table in
+   [agent-setup.md](agent-setup.md). `unknownRateLimitBuckets` non-empty
+   → new upstream bucket, file a backlog item.
+3. **The log file.** `wc -c /tmp/torget-tokenserver.log` (missing file
+   under launchd is itself a finding — /tmp was cleaned).
+   `grep -c serverar` — more than one per intended restart means
+   crash-looping. `grep -n Traceback` — any hit is a bug.
+   `grep -c 'agent-status'` — a large count means a persistent throttled
+   error has been repeating every 30 s.
+4. **State files.** For each file in
+   `~/Library/Application Support/VibePulse/`: does it parse
+   (`python3 -m json.tool < f > /dev/null`)? Is the mtime recent for
+   `usage-history.json` (should move every ≤15 min while you work)? Did
+   `max-tracker.json` shrink dramatically since last comb (silent
+   corruption reset, OBS-11)?
+5. **Screen truth.** Glance at the panel: dashes or `STALE` anywhere data
+   should be live? Remember the max-tracker/agent caveat (OBS-09): a live
+   quota page does not vouch for the other feeds — compare the heatmap
+   against `curl -s http://localhost:8737/api/max-tracker`.
+6. **Device serial (when practical).** Attach `idf.py monitor` (mind the
+   power caveat in source 1), watch one full poll cycle: any signature
+   from the table above? Note the DMA largest-block number and compare
+   with the last comb. If the board rebooted since last time you can't
+   tell today (OBS-01) — that is the point of that backlog item.
+7. **Close the loop.** Every oddity becomes either a backlog entry
+   (observability-backlog.md, with the evidence you just collected), a
+   fix now (small + obvious), or a lessons entry (root-caused stories).
+   Update the `Last combed:` line at the top of the backlog. A comb that
+   files nothing and updates the date is a legitimate result.
+
+## How findings flow
+
+```
+comb / incident
+      │
+      ▼
+observability-backlog.md   (queue: what to look into and fix)
+      │  fixed
+      ▼
+CHANGELOG.md ### Fixed     (release-facing summary)
+      │  when there is a story
+      ▼
+lessons.md                 (root cause → the rule we now follow)
+```
+
+Commit messages stay the primary narrative — write the full story there
+as before — but lessons.md is the index that makes those stories
+findable without `git log -p`.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -33,7 +33,10 @@ idf_component_register(
            esp_wifi
            esp_netif
            esp_event
-           esp_timer)
+           esp_timer
+           # bootbanderollens appdeskriptor (esp_app_desc.h) — explicit
+           # hellre än via transitiva beroenden som kan ändras i en IDF-bump
+           esp_app_format)
 
 if(EXISTS "$ENV{TORGET_SOLELKOLLEN_DIR}/app_solelkollen")
   target_compile_definitions(${COMPONENT_LIB} PRIVATE TORGET_HAVE_SOLELKOLLEN)

--- a/main/main.c
+++ b/main/main.c
@@ -15,6 +15,7 @@
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
 
+#include "esp_app_desc.h"
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_netif.h"
@@ -398,13 +399,15 @@ static const char *reset_reason_name(esp_reset_reason_t r) {
 
 void app_main(void) {
   /* Bootbanderollen svarar på två frågor loggen annars inte kan:
-   * "kör kortet det jag just flashade?" (byggtiden) och "varför startade
-   * det om?" (orsaken — en nattlig panik/brownout är annars osynlig i
-   * efterhand). Serverns motsvarighet är rev/startedAt på GET /. */
+   * "kör kortet det jag just flashade?" (versionen är git describe via
+   * ESP-IDF:s appdeskriptor, plus byggtiden) och "varför startade det om?"
+   * (orsaken — en nattlig panik/brownout är annars osynlig i efterhand).
+   * Serverns motsvarighet är rev/startedAt på GET /. */
+  const esp_app_desc_t *app = esp_app_get_description();
   esp_reset_reason_t rr = esp_reset_reason();
-  ESP_LOGI(TAG, "boot: byggd %s %s, IDF %s, omstartsorsak %s (%d)",
-           __DATE__, __TIME__, esp_get_idf_version(),
-           reset_reason_name(rr), (int)rr);
+  ESP_LOGI(TAG, "boot: %s %s (byggd %s %s, IDF %s), omstartsorsak %s (%d)",
+           app->project_name, app->version, app->date, app->time,
+           app->idf_ver, reset_reason_name(rr), (int)rr);
 
   esp_err_t nvs = nvs_flash_init();
   if (nvs == ESP_ERR_NVS_NO_FREE_PAGES || nvs == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/main/main.c
+++ b/main/main.c
@@ -19,6 +19,7 @@
 #include "esp_log.h"
 #include "esp_netif.h"
 #include "esp_netif_sntp.h"
+#include "esp_system.h"
 #include "esp_timer.h"
 #include "esp_wifi.h"
 #include "nvs_flash.h"
@@ -374,7 +375,37 @@ esp_err_t torget_display_rotation_set(bsp_display_rotation_t rotation) {
 
 /* ------------------------------------------------------------------- start */
 
+static const char *reset_reason_name(esp_reset_reason_t r) {
+  switch (r) {
+  case ESP_RST_POWERON: return "strömpåslag";
+  case ESP_RST_SW: return "mjukvaruomstart";
+  case ESP_RST_PANIC: return "PANIK";
+  case ESP_RST_INT_WDT: return "AVBROTTSVAKTHUND";
+  case ESP_RST_TASK_WDT: return "TASKVAKTHUND";
+  case ESP_RST_WDT: return "annan vakthund";
+  case ESP_RST_BROWNOUT: return "BROWNOUT — misstänk strömförsörjningen";
+  case ESP_RST_DEEPSLEEP: return "djupsömn";
+  case ESP_RST_EXT: return "extern reset";
+  case ESP_RST_USB: return "USB-reset";
+  case ESP_RST_JTAG: return "JTAG";
+  case ESP_RST_SDIO: return "SDIO";
+  case ESP_RST_EFUSE: return "efuse-fel";
+  case ESP_RST_PWR_GLITCH: return "spänningsglitch";
+  case ESP_RST_CPU_LOCKUP: return "CPU-låsning";
+  default: return "okänd";
+  }
+}
+
 void app_main(void) {
+  /* Bootbanderollen svarar på två frågor loggen annars inte kan:
+   * "kör kortet det jag just flashade?" (byggtiden) och "varför startade
+   * det om?" (orsaken — en nattlig panik/brownout är annars osynlig i
+   * efterhand). Serverns motsvarighet är rev/startedAt på GET /. */
+  esp_reset_reason_t rr = esp_reset_reason();
+  ESP_LOGI(TAG, "boot: byggd %s %s, IDF %s, omstartsorsak %s (%d)",
+           __DATE__, __TIME__, esp_get_idf_version(),
+           reset_reason_name(rr), (int)rr);
+
   esp_err_t nvs = nvs_flash_init();
   if (nvs == ESP_ERR_NVS_NO_FREE_PAGES || nvs == ESP_ERR_NVS_NEW_VERSION_FOUND) {
     ESP_ERROR_CHECK(nvs_flash_erase());

--- a/test/run.sh
+++ b/test/run.sh
@@ -126,4 +126,5 @@ cd ..
   tools.tokenserver.test_agent_status \
   tools.tokenserver.test_usage_history \
   tools.tokenserver.test_quota_cache \
-  tools.tokenserver.test_max_tracker -v
+  tools.tokenserver.test_max_tracker \
+  tools.tokenserver.test_smoke -v

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -295,8 +295,18 @@ cp se.torget.tokenserver.plist ~/Library/LaunchAgents/
 launchctl load ~/Library/LaunchAgents/se.torget.tokenserver.plist
 ```
 
-Plisten antar att repot bor i `~/Torget` — redigera sökvägen annars.
-Loggen hamnar i `/tmp/torget-tokenserver.log`.
+Plisten antar att repot bor i `~/Torget` och användaren `niclasvestlund` —
+redigera sökvägarna annars. Loggen hamnar i
+`~/Library/Logs/torget-tokenserver.log` (syns i Konsol-appen, överlever
+omstart; servern roterar den själv vid start om den vuxit förbi ~5 MB, med
+svansen bevarad i `.old`). Raderna har tidsstämplar och loggar övergångar,
+inte tillstånd: en frisk vecka är några rader, inte tusen.
+
+Snabbaste hälsokollen är röktestet — kamrutinens steg 1–4 som ett kommando:
+
+```
+python3 tools/tokenserver/smoke.py
+```
 
 ## Ärlighetsnoter
 

--- a/tools/tokenserver/se.torget.tokenserver.plist
+++ b/tools/tokenserver/se.torget.tokenserver.plist
@@ -2,7 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- Tokenmätarens tjänst som launchd-agent: startar vid inloggning och
-     återstartas om den dör. Antar repot i ~/Torget; redigera annars. -->
+     återstartas om den dör. Antar repot i ~/Torget och användaren
+     niclasvestlund; redigera bägge sökvägarna annars.
+     Loggen bor i ~/Library/Logs (överlever omstart, syns i Konsol-appen;
+     /tmp städas av macOS). Servern roterar den själv vid start när den
+     vuxit förbi taket — launchd har ingen egen rotation.
+     ThrottleInterval är staketet mot respawn-loopar: dör processen direkt
+     vid start väntar launchd 30 s i stället för att fylla loggen. -->
 <plist version="1.0">
 <dict>
   <key>Label</key>
@@ -19,9 +25,11 @@
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
   <key>StandardOutPath</key>
-  <string>/tmp/torget-tokenserver.log</string>
+  <string>/Users/niclasvestlund/Library/Logs/torget-tokenserver.log</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/torget-tokenserver.log</string>
+  <string>/Users/niclasvestlund/Library/Logs/torget-tokenserver.log</string>
 </dict>
 </plist>

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -31,17 +31,47 @@ DEFAULT_BASE_URL = "http://localhost:8737"
 STATE_DIR = Path.home() / "Library" / "Application Support" / "VibePulse"
 STATE_FILES = ("usage-history.json", "quota-cache.json", "max-tracker.json")
 # Versionsskev-snubbeltråd, inte en andra parser: skärmens parsrar är
-# kontraktsstränga och avvisar HELA svaret vid fel version eller saknade
-# bärande fält — HTTP ser friskt ut medan displayen fryser. Kontraktets
-# fulla sanning bor i C-testerna och fixturerna; här räcker versionen plus
-# de obligatoriska fälten (tokens_parse.c:328-332, agent_status_parse.c:530,
-# max_tracker_parse.c:303). Bumpas ett kontrakt är den här tabellen en del
-# av bumpen.
+# kontraktsstränga och avvisar HELA svaret vid fel version, saknade
+# obligatoriska fält eller fel HTTP-status — HTTP kan se friskt ut medan
+# displayen fryser. Här kontrolleras versionen, toppnivåfälten och de
+# grövsta typerna (tokens_parse.c:328-332, agent_status_parse.c:529-542,
+# max_tracker_parse.c:303-317); providrarnas INRE fält bor medvetet bara i
+# C-testerna och fixturerna. Bumpas ett kontrakt är den här tabellen en
+# del av bumpen — och testernas friska svar ÄR sim-fixturerna, så en drift
+# faller i test innan den ljuger i drift.
+
+
+def _tokens_shape(payload):
+    bad = [k for k in ("dayTokens", "dayTokensPerHour", "daySessions",
+                       "monthTokens")
+           if isinstance(payload.get(k), bool)
+           or not isinstance(payload.get(k), (int, float))]
+    return f"icke-numeriska fält {bad}" if bad else None
+
+
+def _agents_shape(payload):
+    agents = payload.get("agents")
+    if not isinstance(agents, dict) or not {"claude", "codex"} <= set(agents):
+        return "agents ska vara ett objekt med claude och codex"
+    return None
+
+
+def _tracker_shape(payload):
+    if not isinstance(payload.get("stale"), bool):
+        return "stale ska vara bool"
+    empty = [k for k in ("claude", "codex")
+             if not isinstance(payload.get(k), dict) or not payload.get(k)]
+    if empty:
+        return f"{empty} ska vara ifyllda providerobjekt"
+    return None
+
+
 ENDPOINT_SHAPE = {
     "/api/tokens": (2, ("dayTokens", "dayTokensPerHour", "daySessions",
-                        "monthTokens")),
-    "/api/agent-status": (2, ("seq", "agents")),
-    "/api/max-tracker": (1, ("weeks", "claude", "codex")),
+                        "monthTokens"), _tokens_shape),
+    "/api/agent-status": (2, ("seq", "agents"), _agents_shape),
+    "/api/max-tracker": (1, ("weeks", "stale", "codingStreakDays",
+                             "claude", "codex"), _tracker_shape),
 }
 PROBE_OK = "usage_http_200 + ok"
 # Fler startrader än så i EN loggfil tyder på en respawn-loop, inte på
@@ -53,13 +83,20 @@ OK, VARN, FAIL = "ok", "varn", "fail"
 
 
 def _get_json(url, timeout=5):
+    """(HTTP-status, parsad JSON). Statusen följer med: skärmen avvisar
+    allt utom 200 (torget_http.c), så en proxy eller cache som svarar 502
+    med frisk-seende kropp får inte bli grönt här. Serverns egna 500 bär
+    kontraktets {"error": ...}-kropp och parsas också."""
     try:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8", errors="replace"))
+            return resp.status, json.loads(
+                resp.read().decode("utf-8", errors="replace"))
     except urllib.error.HTTPError as e:
-        # Serverns 500 bär kontraktets {"error": ...}-kropp — läs den i
-        # stället för att rapportera "inget svar".
-        return json.loads(e.read().decode("utf-8", errors="replace"))
+        body = e.read().decode("utf-8", errors="replace")
+        try:
+            return e.code, json.loads(body)
+        except json.JSONDecodeError:
+            return e.code, None
 
 
 def repo_rev():
@@ -78,11 +115,14 @@ def repo_rev():
 def check_server(base_url, checkout_rev=None):
     """Kamsteg 1–2: identitet, rev och probestatus från GET /."""
     try:
-        root = _get_json(f"{base_url}/")
+        status, root = _get_json(f"{base_url}/")
     except Exception as e:
         return [(FAIL, f"servern svarar inte på {base_url}/ ({type(e).__name__})"
                        " — kör den? launchctl list | grep torget, eller starta"
                        " python3 tokenserver.py för hand")]
+    if status != 200:
+        return [(FAIL, f"HTTP {status} på {base_url}/ — fel tjänst, proxy "
+                       f"eller trasig server")]
     # En annan tjänst på porten kan svara med giltig JSON som inte är ett
     # objekt (lista, tal, null) — det ska bli [FAIL], inte en traceback.
     if (not isinstance(root, dict)
@@ -126,20 +166,28 @@ def check_server(base_url, checkout_rev=None):
 def check_endpoints(base_url):
     """Kamsteg 2, forts: svarar alla tre API:erna med kontraktets form?"""
     results = []
-    for path, (expected_v, required) in ENDPOINT_SHAPE.items():
+    for path, (expected_v, required, shape_check) in ENDPOINT_SHAPE.items():
         try:
-            payload = _get_json(f"{base_url}{path}")
+            status, payload = _get_json(f"{base_url}{path}")
         except Exception as e:
             results.append((FAIL, f"{path}: inget svar ({type(e).__name__})"))
             continue
-        if not isinstance(payload, dict) or "error" in payload:
+        if isinstance(payload, dict) and "error" in payload:
             # Error-formen är kontraktets "något är trasigt i servern" —
             # skärmen avvisar den och fryser hellre än gissar. Orsaken står
             # i loggfilen sedan servern började logga sina 500.
-            detail = (payload.get("error") if isinstance(payload, dict)
-                      else type(payload).__name__)
-            results.append((FAIL, f"{path}: error-form i svaret ({detail}) "
-                                  f"— läs loggfilen"))
+            results.append((FAIL, f"{path}: error-form i svaret "
+                                  f"({payload.get('error')}) — läs "
+                                  f"loggfilen"))
+            continue
+        if status != 200:
+            results.append((FAIL, f"{path}: HTTP {status} — skärmen kräver "
+                                  f"200 och behåller sina gamla värden"))
+            continue
+        if not isinstance(payload, dict):
+            results.append((FAIL, f"{path}: svaret är "
+                                  f"{type(payload).__name__}, inte ett "
+                                  f"objekt — fel tjänst på porten?"))
             continue
         if payload.get("v") != expected_v:
             results.append((FAIL, f"{path}: kontraktsversion "
@@ -152,6 +200,11 @@ def check_endpoints(base_url):
             results.append((FAIL, f"{path}: saknar bärande fält {missing} — "
                                   f"skärmens parser avvisar hela svaret och "
                                   f"displayen fryser"))
+            continue
+        shape_error = shape_check(payload)
+        if shape_error:
+            results.append((FAIL, f"{path}: {shape_error} — skärmens parser "
+                                  f"avvisar hela svaret"))
             continue
         stale_keys = [k for k in ("claudeWeekStale", "claudeModelWeekStale",
                                   "codexWeekStale", "stale")

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -98,6 +98,12 @@ def check_server(base_url, checkout_rev=None):
         results.append((VARN, f"okända rate-limit-buckets: {unknown} — "
                               f"uppströms har fått ett nytt fönster; värt en "
                               f"post i docs/observability-backlog.md"))
+    # Saknas nyckeln pratar vi med en äldre server — inget att bedöma då.
+    if root.get("usageComputeOk") is False:
+        secs = root.get("usageComputeFailingForS") or 0
+        results.append((FAIL, f"usage-omräkningen har kraschat (i {secs} s) "
+                              f"— /api/tokens serverar frysta siffror som "
+                              f"ser färska ut; läs loggfilen"))
     return results
 
 

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -287,9 +287,14 @@ def run(base_url=DEFAULT_BASE_URL, log_path=None, state_dir=None,
         checkout_rev=None, out=None):
     out = out or sys.stdout
     results = []
-    results += check_server(base_url,
-                            checkout_rev if checkout_rev else repo_rev())
-    if not any(level == FAIL for level, _ in results):
+    server_results = check_server(base_url,
+                                  checkout_rev if checkout_rev else repo_rev())
+    results += server_results
+    # Hoppa över endpointkollen BARA när ingen riktig tokenserver svarar
+    # (onåbar, fel tjänst, fel status — då är första raden ett FAIL). En
+    # nådd men sjuk server ska få alla tre kontrakten granskade: det är
+    # mitt i ett haveri de oberoende felen behöver synas.
+    if server_results and server_results[0][0] != FAIL:
         results += check_endpoints(base_url)
     results += check_log_file(log_path or DEFAULT_LOG_PATH)
     results += check_state_files(state_dir or STATE_DIR)

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -84,6 +84,40 @@ USAGE_HISTORY_FRESH_S = 24 * 3600
 OK, VARN, FAIL = "ok", "varn", "fail"
 
 
+# Laddarna nollställer TYST på fel form trots giltig JSON (usage_history
+# kräver {v:1, samples:[...]}, quota_cache exakt {v:1, records:[...]},
+# max_tracker provider-sektioner) — samma dataförlust som OBS-11, fast
+# via form i stället för korrupta bytes. Samma snubbeltrådsnivå som
+# ENDPOINT_SHAPE: toppnivån, inte postinnehållet.
+def _history_state_shape(payload):
+    if (not isinstance(payload, dict) or payload.get("v") != 1
+            or not isinstance(payload.get("samples"), list)):
+        return "kräver v=1 och en samples-lista"
+    return None
+
+
+def _quota_state_shape(payload):
+    if (not isinstance(payload, dict) or set(payload) != {"v", "records"}
+            or payload.get("v") != 1
+            or not isinstance(payload.get("records"), list)):
+        return "kräver exakt {v: 1, records: [...]}"
+    return None
+
+
+def _tracker_state_shape(payload):
+    if not isinstance(payload, dict) or not all(
+            isinstance(payload.get(p), dict) for p in ("claude", "codex")):
+        return "kräver provider-sektionerna claude och codex"
+    return None
+
+
+STATE_SHAPE = {
+    "usage-history.json": _history_state_shape,
+    "quota-cache.json": _quota_state_shape,
+    "max-tracker.json": _tracker_state_shape,
+}
+
+
 def _get_json(url, timeout=5):
     """(HTTP-status, parsad JSON). Statusen följer med: skärmen avvisar
     allt utom 200 (torget_http.c), så en proxy eller cache som svarar 502
@@ -275,13 +309,20 @@ def check_state_files(state_dir, now_ts=None):
                                   f"observationen"))
             continue
         try:
-            json.loads(f.read_text(encoding="utf-8"))
+            payload = json.loads(f.read_text(encoding="utf-8"))
         except Exception as e:
             # Servern startar tyst om från noll på en korrupt fil (OBS-11) —
             # flytta undan den INNAN nästa save skriver över bevisen.
             results.append((FAIL, f"{name} är KORRUPT ({type(e).__name__}) — "
                                   f"flytta undan filen för forensik innan "
                                   f"nästa skrivning nollar den"))
+            continue
+        shape_error = STATE_SHAPE[name](payload)
+        if shape_error:
+            results.append((FAIL, f"{name}: parsar men har FEL FORM "
+                                  f"({shape_error}) — laddaren nollställer "
+                                  f"tyst vid nästa start; flytta undan "
+                                  f"filen för forensik"))
             continue
         results.append((OK, f"{name}: parsar ({f.stat().st_size} byte)"))
         if name == "usage-history.json":

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -269,26 +269,37 @@ def check_log_file(path):
         return [(VARN, f"ingen loggfil på {path} — normalt vid "
                        f"terminalkörning; under launchd betyder det att "
                        f"tjänsten aldrig startat")]
+    def tail_text(p, cap=2 * 1024 * 1024):
+        # Läs bara svansen på en stor fil — röktestet ska vara snabbt.
+        n = p.stat().st_size
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            if n > cap:
+                fh.seek(n - cap)
+            return fh.read()
+
     results = []
     size = path.stat().st_size
+    # Rotationen flyttar den senaste svansen till .old — direkt efter en
+    # rotation bor de färska bevisen DÄR, inte i den nytrunkerade filen.
+    old = path.with_name(path.name + ".old")
+    old_text = tail_text(old) if old.exists() else ""
+    suffix = " (+ roterad svans i .old)" if old_text else ""
     if size > _LOG_CAP_BYTES:
         results.append((VARN, f"loggfilen är {size} byte (> taket "
-                              f"{_LOG_CAP_BYTES}) — startrotationen har inte "
+                              f"{_LOG_CAP_BYTES}) — rotationen har inte "
                               f"fått köra; står tjänsten still?"))
     else:
-        results.append((OK, f"loggfil {path.name}: {size} byte"))
-    # Läs bara svansen på en stor fil — röktestet ska vara snabbt.
-    with open(path, "r", encoding="utf-8", errors="replace") as fh:
-        if size > 2 * 1024 * 1024:
-            fh.seek(size - 2 * 1024 * 1024)
-        text = fh.read()
-    tracebacks = text.count("Traceback (most recent call last)")
+        results.append((OK, f"loggfil {path.name}: {size} byte{suffix}"))
+    text = tail_text(path)
+    tracebacks = (text.count("Traceback (most recent call last)")
+                  + old_text.count("Traceback (most recent call last)"))
     if tracebacks:
-        results.append((VARN, f"{tracebacks} traceback i loggen — grep -n "
-                              f"Traceback {path}"))
-    starts = text.count("serverar http://")
+        results.append((VARN, f"{tracebacks} traceback i loggen{suffix} — "
+                              f"grep -n Traceback {path}*"))
+    starts = (text.count("serverar http://")
+              + old_text.count("serverar http://"))
     if starts >= RESPAWN_SUSPICION_COUNT:
-        results.append((VARN, f"{starts} startrader i loggen — "
+        results.append((VARN, f"{starts} startrader i loggen{suffix} — "
                               f"respawn-loop? (launchd startar om var 30 s "
                               f"vid tidig död)"))
     return results

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -70,11 +70,14 @@ def check_server(base_url, checkout_rev=None):
         return [(FAIL, f"servern svarar inte på {base_url}/ ({type(e).__name__})"
                        " — kör den? launchctl list | grep torget, eller starta"
                        " python3 tokenserver.py för hand")]
+    # En annan tjänst på porten kan svara med giltig JSON som inte är ett
+    # objekt (lista, tal, null) — det ska bli [FAIL], inte en traceback.
+    if (not isinstance(root, dict)
+            or root.get("service") != "torget-tokenserver"):
+        got = (root.get("service") if isinstance(root, dict)
+               else type(root).__name__)
+        return [(FAIL, f"fel tjänst på {base_url} — 'service' är {got!r}")]
     results = []
-    if root.get("service") != "torget-tokenserver":
-        results.append((FAIL, f"fel tjänst på {base_url} — 'service' är "
-                              f"{root.get('service')!r}"))
-        return results
     rev = root.get("rev", "unknown")
     started = root.get("startedAt", "okänt")
     if checkout_rev and rev != checkout_rev:

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -30,6 +30,19 @@ else:  # direktkörning: python3 tools/tokenserver/smoke.py
 DEFAULT_BASE_URL = "http://localhost:8737"
 STATE_DIR = Path.home() / "Library" / "Application Support" / "VibePulse"
 STATE_FILES = ("usage-history.json", "quota-cache.json", "max-tracker.json")
+# Versionsskev-snubbeltråd, inte en andra parser: skärmens parsrar är
+# kontraktsstränga och avvisar HELA svaret vid fel version eller saknade
+# bärande fält — HTTP ser friskt ut medan displayen fryser. Kontraktets
+# fulla sanning bor i C-testerna och fixturerna; här räcker versionen plus
+# de obligatoriska fälten (tokens_parse.c:328-332, agent_status_parse.c:530,
+# max_tracker_parse.c:303). Bumpas ett kontrakt är den här tabellen en del
+# av bumpen.
+ENDPOINT_SHAPE = {
+    "/api/tokens": (2, ("dayTokens", "dayTokensPerHour", "daySessions",
+                        "monthTokens")),
+    "/api/agent-status": (2, ("seq", "agents")),
+    "/api/max-tracker": (1, ("weeks", "claude", "codex")),
+}
 PROBE_OK = "usage_http_200 + ok"
 # Fler startrader än så i EN loggfil tyder på en respawn-loop, inte på
 # avsiktliga omstarter (rotationen vid start håller filen till en era).
@@ -113,7 +126,7 @@ def check_server(base_url, checkout_rev=None):
 def check_endpoints(base_url):
     """Kamsteg 2, forts: svarar alla tre API:erna med kontraktets form?"""
     results = []
-    for path in ("/api/tokens", "/api/agent-status", "/api/max-tracker"):
+    for path, (expected_v, required) in ENDPOINT_SHAPE.items():
         try:
             payload = _get_json(f"{base_url}{path}")
         except Exception as e:
@@ -127,6 +140,18 @@ def check_endpoints(base_url):
                       else type(payload).__name__)
             results.append((FAIL, f"{path}: error-form i svaret ({detail}) "
                                   f"— läs loggfilen"))
+            continue
+        if payload.get("v") != expected_v:
+            results.append((FAIL, f"{path}: kontraktsversion "
+                                  f"{payload.get('v')!r}, skärmen kräver "
+                                  f"{expected_v} — versionsskev server/"
+                                  f"firmware? (jämför rev-raden ovan)"))
+            continue
+        missing = [k for k in required if k not in payload]
+        if missing:
+            results.append((FAIL, f"{path}: saknar bärande fält {missing} — "
+                                  f"skärmens parser avvisar hela svaret och "
+                                  f"displayen fryser"))
             continue
         stale_keys = [k for k in ("claudeWeekStale", "claudeModelWeekStale",
                                   "codexWeekStale", "stale")

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Röktest för VibePulse-kedjan på Macen: en körning, ett facit.
+
+Automatiserar kamrutinens steg 1–4 (docs/observability.md): serverns
+identitet och rev, Claude-probens status, alla tre API-svaren, loggfilen
+och tillståndsfilerna. Ingen del kräver hårdvara — skärmens sanning
+(kamsteg 5–6) förblir manuell.
+
+    python3 tools/tokenserver/smoke.py [--base-url http://localhost:8737]
+
+Utgång: 0 = allt ok, 1 = varningar (fungerar, men värt en titt),
+2 = minst ett FAIL. Ren stdlib, som resten av tjänsten.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+if __package__:
+    from .tokenserver import DEFAULT_LOG_PATH, _LOG_CAP_BYTES
+else:  # direktkörning: python3 tools/tokenserver/smoke.py
+    from tokenserver import DEFAULT_LOG_PATH, _LOG_CAP_BYTES
+
+DEFAULT_BASE_URL = "http://localhost:8737"
+STATE_DIR = Path.home() / "Library" / "Application Support" / "VibePulse"
+STATE_FILES = ("usage-history.json", "quota-cache.json", "max-tracker.json")
+PROBE_OK = "usage_http_200 + ok"
+# Fler startrader än så i EN loggfil tyder på en respawn-loop, inte på
+# avsiktliga omstarter (rotationen vid start håller filen till en era).
+RESPAWN_SUSPICION_COUNT = 10
+USAGE_HISTORY_FRESH_S = 24 * 3600
+
+OK, VARN, FAIL = "ok", "varn", "fail"
+
+
+def _get_json(url, timeout=5):
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as e:
+        # Serverns 500 bär kontraktets {"error": ...}-kropp — läs den i
+        # stället för att rapportera "inget svar".
+        return json.loads(e.read().decode("utf-8", errors="replace"))
+
+
+def repo_rev():
+    """Checkoutens rev, för jämförelsen mot serverns — None utan git."""
+    try:
+        rev = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+        ).stdout.strip()
+        return rev or None
+    except Exception:
+        return None
+
+
+def check_server(base_url, checkout_rev=None):
+    """Kamsteg 1–2: identitet, rev och probestatus från GET /."""
+    try:
+        root = _get_json(f"{base_url}/")
+    except Exception as e:
+        return [(FAIL, f"servern svarar inte på {base_url}/ ({type(e).__name__})"
+                       " — kör den? launchctl list | grep torget, eller starta"
+                       " python3 tokenserver.py för hand")]
+    results = []
+    if root.get("service") != "torget-tokenserver":
+        results.append((FAIL, f"fel tjänst på {base_url} — 'service' är "
+                              f"{root.get('service')!r}"))
+        return results
+    rev = root.get("rev", "unknown")
+    started = root.get("startedAt", "okänt")
+    if checkout_rev and rev != checkout_rev:
+        results.append((VARN, f"servern kör rev {rev}, checkouten är "
+                              f"{checkout_rev} — pekar plistens "
+                              f"WorkingDirectory på en annan katalog?"))
+    else:
+        results.append((OK, f"torget-tokenserver rev {rev}, igång sedan "
+                            f"{started}"))
+    probe = root.get("claudeProbe", "saknas")
+    if probe == PROBE_OK:
+        results.append((OK, f"claude-proben: {probe}"))
+    elif probe == "not_run":
+        results.append((VARN, "claude-proben har inte kört än (120 s-cykel) "
+                              "— kör om röktestet om en stund"))
+    else:
+        results.append((VARN, f"claude-proben: {probe} — se tabellen i "
+                              f"docs/agent-setup.md"))
+    unknown = root.get("unknownRateLimitBuckets") or []
+    if unknown:
+        results.append((VARN, f"okända rate-limit-buckets: {unknown} — "
+                              f"uppströms har fått ett nytt fönster; värt en "
+                              f"post i docs/observability-backlog.md"))
+    return results
+
+
+def check_endpoints(base_url):
+    """Kamsteg 2, forts: svarar alla tre API:erna med kontraktets form?"""
+    results = []
+    for path in ("/api/tokens", "/api/agent-status", "/api/max-tracker"):
+        try:
+            payload = _get_json(f"{base_url}{path}")
+        except Exception as e:
+            results.append((FAIL, f"{path}: inget svar ({type(e).__name__})"))
+            continue
+        if not isinstance(payload, dict) or "error" in payload:
+            # Error-formen är kontraktets "något är trasigt i servern" —
+            # skärmen avvisar den och fryser hellre än gissar. Orsaken står
+            # i loggfilen sedan servern började logga sina 500.
+            detail = (payload.get("error") if isinstance(payload, dict)
+                      else type(payload).__name__)
+            results.append((FAIL, f"{path}: error-form i svaret ({detail}) "
+                                  f"— läs loggfilen"))
+            continue
+        stale_keys = [k for k in ("claudeWeekStale", "claudeModelWeekStale",
+                                  "codexWeekStale", "stale")
+                      if payload.get(k) is True]
+        if stale_keys:
+            results.append((VARN, f"{path}: svarar men {', '.join(stale_keys)}"
+                                  f" — källan levererar inte färskt"))
+        else:
+            results.append((OK, f"{path}: svarar"))
+    return results
+
+
+def check_log_file(path):
+    """Kamsteg 3: finns loggfilen, växer den lagom, står det otäckt i den?"""
+    path = Path(path)
+    if not path.exists():
+        return [(VARN, f"ingen loggfil på {path} — normalt vid "
+                       f"terminalkörning; under launchd betyder det att "
+                       f"tjänsten aldrig startat")]
+    results = []
+    size = path.stat().st_size
+    if size > _LOG_CAP_BYTES:
+        results.append((VARN, f"loggfilen är {size} byte (> taket "
+                              f"{_LOG_CAP_BYTES}) — startrotationen har inte "
+                              f"fått köra; står tjänsten still?"))
+    else:
+        results.append((OK, f"loggfil {path.name}: {size} byte"))
+    # Läs bara svansen på en stor fil — röktestet ska vara snabbt.
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        if size > 2 * 1024 * 1024:
+            fh.seek(size - 2 * 1024 * 1024)
+        text = fh.read()
+    tracebacks = text.count("Traceback (most recent call last)")
+    if tracebacks:
+        results.append((VARN, f"{tracebacks} traceback i loggen — grep -n "
+                              f"Traceback {path}"))
+    starts = text.count("serverar http://")
+    if starts >= RESPAWN_SUSPICION_COUNT:
+        results.append((VARN, f"{starts} startrader i loggen — "
+                              f"respawn-loop? (launchd startar om var 30 s "
+                              f"vid tidig död)"))
+    return results
+
+
+def check_state_files(state_dir, now_ts=None):
+    """Kamsteg 4: parsar tillståndsfilerna, och rör sig trenddatat?"""
+    state_dir = Path(state_dir)
+    now_ts = time.time() if now_ts is None else now_ts
+    if not state_dir.is_dir():
+        return [(VARN, f"ingen tillståndskatalog {state_dir} — färsk "
+                       f"installation, eller så har inget observerats än")]
+    results = []
+    for name in STATE_FILES:
+        f = state_dir / name
+        if not f.exists():
+            results.append((VARN, f"{name} saknas — skapas vid första "
+                                  f"observationen"))
+            continue
+        try:
+            json.loads(f.read_text(encoding="utf-8"))
+        except Exception as e:
+            # Servern startar tyst om från noll på en korrupt fil (OBS-11) —
+            # flytta undan den INNAN nästa save skriver över bevisen.
+            results.append((FAIL, f"{name} är KORRUPT ({type(e).__name__}) — "
+                                  f"flytta undan filen för forensik innan "
+                                  f"nästa skrivning nollar den"))
+            continue
+        results.append((OK, f"{name}: parsar ({f.stat().st_size} byte)"))
+        if name == "usage-history.json":
+            age_s = now_ts - f.stat().st_mtime
+            if age_s > USAGE_HISTORY_FRESH_S:
+                results.append((VARN, f"usage-history.json senast skriven "
+                                      f"för {age_s / 3600:.0f} h sedan — "
+                                      f"trendpunkter skrivs var 15:e minut "
+                                      f"när kvotdata flödar"))
+    return results
+
+
+def run(base_url=DEFAULT_BASE_URL, log_path=None, state_dir=None,
+        checkout_rev=None, out=None):
+    out = out or sys.stdout
+    results = []
+    results += check_server(base_url,
+                            checkout_rev if checkout_rev else repo_rev())
+    if not any(level == FAIL for level, _ in results):
+        results += check_endpoints(base_url)
+    results += check_log_file(log_path or DEFAULT_LOG_PATH)
+    results += check_state_files(state_dir or STATE_DIR)
+
+    tag = {OK: "[ OK ]", VARN: "[VARN]", FAIL: "[FAIL]"}
+    for level, text in results:
+        print(f"{tag[level]} {text}", file=out)
+    counts = {lvl: sum(1 for level, _ in results if level == lvl)
+              for lvl in (OK, VARN, FAIL)}
+    print(f"röktest: {counts[OK]} ok, {counts[VARN]} varningar, "
+          f"{counts[FAIL]} fel", file=out)
+    if counts[FAIL]:
+        return 2
+    if counts[VARN]:
+        return 1
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    ap.add_argument("--log-file", default=None,
+                    help=f"loggfil att granska (default {DEFAULT_LOG_PATH})")
+    ap.add_argument("--state-dir", default=None,
+                    help=f"tillståndskatalog (default {STATE_DIR})")
+    args = ap.parse_args()
+    return run(args.base_url, args.log_file, args.state_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -23,9 +23,11 @@ import urllib.request
 from pathlib import Path
 
 if __package__:
-    from .tokenserver import DEFAULT_LOG_PATH, _LOG_CAP_BYTES
+    from .tokenserver import (DEFAULT_LOG_PATH, _LOG_CAP_BYTES,
+                              _read_source_fingerprint)
 else:  # direktkörning: python3 tools/tokenserver/smoke.py
-    from tokenserver import DEFAULT_LOG_PATH, _LOG_CAP_BYTES
+    from tokenserver import (DEFAULT_LOG_PATH, _LOG_CAP_BYTES,
+                             _read_source_fingerprint)
 
 DEFAULT_BASE_URL = "http://localhost:8737"
 STATE_DIR = Path.home() / "Library" / "Application Support" / "VibePulse"
@@ -112,8 +114,9 @@ def repo_rev():
         return None
 
 
-def check_server(base_url, checkout_rev=None):
-    """Kamsteg 1–2: identitet, rev och probestatus från GET /."""
+def check_server(base_url, checkout_rev=None, checkout_src=None):
+    """Kamsteg 1–2: identitet, rev, källfingerprint och probestatus från
+    GET /. Jämförelser görs bara när båda sidor finns (None hoppar)."""
     try:
         status, root = _get_json(f"{base_url}/")
     except Exception as e:
@@ -140,6 +143,14 @@ def check_server(base_url, checkout_rev=None):
     else:
         results.append((OK, f"torget-tokenserver rev {rev}, igång sedan "
                             f"{started}"))
+    # Fingerprint fångar det rev inte kan: smutsig worktree vid start,
+    # eller filer redigerade EFTER start — bägge delar HEAD med checkouten.
+    src = root.get("srcFingerprint")
+    if src and checkout_src and src != checkout_src:
+        results.append((VARN, f"servern kör annan källkod än checkouten "
+                              f"(fingerprint {src} ≠ {checkout_src}) — "
+                              f"redigerad efter start eller smutsig "
+                              f"worktree; starta om tjänsten"))
     probe = root.get("claudeProbe", "saknas")
     if probe == PROBE_OK:
         results.append((OK, f"claude-proben: {probe}"))
@@ -287,8 +298,10 @@ def run(base_url=DEFAULT_BASE_URL, log_path=None, state_dir=None,
         checkout_rev=None, out=None):
     out = out or sys.stdout
     results = []
-    server_results = check_server(base_url,
-                                  checkout_rev if checkout_rev else repo_rev())
+    server_results = check_server(
+        base_url,
+        checkout_rev if checkout_rev else repo_rev(),
+        checkout_src=_read_source_fingerprint())
     results += server_results
     # Hoppa över endpointkollen BARA när ingen riktig tokenserver svarar
     # (onåbar, fel tjänst, fel status — då är första raden ett FAIL). En

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -101,6 +101,17 @@ class ServerCheckTests(unittest.TestCase):
             results = smoke.check_server(base, checkout_rev="abc1234")
         self.assertEqual(levels(results), [smoke.FAIL])
 
+    def test_non_object_json_on_port_is_fail_not_a_traceback(self):
+        # En främmande tjänst kan svara med en lista, ett tal eller null —
+        # exakt fel-tjänst-scenariot får inte krascha diagnosen.
+        for foreign in ([1, 2, 3], 42, None, "text"):
+            with self.subTest(foreign=foreign):
+                with canned_server({"/": foreign}) as base:
+                    results = smoke.check_server(base,
+                                                 checkout_rev="abc1234")
+                self.assertEqual(levels(results), [smoke.FAIL])
+                self.assertIn("fel tjänst", results[0][1])
+
     def test_frozen_usage_compute_is_fail(self):
         # OBS-08: siffror som fryst men ser färska ut är värsta sortens fel
         # — röktestet ska skrika, inte viska.

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -30,14 +30,16 @@ HEALTHY_ROOT = {
     "usageComputeOk": True,
     "usageComputeFailingForS": None,
 }
-# Formerna speglar de verkliga kontrakten (v2/v2/v1 med bärande fält) —
-# ENDPOINT_SHAPE i smoke.py avvisar annat, precis som skärmens parsrar.
-HEALTHY_TOKENS = {"v": 2, "dayTokens": 1, "dayTokensPerHour": 0,
-                  "daySessions": 1, "monthTokens": 2,
-                  "claudeWeekStale": False, "codexWeekStale": False}
-HEALTHY_AGENTS = {"v": 2, "seq": 1, "agents": []}
-HEALTHY_TRACKER = {"v": 1, "weeks": 20, "claude": {}, "codex": {},
-                   "stale": False}
+# De friska svaren ÄR sim-fixturerna — samma payloads som firmwarens
+# parsrar bevisligen accepterar (de matas genom exakt de parsrarna i
+# simulatorn och C-testerna). Driftar kontraktet faller de här testen
+# i stället för att röktestet ljuger grönt.
+_FIXTURES = Path(__file__).resolve().parents[2] / "sim-fixtures"
+HEALTHY_TOKENS = json.loads((_FIXTURES / "tokens.json").read_text())
+HEALTHY_AGENTS = json.loads(
+    (_FIXTURES / "agent-status-idle.json").read_text())
+HEALTHY_TRACKER = json.loads(
+    (_FIXTURES / "max-tracker-live-shape.json").read_text())
 
 
 @contextlib.contextmanager
@@ -190,6 +192,40 @@ class EndpointCheckTests(unittest.TestCase):
         self.assertEqual(levels(results),
                          [smoke.FAIL, smoke.OK, smoke.OK])
         self.assertIn("monthTokens", results[0][1])
+
+    def test_non_200_with_healthy_body_is_fail(self):
+        # torget_http.c avvisar allt utom HTTP 200 — en proxy eller cache
+        # som svarar 502 med frisk-seende kropp får inte smoke-grönt.
+        payloads = {"/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
+        with canned_server(payloads, status=502) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results), [smoke.FAIL] * 3)
+        for _, text in results:
+            self.assertIn("502", text)
+
+    def test_agents_as_list_is_fail(self):
+        # agent_status_parse.c kräver att agents är ett objekt med claude
+        # och codex — en lista ser HTTP-frisk ut men skärmen avvisar den.
+        payloads = {"/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": dict(HEALTHY_AGENTS, agents=[]),
+                    "/api/max-tracker": HEALTHY_TRACKER}
+        with canned_server(payloads) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results),
+                         [smoke.OK, smoke.FAIL, smoke.OK])
+        self.assertIn("agents", results[1][1])
+
+    def test_empty_provider_object_is_fail(self):
+        payloads = {"/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": dict(HEALTHY_TRACKER, claude={})}
+        with canned_server(payloads) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results),
+                         [smoke.OK, smoke.OK, smoke.FAIL])
+        self.assertIn("providerobjekt", results[2][1])
 
 
 class LogFileCheckTests(unittest.TestCase):

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -120,6 +120,28 @@ class ServerCheckTests(unittest.TestCase):
                 self.assertEqual(levels(results), [smoke.FAIL])
                 self.assertIn("fel tjänst", results[0][1])
 
+    def test_source_fingerprint_mismatch_warns_about_edited_code(self):
+        # Rev kan inte se en smutsig worktree eller en redigering efter
+        # start — fingerprintet kan. Jämförs bara när bägge sidor finns.
+        root = dict(HEALTHY_ROOT, srcFingerprint="aaaa11112222")
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234",
+                                         checkout_src="bbbb33334444")
+        warn = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warn), 1)
+        self.assertIn("annan källkod", warn[0])
+
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234",
+                                         checkout_src="aaaa11112222")
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+
+    def test_missing_fingerprint_on_older_server_is_not_judged(self):
+        with canned_server({"/": HEALTHY_ROOT}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234",
+                                         checkout_src="bbbb33334444")
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+
     def test_frozen_usage_compute_is_fail(self):
         # OBS-08: siffror som fryst men ser färska ut är värsta sortens fel
         # — röktestet ska skrika, inte viska.

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -276,16 +276,38 @@ class LogFileCheckTests(unittest.TestCase):
         self.assertIn("respawn", results[2][1])
 
 
+VALID_STATE = {
+    "usage-history.json": '{"v": 1, "samples": []}',
+    "quota-cache.json": '{"v": 1, "records": []}',
+    "max-tracker.json": '{"claude": {}, "codex": {}}',
+}
+
+
 class StateFileCheckTests(unittest.TestCase):
     def _write_state(self, tmp, **overrides):
         for name in smoke.STATE_FILES:
-            (Path(tmp) / name).write_text(overrides.get(name, "{}"))
+            (Path(tmp) / name).write_text(
+                overrides.get(name, VALID_STATE[name]))
 
     def test_valid_files_are_ok_and_fresh_history_stays_quiet(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._write_state(tmp)
             results = smoke.check_state_files(tmp, now_ts=time.time())
         self.assertEqual(levels(results), [smoke.OK] * 3)
+
+    def test_valid_json_with_wrong_shape_is_fail(self):
+        # Giltig JSON med fel form nollställs LIKA tyst som korrupta bytes
+        # av laddarna — röktestet får inte kalla den frisk.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_state(tmp, **{
+                "usage-history.json": '{"v": 2, "samples": []}',
+                "quota-cache.json": "{}",
+            })
+            results = smoke.check_state_files(tmp, now_ts=time.time())
+        fails = [text for level, text in results if level == smoke.FAIL]
+        self.assertEqual(len(fails), 2)
+        for text in fails:
+            self.assertIn("FEL FORM", text)
 
     def test_corrupt_state_file_is_fail_with_forensics_pointer(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -320,7 +342,7 @@ class RunExitCodeTests(unittest.TestCase):
             state = Path(tmp) / "state"
             state.mkdir()
             for name in smoke.STATE_FILES:
-                (state / name).write_text("{}")
+                (state / name).write_text(VALID_STATE[name])
             out = io.StringIO()
             with canned_server(payloads, status=status) as base:
                 code = smoke.run(base, log_path=log_file, state_dir=state,

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -27,6 +27,8 @@ HEALTHY_ROOT = {
     "claudeProbe": "usage_http_200 + ok",
     "ratelimitHeaders": [],
     "unknownRateLimitBuckets": [],
+    "usageComputeOk": True,
+    "usageComputeFailingForS": None,
 }
 HEALTHY_TOKENS = {"v": 1, "dayTokens": 1, "claudeWeekStale": False,
                   "codexWeekStale": False}
@@ -98,6 +100,25 @@ class ServerCheckTests(unittest.TestCase):
         with canned_server({"/": {"service": "annan"}}) as base:
             results = smoke.check_server(base, checkout_rev="abc1234")
         self.assertEqual(levels(results), [smoke.FAIL])
+
+    def test_frozen_usage_compute_is_fail(self):
+        # OBS-08: siffror som fryst men ser färska ut är värsta sortens fel
+        # — röktestet ska skrika, inte viska.
+        root = dict(HEALTHY_ROOT, usageComputeOk=False,
+                    usageComputeFailingForS=612)
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        fails = [text for level, text in results if level == smoke.FAIL]
+        self.assertEqual(len(fails), 1)
+        self.assertIn("frysta siffror", fails[0])
+        self.assertIn("612", fails[0])
+
+    def test_older_server_without_compute_field_is_not_judged(self):
+        root = {k: v for k, v in HEALTHY_ROOT.items()
+                if not k.startswith("usageCompute")}
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
 
 
 class EndpointCheckTests(unittest.TestCase):

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -30,8 +30,14 @@ HEALTHY_ROOT = {
     "usageComputeOk": True,
     "usageComputeFailingForS": None,
 }
-HEALTHY_TOKENS = {"v": 1, "dayTokens": 1, "claudeWeekStale": False,
-                  "codexWeekStale": False}
+# Formerna speglar de verkliga kontrakten (v2/v2/v1 med bärande fält) —
+# ENDPOINT_SHAPE i smoke.py avvisar annat, precis som skärmens parsrar.
+HEALTHY_TOKENS = {"v": 2, "dayTokens": 1, "dayTokensPerHour": 0,
+                  "daySessions": 1, "monthTokens": 2,
+                  "claudeWeekStale": False, "codexWeekStale": False}
+HEALTHY_AGENTS = {"v": 2, "seq": 1, "agents": []}
+HEALTHY_TRACKER = {"v": 1, "weeks": 20, "claude": {}, "codex": {},
+                   "stale": False}
 
 
 @contextlib.contextmanager
@@ -135,16 +141,16 @@ class ServerCheckTests(unittest.TestCase):
 class EndpointCheckTests(unittest.TestCase):
     def test_three_healthy_endpoints_are_ok(self):
         payloads = {"/api/tokens": HEALTHY_TOKENS,
-                    "/api/agent-status": {"v": 1},
-                    "/api/max-tracker": {"v": 1, "stale": False}}
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
         with canned_server(payloads) as base:
             results = smoke.check_endpoints(base)
         self.assertEqual(levels(results), [smoke.OK] * 3)
 
     def test_error_form_is_fail_even_on_http_500(self):
         payloads = {"/api/tokens": {"error": "internal server error"},
-                    "/api/agent-status": {"v": 1},
-                    "/api/max-tracker": {"v": 1}}
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
         with canned_server(payloads, status=500) as base:
             results = smoke.check_endpoints(base)
         self.assertEqual(levels(results)[0], smoke.FAIL)
@@ -153,12 +159,37 @@ class EndpointCheckTests(unittest.TestCase):
     def test_stale_flags_warn(self):
         payloads = {"/api/tokens": dict(HEALTHY_TOKENS,
                                         claudeWeekStale=True),
-                    "/api/agent-status": {"v": 1},
-                    "/api/max-tracker": {"v": 1, "stale": True}}
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": dict(HEALTHY_TRACKER, stale=True)}
         with canned_server(payloads) as base:
             results = smoke.check_endpoints(base)
         self.assertEqual(levels(results),
                          [smoke.VARN, smoke.OK, smoke.VARN])
+
+    def test_contract_version_skew_is_fail_not_a_false_green(self):
+        # En gammal serverprocess som serverar v1 ser HTTP-frisk ut medan
+        # skärmens parser avvisar allt (tokens_parse.c kräver v == 2) —
+        # exakt fallet "smoke grönt, display frusen" som ska bli FAIL.
+        payloads = {"/api/tokens": dict(HEALTHY_TOKENS, v=1),
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
+        with canned_server(payloads) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results),
+                         [smoke.FAIL, smoke.OK, smoke.OK])
+        self.assertIn("kontraktsversion", results[0][1])
+
+    def test_missing_mandatory_field_is_fail(self):
+        broken = {k: v for k, v in HEALTHY_TOKENS.items()
+                  if k != "monthTokens"}
+        payloads = {"/api/tokens": broken,
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
+        with canned_server(payloads) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results),
+                         [smoke.FAIL, smoke.OK, smoke.OK])
+        self.assertIn("monthTokens", results[0][1])
 
 
 class LogFileCheckTests(unittest.TestCase):
@@ -241,8 +272,8 @@ class RunExitCodeTests(unittest.TestCase):
     def test_healthy_chain_exits_0(self):
         payloads = {"/": HEALTHY_ROOT,
                     "/api/tokens": HEALTHY_TOKENS,
-                    "/api/agent-status": {"v": 1},
-                    "/api/max-tracker": {"v": 1, "stale": False}}
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
         code, text = self._run(payloads)
         self.assertEqual(code, 0, text)
         self.assertIn("röktest:", text)
@@ -251,16 +282,16 @@ class RunExitCodeTests(unittest.TestCase):
     def test_warnings_exit_1(self):
         payloads = {"/": dict(HEALTHY_ROOT, claudeProbe="not_run"),
                     "/api/tokens": HEALTHY_TOKENS,
-                    "/api/agent-status": {"v": 1},
-                    "/api/max-tracker": {"v": 1, "stale": False}}
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
         code, text = self._run(payloads)
         self.assertEqual(code, 1, text)
 
     def test_error_form_exits_2(self):
         payloads = {"/": HEALTHY_ROOT,
                     "/api/tokens": {"error": "internal server error"},
-                    "/api/agent-status": {"v": 1},
-                    "/api/max-tracker": {"v": 1, "stale": False}}
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
         code, text = self._run(payloads)
         self.assertEqual(code, 2, text)
 

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -331,6 +331,19 @@ class RunExitCodeTests(unittest.TestCase):
         code, text = self._run(payloads)
         self.assertEqual(code, 2, text)
 
+    def test_compute_failure_still_checks_every_endpoint(self):
+        # Nådd men sjuk server: kompute-FAIL:et får inte gömma oberoende
+        # fel i de andra feedarna — alla tre kontrakten ska granskas.
+        payloads = {"/": dict(HEALTHY_ROOT, usageComputeOk=False,
+                              usageComputeFailingForS=90),
+                    "/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": HEALTHY_AGENTS,
+                    "/api/max-tracker": HEALTHY_TRACKER}
+        code, text = self._run(payloads)
+        self.assertEqual(code, 2, text)
+        self.assertIn("/api/agent-status: svarar", text)
+        self.assertIn("/api/max-tracker: svarar", text)
+
     def test_unreachable_server_skips_endpoint_checks_and_exits_2(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = io.StringIO()

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -1,0 +1,247 @@
+"""Röktestets eget facit: varje kamsteg mot riggade servrar och filer.
+
+Ingen testklass rör nätet utom via en lokal kannad HTTP-server på port 0,
+och ingen rör hemkatalogen — allt tillstånd bor i tempkataloger.
+"""
+
+import contextlib
+import io
+import json
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+if __package__:
+    from . import smoke
+else:
+    import smoke
+
+
+HEALTHY_ROOT = {
+    "service": "torget-tokenserver",
+    "rev": "abc1234",
+    "startedAt": "2026-08-13T20:00:00+02:00",
+    "claudeProbe": "usage_http_200 + ok",
+    "ratelimitHeaders": [],
+    "unknownRateLimitBuckets": [],
+}
+HEALTHY_TOKENS = {"v": 1, "dayTokens": 1, "claudeWeekStale": False,
+                  "codexWeekStale": False}
+
+
+@contextlib.contextmanager
+def canned_server(payloads, status=200):
+    """Lokal HTTP-server på port 0 som svarar med riggade JSON-kroppar."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = json.dumps(payloads.get(self.path,
+                                           {"error": "not found"})).encode()
+            self.send_response(status if self.path in payloads else 404)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt, *args):
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def levels(results):
+    return [level for level, _ in results]
+
+
+class ServerCheckTests(unittest.TestCase):
+    def test_healthy_server_with_matching_rev_is_all_ok(self):
+        with canned_server({"/": HEALTHY_ROOT}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+
+    def test_unreachable_server_is_fail(self):
+        results = smoke.check_server("http://127.0.0.1:9")  # discard-porten
+        self.assertEqual(levels(results), [smoke.FAIL])
+
+    def test_rev_mismatch_warns_about_stale_worktree(self):
+        with canned_server({"/": HEALTHY_ROOT}) as base:
+            results = smoke.check_server(base, checkout_rev="fff9999")
+        self.assertIn(smoke.VARN, levels(results))
+        self.assertIn("WorkingDirectory", results[0][1])
+
+    def test_probe_status_other_than_ok_warns_with_runbook_pointer(self):
+        root = dict(HEALTHY_ROOT, claudeProbe="usage_http_401")
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        warn = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warn), 1)
+        self.assertIn("usage_http_401", warn[0])
+        self.assertIn("agent-setup", warn[0])
+
+    def test_unknown_buckets_warn(self):
+        root = dict(HEALTHY_ROOT, unknownRateLimitBuckets=["7d_haiku"])
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        self.assertIn(smoke.VARN, levels(results))
+
+    def test_wrong_service_on_port_is_fail(self):
+        with canned_server({"/": {"service": "annan"}}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        self.assertEqual(levels(results), [smoke.FAIL])
+
+
+class EndpointCheckTests(unittest.TestCase):
+    def test_three_healthy_endpoints_are_ok(self):
+        payloads = {"/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": {"v": 1},
+                    "/api/max-tracker": {"v": 1, "stale": False}}
+        with canned_server(payloads) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results), [smoke.OK] * 3)
+
+    def test_error_form_is_fail_even_on_http_500(self):
+        payloads = {"/api/tokens": {"error": "internal server error"},
+                    "/api/agent-status": {"v": 1},
+                    "/api/max-tracker": {"v": 1}}
+        with canned_server(payloads, status=500) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results)[0], smoke.FAIL)
+        self.assertIn("internal server error", results[0][1])
+
+    def test_stale_flags_warn(self):
+        payloads = {"/api/tokens": dict(HEALTHY_TOKENS,
+                                        claudeWeekStale=True),
+                    "/api/agent-status": {"v": 1},
+                    "/api/max-tracker": {"v": 1, "stale": True}}
+        with canned_server(payloads) as base:
+            results = smoke.check_endpoints(base)
+        self.assertEqual(levels(results),
+                         [smoke.VARN, smoke.OK, smoke.VARN])
+
+
+class LogFileCheckTests(unittest.TestCase):
+    def test_missing_file_is_a_warning_not_a_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results = smoke.check_log_file(Path(tmp) / "finns-inte.log")
+        self.assertEqual(levels(results), [smoke.VARN])
+
+    def test_small_clean_file_is_ok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Path(tmp) / "t.log"
+            f.write_text("2026-08-13 INFO serverar http://0.0.0.0:8737\n")
+            results = smoke.check_log_file(f)
+        self.assertEqual(levels(results), [smoke.OK])
+
+    def test_tracebacks_and_respawn_churn_warn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Path(tmp) / "t.log"
+            f.write_text(
+                "Traceback (most recent call last)\n boom\n" +
+                "serverar http://0.0.0.0:8737\n" * 12)
+            results = smoke.check_log_file(f)
+        self.assertEqual(levels(results),
+                         [smoke.OK, smoke.VARN, smoke.VARN])
+        self.assertIn("traceback", results[1][1])
+        self.assertIn("respawn", results[2][1])
+
+
+class StateFileCheckTests(unittest.TestCase):
+    def _write_state(self, tmp, **overrides):
+        for name in smoke.STATE_FILES:
+            (Path(tmp) / name).write_text(overrides.get(name, "{}"))
+
+    def test_valid_files_are_ok_and_fresh_history_stays_quiet(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_state(tmp)
+            results = smoke.check_state_files(tmp, now_ts=time.time())
+        self.assertEqual(levels(results), [smoke.OK] * 3)
+
+    def test_corrupt_state_file_is_fail_with_forensics_pointer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_state(tmp, **{"max-tracker.json": "{trasig"})
+            results = smoke.check_state_files(tmp, now_ts=time.time())
+        fails = [text for level, text in results if level == smoke.FAIL]
+        self.assertEqual(len(fails), 1)
+        self.assertIn("KORRUPT", fails[0])
+        self.assertIn("forensik", fails[0])
+
+    def test_missing_files_and_missing_dir_warn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results = smoke.check_state_files(Path(tmp) / "finns-inte")
+            self.assertEqual(levels(results), [smoke.VARN])
+            results = smoke.check_state_files(tmp)
+            self.assertEqual(levels(results), [smoke.VARN] * 3)
+
+    def test_stale_usage_history_warns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_state(tmp)
+            results = smoke.check_state_files(
+                tmp, now_ts=time.time() + 25 * 3600)
+        self.assertEqual(
+            levels(results), [smoke.OK, smoke.VARN, smoke.OK, smoke.OK])
+
+
+class RunExitCodeTests(unittest.TestCase):
+    def _run(self, payloads, status=200):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_file = Path(tmp) / "t.log"
+            log_file.write_text("serverar http://0.0.0.0:8737\n")
+            state = Path(tmp) / "state"
+            state.mkdir()
+            for name in smoke.STATE_FILES:
+                (state / name).write_text("{}")
+            out = io.StringIO()
+            with canned_server(payloads, status=status) as base:
+                code = smoke.run(base, log_path=log_file, state_dir=state,
+                                 checkout_rev="abc1234", out=out)
+            return code, out.getvalue()
+
+    def test_healthy_chain_exits_0(self):
+        payloads = {"/": HEALTHY_ROOT,
+                    "/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": {"v": 1},
+                    "/api/max-tracker": {"v": 1, "stale": False}}
+        code, text = self._run(payloads)
+        self.assertEqual(code, 0, text)
+        self.assertIn("röktest:", text)
+        self.assertNotIn("[FAIL]", text)
+
+    def test_warnings_exit_1(self):
+        payloads = {"/": dict(HEALTHY_ROOT, claudeProbe="not_run"),
+                    "/api/tokens": HEALTHY_TOKENS,
+                    "/api/agent-status": {"v": 1},
+                    "/api/max-tracker": {"v": 1, "stale": False}}
+        code, text = self._run(payloads)
+        self.assertEqual(code, 1, text)
+
+    def test_error_form_exits_2(self):
+        payloads = {"/": HEALTHY_ROOT,
+                    "/api/tokens": {"error": "internal server error"},
+                    "/api/agent-status": {"v": 1},
+                    "/api/max-tracker": {"v": 1, "stale": False}}
+        code, text = self._run(payloads)
+        self.assertEqual(code, 2, text)
+
+    def test_unreachable_server_skips_endpoint_checks_and_exits_2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = io.StringIO()
+            code = smoke.run("http://127.0.0.1:9",
+                             log_path=Path(tmp) / "t.log",
+                             state_dir=Path(tmp) / "state",
+                             checkout_rev="abc1234", out=out)
+        self.assertEqual(code, 2)
+        self.assertNotIn("/api/tokens", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -275,6 +275,21 @@ class LogFileCheckTests(unittest.TestCase):
         self.assertIn("traceback", results[1][1])
         self.assertIn("respawn", results[2][1])
 
+    def test_rotated_tail_evidence_is_still_seen(self):
+        # Direkt efter en rotation bor de färska bevisen i .old — en ren
+        # nytrunkerad fil får inte dölja dem.
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Path(tmp) / "t.log"
+            f.write_text("serverar http://0.0.0.0:8737\n")
+            (Path(tmp) / "t.log.old").write_text(
+                "Traceback (most recent call last)\n boom\n" +
+                "serverar http://0.0.0.0:8737\n" * 11)
+            results = smoke.check_log_file(f)
+        self.assertEqual(levels(results),
+                         [smoke.OK, smoke.VARN, smoke.VARN])
+        self.assertIn(".old", results[1][1])
+        self.assertIn("respawn", results[2][1])
+
 
 VALID_STATE = {
     "usage-history.json": '{"v": 1, "samples": []}',

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import logging
 import tempfile
 import threading
 import time
@@ -2227,6 +2228,39 @@ class LogRotationTests(unittest.TestCase):
             tail = old.read_bytes()
             self.assertEqual(len(tail), tokenserver._LOG_TAIL_KEEP_BYTES)
             self.assertTrue(tail.endswith(b"SVANSEN\n"))
+
+    def test_rotation_holds_the_logging_handler_locks(self):
+        # En loggrad mellan svansläsningen och trunkeringen skulle raderas
+        # ur BÅDA filerna — rotationen ska hålla handlerlåsen så att
+        # logging-skrivningar inte kan interfoliera.
+        class CountingHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.acquisitions = 0
+
+            def acquire(self):
+                self.acquisitions += 1
+                super().acquire()
+
+            def emit(self, record):
+                pass
+
+        counting = CountingHandler()
+        root = logging.getLogger()
+        root.addHandler(counting)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                path = self._big_file(tmp)
+                fd = os.open(path, os.O_WRONLY | os.O_APPEND)
+                try:
+                    rotated = tokenserver._maybe_rotate_own_log(
+                        path, stderr_fd=fd)
+                finally:
+                    os.close(fd)
+            self.assertTrue(rotated)
+            self.assertGreaterEqual(counting.acquisitions, 1)
+        finally:
+            root.removeHandler(counting)
 
     def test_terminal_run_never_touches_the_file(self):
         # stderr_fd=2 är testkörarens stderr, inte filen — fstat/stat-vakten

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1475,15 +1475,20 @@ class HandlerPrivacyTests(unittest.TestCase):
         handler._send = mock.Mock()
         return handler
 
-    def test_tokens_error_is_sanitized(self):
+    def test_tokens_error_is_sanitized_but_cause_reaches_the_local_log(self):
         handler = self._handler("/api/tokens")
         with mock.patch.object(
                 tokenserver, "get_snapshot",
-                side_effect=RuntimeError("/private/source/path secret")):
+                side_effect=RuntimeError("/private/source/path secret")), \
+                self.assertLogs("tokenserver", level="ERROR") as captured:
             handler.do_GET()
 
+        # Över LAN:et: bara kontraktets sanerade form. I den lokala loggen:
+        # hela orsaken — ett tyst 500 var så serverfel förblev osynliga.
         handler._send.assert_called_once_with(
             500, {"error": "internal server error"})
+        self.assertIn("/private/source/path secret",
+                      "\n".join(captured.output))
 
     def test_root_diagnostics_contain_names_but_no_header_values_or_body(self):
         handler = self._handler("/")
@@ -1500,6 +1505,50 @@ class HandlerPrivacyTests(unittest.TestCase):
         self.assertEqual(payload["ratelimitHeaders"], [
             "anthropic-ratelimit-unified-7d-utilization"])
         self.assertEqual(payload["unknownRateLimitBuckets"], ["7d_haiku"])
+
+
+class HandlerErrorLoggingTests(unittest.TestCase):
+    """500-kontraktet plus loggning: felen ska synas lokalt, aldrig på LAN:et,
+    och en försvunnen klient är inte ett serverfel."""
+
+    def _handler(self, path):
+        handler = tokenserver.Handler.__new__(tokenserver.Handler)
+        handler.path = path
+        handler.projects_dir = Path("/private/source/path")
+        handler.agent_status = mock.Mock()
+        handler.client_address = ("192.0.2.10", 4711)
+        handler._send = mock.Mock()
+        return handler
+
+    def test_agent_status_route_keeps_the_error_contract(self):
+        # Rutten saknade try/except: ett fel läckte som rå traceback över
+        # HTTP i stället för kontraktets {"error": ...}.
+        handler = self._handler("/api/agent-status")
+        handler.agent_status.snapshot.side_effect = RuntimeError("trasig")
+        with self.assertLogs("tokenserver", level="ERROR") as captured:
+            handler.do_GET()
+
+        handler._send.assert_called_once_with(
+            500, {"error": "internal server error"})
+        self.assertIn("trasig", "\n".join(captured.output))
+
+    def test_client_disconnect_is_quiet_and_not_a_500(self):
+        handler = self._handler("/api/agent-status")
+        handler.agent_status.snapshot.return_value = {"v": 1}
+        handler._send.side_effect = BrokenPipeError()
+        with self.assertNoLogs("tokenserver"):
+            handler.do_GET()
+
+        handler._send.assert_called_once()  # inget 500-försök till ett lik
+
+    def test_log_error_reaches_the_log_while_access_log_stays_muted(self):
+        handler = self._handler("/api/tokens")
+        with self.assertLogs("tokenserver", level="WARNING") as captured:
+            handler.log_error("code %d, message %s", 400, "Bad request")
+        self.assertIn("Bad request", "\n".join(captured.output))
+
+        with self.assertNoLogs("tokenserver"):
+            handler.log_message("%s", "GET /api/tokens 200")
 
 
 class MaxTrackerLiveHookTests(unittest.TestCase):
@@ -1783,13 +1832,23 @@ class MaxTrackerDirtyWriterTests(unittest.TestCase):
         self.previous = (
             tokenserver._max_tracker_dirty,
             tokenserver._max_tracker_writer_running,
+            tokenserver._last_save_error_logged,
         )
         tokenserver._max_tracker_dirty = False
         tokenserver._max_tracker_writer_running = False
+        tokenserver._last_save_error_logged = 0.0
 
     def tearDown(self):
         (tokenserver._max_tracker_dirty,
-         tokenserver._max_tracker_writer_running) = self.previous
+         tokenserver._max_tracker_writer_running,
+         tokenserver._last_save_error_logged) = self.previous
+
+    def _wait_for_writer_stop(self):
+        for _ in range(50):
+            if not tokenserver._max_tracker_writer_running:
+                return
+            time.sleep(0.01)
+        self.fail("writer-tråden stannade aldrig")
 
     def test_marking_dirty_eventually_saves_off_the_calling_thread(self):
         store = mock.Mock()
@@ -1833,6 +1892,36 @@ class MaxTrackerDirtyWriterTests(unittest.TestCase):
         # Coalesced into (at most) one trailing save after the in-flight
         # one, never a save per dirty mark.
         self.assertLessEqual(store.save.call_count, 2)
+
+    def test_failed_save_keeps_dirty_so_the_next_mark_retries(self):
+        # Var: dirty nollades FÖRE save() och felet svaldes — en disk- eller
+        # rättighetsmiss slängde observationerna tyst tills någon orelaterad
+        # händelse råkade markera om (OBS-10 i observability-backloggen).
+        store = mock.Mock()
+        store.save.side_effect = OSError("disken full")
+
+        with self.assertLogs("tokenserver", level="ERROR") as captured:
+            tokenserver._mark_max_tracker_dirty(store)
+            for _ in range(50):
+                if store.save.called:
+                    break
+                time.sleep(0.01)
+            self._wait_for_writer_stop()
+
+        store.save.assert_called_once()
+        self.assertTrue(tokenserver._max_tracker_dirty)
+        self.assertIn("save misslyckades", "\n".join(captured.output))
+
+        # Nästa markering försöker igen — signalen överlevde felet.
+        store.save.side_effect = None
+        tokenserver._mark_max_tracker_dirty(store)
+        for _ in range(50):
+            if store.save.call_count == 2:
+                break
+            time.sleep(0.01)
+        self._wait_for_writer_stop()
+        self.assertEqual(store.save.call_count, 2)
+        self.assertFalse(tokenserver._max_tracker_dirty)
 
 
 class MaxTrackerBackfillLoopTests(unittest.TestCase):
@@ -1961,7 +2050,8 @@ class MaxTrackerEndpointTests(unittest.TestCase):
         handler = self._handler(mock.Mock())
         with mock.patch.object(
                 tokenserver, "get_snapshot",
-                side_effect=RuntimeError("/private/source/path secret")):
+                side_effect=RuntimeError("/private/source/path secret")), \
+                self.assertLogs("tokenserver", level="ERROR"):
             handler.do_GET()
 
         handler._send.assert_called_once_with(
@@ -2004,6 +2094,98 @@ class ArgumentParsingTests(unittest.TestCase):
         args = parser.parse_args([])
         self.assertIsNone(args.claude_plan)
         self.assertIsNone(args.codex_plan)
+
+
+class LogRotationTests(unittest.TestCase):
+    """_maybe_rotate_own_log: trunkera bara launchd-loggen, bara över taket,
+    och bevara svansen — utan att någonsin röra en fil stderr inte äger."""
+
+    def _big_file(self, tmp):
+        path = Path(tmp) / "torget-tokenserver.log"
+        filler = b"x" * (tokenserver._LOG_CAP_BYTES + 4096)
+        path.write_bytes(filler[:-8] + b"SVANSEN\n")
+        return path
+
+    def test_rotates_when_stderr_is_the_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._big_file(tmp)
+            fd = os.open(path, os.O_WRONLY | os.O_APPEND)
+            try:
+                rotated = tokenserver._maybe_rotate_own_log(
+                    path, stderr_fd=fd)
+            finally:
+                os.close(fd)
+
+            self.assertTrue(rotated)
+            self.assertEqual(path.stat().st_size, 0)
+            old = path.with_name(path.name + ".old")
+            tail = old.read_bytes()
+            self.assertEqual(len(tail), tokenserver._LOG_TAIL_KEEP_BYTES)
+            self.assertTrue(tail.endswith(b"SVANSEN\n"))
+
+    def test_terminal_run_never_touches_the_file(self):
+        # stderr_fd=2 är testkörarens stderr, inte filen — fstat/stat-vakten
+        # ska vägra, oavsett storlek.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._big_file(tmp)
+            size_before = path.stat().st_size
+            self.assertFalse(
+                tokenserver._maybe_rotate_own_log(path, stderr_fd=2))
+            self.assertEqual(path.stat().st_size, size_before)
+
+    def test_under_cap_and_missing_file_are_noops(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "liten.log"
+            path.write_bytes(b"kort\n")
+            fd = os.open(path, os.O_WRONLY | os.O_APPEND)
+            try:
+                self.assertFalse(
+                    tokenserver._maybe_rotate_own_log(path, stderr_fd=fd))
+            finally:
+                os.close(fd)
+            self.assertEqual(path.read_bytes(), b"kort\n")
+
+            self.assertFalse(tokenserver._maybe_rotate_own_log(
+                Path(tmp) / "finns-inte.log", stderr_fd=2))
+
+
+class ProbeTransitionLogTests(unittest.TestCase):
+    """Övergångsloggen: en rad när probestatusen ändras, tystnad medan
+    samma läge står — loggfilen ska vara läsbar över veckor."""
+
+    def test_status_change_logs_once_then_stays_quiet(self):
+        with mock.patch.object(tokenserver, "_probe_status",
+                               "usage_http_401"), \
+                mock.patch.object(tokenserver, "_probe_status_logged", None), \
+                mock.patch.object(tokenserver, "_last_limits", None), \
+                mock.patch.object(tokenserver, "_last_probed", 0.0), \
+                mock.patch.object(tokenserver, "_limits_refreshing", False), \
+                mock.patch.object(tokenserver, "_probe_failure_streak", 0), \
+                mock.patch.object(tokenserver, "_probe_limits",
+                                  return_value=None):
+            with self.assertLogs("tokenserver", level="INFO") as captured:
+                tokenserver._refresh_limits()
+            self.assertIn("start -> usage_http_401",
+                          "\n".join(captured.output))
+
+            with self.assertNoLogs("tokenserver"):
+                tokenserver._refresh_limits()
+
+    def test_recovery_is_a_transition_too(self):
+        with mock.patch.object(tokenserver, "_probe_status",
+                               "usage_http_200 + ok"), \
+                mock.patch.object(tokenserver, "_probe_status_logged",
+                                  "usage_http_401"), \
+                mock.patch.object(tokenserver, "_last_limits", None), \
+                mock.patch.object(tokenserver, "_last_probed", 0.0), \
+                mock.patch.object(tokenserver, "_limits_refreshing", False), \
+                mock.patch.object(tokenserver, "_probe_failure_streak", 3), \
+                mock.patch.object(tokenserver, "_probe_limits",
+                                  return_value={"weekPct": 60.0}):
+            with self.assertLogs("tokenserver", level="INFO") as captured:
+                tokenserver._refresh_limits()
+            self.assertIn("usage_http_401 -> usage_http_200 + ok",
+                          "\n".join(captured.output))
 
 
 if __name__ == "__main__":

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1551,6 +1551,63 @@ class HandlerErrorLoggingTests(unittest.TestCase):
             handler.log_message("%s", "GET /api/tokens 200")
 
 
+class UsageComputeHealthTests(unittest.TestCase):
+    """OBS-08: en kraschad omräkning får frysa siffrorna (senaste goda
+    serveras vidare) men aldrig tyst — logg vid övergången, strypt
+    upprepning, usageComputeOk på GET /, och återhämtningen loggad."""
+
+    def test_compute_crash_logs_throttled_and_flags_the_root_payload(self):
+        with mock.patch.object(tokenserver, "_compute_failing_since", None), \
+                mock.patch.object(tokenserver, "_last_compute_error_logged",
+                                  None), \
+                mock.patch.object(tokenserver, "_last_result", {"v": 1}), \
+                mock.patch.object(tokenserver, "_last_computed", 0.0), \
+                mock.patch.object(tokenserver, "_snapshot_refreshing", True), \
+                mock.patch.object(tokenserver, "_compute",
+                                  side_effect=RuntimeError("boom")):
+            with self.assertLogs("tokenserver", level="ERROR") as captured:
+                tokenserver._refresh_usage_totals(Path("/x"))
+            self.assertIn("frysta siffror", "\n".join(captured.output))
+            # Ihållande fel stryps — ingen ny rad inom fönstret.
+            with self.assertNoLogs("tokenserver"):
+                tokenserver._refresh_usage_totals(Path("/x"))
+            self.assertIsNotNone(tokenserver._compute_failing_since)
+            # Senaste goda snapshotet serveras vidare — det är avsikten.
+            self.assertEqual(tokenserver._last_result, {"v": 1})
+
+            handler = tokenserver.Handler.__new__(tokenserver.Handler)
+            handler.path = "/"
+            handler._send = mock.Mock()
+            handler.do_GET()
+            payload = handler._send.call_args.args[1]
+            self.assertFalse(payload["usageComputeOk"])
+            self.assertIsInstance(payload["usageComputeFailingForS"], int)
+
+    def test_recovery_logs_the_transition_and_clears_the_flag(self):
+        with mock.patch.object(tokenserver, "_compute_failing_since",
+                               time.monotonic() - 42.0), \
+                mock.patch.object(tokenserver, "_last_compute_error_logged",
+                                  time.monotonic()), \
+                mock.patch.object(tokenserver, "_last_result", None), \
+                mock.patch.object(tokenserver, "_last_computed", 0.0), \
+                mock.patch.object(tokenserver, "_snapshot_refreshing", True), \
+                mock.patch.object(tokenserver, "_compute",
+                                  return_value={"v": 2}):
+            with self.assertLogs("tokenserver", level="INFO") as captured:
+                tokenserver._refresh_usage_totals(Path("/x"))
+            self.assertIn("frisk igen", "\n".join(captured.output))
+            self.assertIsNone(tokenserver._compute_failing_since)
+            self.assertEqual(tokenserver._last_result, {"v": 2})
+
+            handler = tokenserver.Handler.__new__(tokenserver.Handler)
+            handler.path = "/"
+            handler._send = mock.Mock()
+            handler.do_GET()
+            payload = handler._send.call_args.args[1]
+            self.assertTrue(payload["usageComputeOk"])
+            self.assertIsNone(payload["usageComputeFailingForS"])
+
+
 class MaxTrackerLiveHookTests(unittest.TestCase):
     """get_snapshot()'s observe_quota wiring: session/week windows, the
     *Stale: false gate, and Codex's natively-carried window_minutes."""
@@ -1836,7 +1893,10 @@ class MaxTrackerDirtyWriterTests(unittest.TestCase):
         )
         tokenserver._max_tracker_dirty = False
         tokenserver._max_tracker_writer_running = False
-        tokenserver._last_save_error_logged = 0.0
+        # None = "aldrig loggat" — 0.0 hade svalt första felet på en maskin
+        # med kort uptime, eftersom monotonic räknar från boot (CI fällde
+        # exakt det).
+        tokenserver._last_save_error_logged = None
 
     def tearDown(self):
         (tokenserver._max_tracker_dirty,

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -2288,6 +2288,20 @@ class LogRotationTests(unittest.TestCase):
                 Path(tmp) / "finns-inte.log", stderr_fd=2))
 
 
+class SourceFingerprintTests(unittest.TestCase):
+    def test_fingerprint_is_stable_and_served_on_root(self):
+        first = tokenserver._read_source_fingerprint()
+        self.assertRegex(first, r"^[0-9a-f]{12}$")
+        self.assertEqual(first, tokenserver._read_source_fingerprint())
+
+        handler = tokenserver.Handler.__new__(tokenserver.Handler)
+        handler.path = "/"
+        handler._send = mock.Mock()
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertEqual(payload["srcFingerprint"], tokenserver._SERVER_SRC)
+
+
 class LogRotationWatchTests(unittest.TestCase):
     def test_watch_keeps_checking_until_stopped(self):
         # Startrotationen räcker inte för en långlivad process — vakten ska

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1607,6 +1607,14 @@ class UsageComputeHealthTests(unittest.TestCase):
             self.assertTrue(payload["usageComputeOk"])
             self.assertIsNone(payload["usageComputeFailingForS"])
 
+            # Återhämtningen stänger episoden: ett NYTT fel inom gamla
+            # strypfönstret ska logga direkt, inte tigas ihjäl.
+            self.assertIsNone(tokenserver._last_compute_error_logged)
+            with mock.patch.object(tokenserver, "_compute",
+                                   side_effect=RuntimeError("ny episod")), \
+                    self.assertLogs("tokenserver", level="ERROR"):
+                tokenserver._refresh_usage_totals(Path("/x"))
+
 
 class MaxTrackerLiveHookTests(unittest.TestCase):
     """get_snapshot()'s observe_quota wiring: session/week windows, the
@@ -1972,16 +1980,30 @@ class MaxTrackerDirtyWriterTests(unittest.TestCase):
         self.assertTrue(tokenserver._max_tracker_dirty)
         self.assertIn("save misslyckades", "\n".join(captured.output))
 
-        # Nästa markering försöker igen — signalen överlevde felet.
+        # Nästa markering försöker igen — signalen överlevde felet, och
+        # den lyckade skrivningen stänger episoden i loggen.
         store.save.side_effect = None
-        tokenserver._mark_max_tracker_dirty(store)
-        for _ in range(50):
-            if store.save.call_count == 2:
-                break
-            time.sleep(0.01)
-        self._wait_for_writer_stop()
+        with self.assertLogs("tokenserver", level="INFO") as recovered:
+            tokenserver._mark_max_tracker_dirty(store)
+            for _ in range(50):
+                if store.save.call_count == 2:
+                    break
+                time.sleep(0.01)
+            self._wait_for_writer_stop()
         self.assertEqual(store.save.call_count, 2)
         self.assertFalse(tokenserver._max_tracker_dirty)
+        self.assertIn("lyckades igen", "\n".join(recovered.output))
+        # Episoden är stängd: ett nytt fel loggar direkt trots att gamla
+        # strypfönstret inte hunnit löpa ut.
+        store.save.side_effect = OSError("disken full igen")
+        with self.assertLogs("tokenserver", level="ERROR"):
+            tokenserver._mark_max_tracker_dirty(store)
+            for _ in range(50):
+                if store.save.call_count == 3:
+                    break
+                time.sleep(0.01)
+            self._wait_for_writer_stop()
+        self.assertTrue(tokenserver._max_tracker_dirty)
 
 
 class MaxTrackerBackfillLoopTests(unittest.TestCase):

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1541,6 +1541,29 @@ class HandlerErrorLoggingTests(unittest.TestCase):
 
         handler._send.assert_called_once()  # inget 500-försök till ett lik
 
+    def test_producer_connection_error_is_a_server_error_not_a_disconnect(self):
+        # ConnectionError FRÅN producenten är ett serverfel och ska logga +
+        # 500 — bara under svarsskrivningen betyder det att klienten dog.
+        handler = self._handler("/api/agent-status")
+        handler.agent_status.snapshot.side_effect = ConnectionError("inuti")
+        with self.assertLogs("tokenserver", level="ERROR") as captured:
+            handler.do_GET()
+
+        handler._send.assert_called_once_with(
+            500, {"error": "internal server error"})
+        self.assertIn("inuti", "\n".join(captured.output))
+
+    def test_unwritable_payload_logs_and_falls_back_to_500(self):
+        handler = self._handler("/api/agent-status")
+        handler.agent_status.snapshot.return_value = {"v": 1}
+        handler._send.side_effect = [TypeError("oserialiserbar"), None]
+        with self.assertLogs("tokenserver", level="ERROR") as captured:
+            handler.do_GET()
+
+        self.assertEqual(handler._send.call_count, 2)
+        self.assertEqual(handler._send.call_args.args[0], 500)
+        self.assertIn("svarsskrivningen", "\n".join(captured.output))
+
     def test_log_error_reaches_the_log_while_access_log_stays_muted(self):
         handler = self._handler("/api/tokens")
         with self.assertLogs("tokenserver", level="WARNING") as captured:

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -2254,6 +2254,28 @@ class LogRotationTests(unittest.TestCase):
                 Path(tmp) / "finns-inte.log", stderr_fd=2))
 
 
+class LogRotationWatchTests(unittest.TestCase):
+    def test_watch_keeps_checking_until_stopped(self):
+        # Startrotationen räcker inte för en långlivad process — vakten ska
+        # titta om och om igen och dö snyggt på stoppsignalen.
+        stop = threading.Event()
+        calls = []
+        with mock.patch.object(tokenserver, "_maybe_rotate_own_log",
+                               side_effect=lambda: calls.append(1)):
+            watcher = threading.Thread(
+                target=tokenserver._run_log_rotation_watch,
+                args=(stop,), kwargs={"interval_s": 0.01}, daemon=True)
+            watcher.start()
+            for _ in range(200):
+                if len(calls) >= 2:
+                    break
+                time.sleep(0.01)
+            stop.set()
+            watcher.join(timeout=2)
+        self.assertGreaterEqual(len(calls), 2)
+        self.assertFalse(watcher.is_alive())
+
+
 class ProbeTransitionLogTests(unittest.TestCase):
     """Övergångsloggen: en rad när probestatusen ändras, tystnad medan
     samma läge står — loggfilen ska vara läsbar över veckor."""
@@ -2273,6 +2295,33 @@ class ProbeTransitionLogTests(unittest.TestCase):
             self.assertIn("start -> usage_http_401",
                           "\n".join(captured.output))
 
+            with self.assertNoLogs("tokenserver"):
+                tokenserver._refresh_limits()
+
+    def test_probe_crash_replaces_stale_ok_status_and_logs_once(self):
+        # Kraschar proben innan den satt status fick "usage_http_200 + ok"
+        # stå kvar och ljuga medan värdena försvann — kraschen ska bli en
+        # egen status (syns på GET / och i röktestet) med traceback en
+        # gång per episod.
+        with mock.patch.object(tokenserver, "_probe_status",
+                               "usage_http_200 + ok"), \
+                mock.patch.object(tokenserver, "_probe_status_logged",
+                                  "usage_http_200 + ok"), \
+                mock.patch.object(tokenserver, "_last_limits", None), \
+                mock.patch.object(tokenserver, "_last_probed", 0.0), \
+                mock.patch.object(tokenserver, "_limits_refreshing", False), \
+                mock.patch.object(tokenserver, "_probe_failure_streak", 0), \
+                mock.patch.object(tokenserver, "_probe_limits",
+                                  side_effect=RuntimeError("boom")):
+            with self.assertLogs("tokenserver", level="INFO") as captured:
+                tokenserver._refresh_limits()
+            out = "\n".join(captured.output)
+            self.assertEqual(tokenserver._probe_status,
+                             "probe_crashed: RuntimeError")
+            self.assertIn("kraschade", out)
+            self.assertIn("-> probe_crashed: RuntimeError", out)
+
+            # Samma krasch igen: samma episod, ingen ny rad.
             with self.assertNoLogs("tokenserver"):
                 tokenserver._refresh_limits()
 

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -155,7 +155,29 @@ def _read_server_rev():
         return "unknown"
 
 
+def _read_source_fingerprint():
+    """Innehållshash av tjänstens källfiler, tagen vid start. Rev räcker
+    inte för "kör servern det som ligger här?": en smutsig worktree, eller
+    en redigering EFTER att processen startade, delar HEAD med checkouten
+    och låter rev-jämförelsen ljuga "aktuell". Röktestet räknar om samma
+    hash från disken och jämför. test_* och smoke.py ingår inte — tjänsten
+    laddar dem aldrig, och en redigerad smoke ska inte se ut som en
+    föråldrad server."""
+    try:
+        digest = hashlib.sha256()
+        base = Path(os.path.dirname(os.path.abspath(__file__)))
+        for f in sorted(base.glob("*.py")):
+            if f.name.startswith("test_") or f.name == "smoke.py":
+                continue
+            digest.update(f.name.encode())
+            digest.update(f.read_bytes())
+        return digest.hexdigest()[:12]
+    except Exception:
+        return "unknown"
+
+
 _SERVER_REV = _read_server_rev()
+_SERVER_SRC = _read_source_fingerprint()
 _SERVER_STARTED = datetime.now().astimezone().isoformat(timespec="seconds")
 MAX_TRACKER_BACKFILL_TICK_S = 0.5  # samma kadens som agent_status.POLL_S
 # Claude bär aldrig fönstrets minuttal i klartext (bara namnen "5h"/"7d") --
@@ -1679,6 +1701,7 @@ class Handler(BaseHTTPRequestHandler):
         elif self.path == "/":
             self._reply(lambda: {"service": "torget-tokenserver",
                                  "rev": _SERVER_REV,
+                                 "srcFingerprint": _SERVER_SRC,
                                  "startedAt": _SERVER_STARTED,
                                  "endpoint": "/api/tokens",
                                  "endpoints": ["/api/tokens",

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -115,6 +115,20 @@ def _maybe_rotate_own_log(path=None, stderr_fd=2):
         return False
 
 
+_LOG_ROTATE_CHECK_S = 3600.0
+
+
+def _run_log_rotation_watch(stop_event, interval_s=None):
+    """Timvis rotationsvakt: startrotationen räcker inte för en process som
+    lever länge — en ihållande felande deltjänst kan annars skriva förbi
+    taket tills en orelaterad omstart råkar städa. Samma fstat-vakt som vid
+    start, så terminalkörningar förblir orörda; tråden sover resten av
+    tiden."""
+    interval = _LOG_ROTATE_CHECK_S if interval_s is None else interval_s
+    while not stop_event.wait(interval):
+        _maybe_rotate_own_log()
+
+
 def _read_server_rev():
     """Git-revisionen som faktiskt serverar — gör 'fel kod kör' synligt i en
     curl i stället för en timmes processarkeologi."""
@@ -741,11 +755,20 @@ def _probe_interval_s():
 
 def _refresh_limits():
     global _last_limits, _last_probed, _limits_refreshing, \
-        _probe_failure_streak, _probe_status_logged
+        _probe_failure_streak, _probe_status_logged, _probe_status
     try:
         refreshed = _probe_limits()
-    except Exception:
+    except Exception as e:
         refreshed = None
+        # Kraschar proben INNAN den hunnit sätta status skulle den gamla
+        # strängen stå kvar — i värsta fall "usage_http_200 + ok" medan
+        # värdena försvinner. En krasch är en bugg (ingen vanlig felväg):
+        # sätt en egen status och logga traceback en gång per episod.
+        crashed = f"probe_crashed: {type(e).__name__}"
+        if _probe_status != crashed:
+            log.exception("claude-proben kraschade (status var %s)",
+                          _probe_status)
+        _probe_status = crashed
     # Övergångsloggen: 401 som dyker upp, 429-backoff, återhämtningen.
     # Läses här på probetråden (enda skrivaren), efter att statussträngen
     # är färdigbyggd — samma läge står stilla utan att skriva en rad till.
@@ -1722,6 +1745,12 @@ def main():
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     _maybe_rotate_own_log()
+    threading.Thread(
+        target=_run_log_rotation_watch,
+        args=(threading.Event(),),
+        name="log-rotation-watch",
+        daemon=True,
+    ).start()
     log.info("startar: rev %s", _SERVER_REV)
 
     Handler.projects_dir = Path(args.dir)

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -5,7 +5,7 @@ Skannar sessionsloggarna i ~/.claude/projects/**/*.jsonl (samma källa som
 usage-verktyg i ccusage-familjen läser), summerar tokens per dag och serverar
 glance-mönstrets kontrakt på /api/tokens:
 
-    {"v": 1, "dayTokens": ..., "dayTokensPerHour": ..., "daySessions": ...,
+    {"v": 2, "dayTokens": ..., "dayTokensPerHour": ..., "daySessions": ...,
      "monthTokens": ...}
 
 Designregler, ärvda från Solelkollens /api/glance:
@@ -1267,6 +1267,12 @@ def _max_tracker_writer(store):
             _max_tracker_dirty = False
         try:
             store.save()
+            if _last_save_error_logged is not None:
+                # Lyckad skrivning stänger felepisoden: logga slutet och
+                # nollställ strypningen, så nästa fel (en NY episod) loggar
+                # direkt i stället för att ärva gamla fönstret.
+                log.info("max-tracker: save lyckades igen")
+                _last_save_error_logged = None
         except Exception:
             # En misslyckad skrivning får inte tappa dirty-signalen: markera
             # om och avsluta, så NÄSTA observation (eller slutflushen)
@@ -1386,6 +1392,9 @@ def _refresh_usage_totals(projects_dir, max_tracker_store=None):
             log.info("usage-omräkningen frisk igen efter %.0f s",
                      time.monotonic() - _compute_failing_since)
             _compute_failing_since = None
+            # Återhämtningen stänger episoden: nästa fel är en NY episod
+            # och ska logga direkt, inte ärva gamla strypfönstret.
+            _last_compute_error_logged = None
     with _cache_lock:
         if refreshed is not None:
             _last_result = refreshed

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -89,12 +89,22 @@ def _maybe_rotate_own_log(path=None, stderr_fd=2):
     skyddar terminalkörningar från att röra en fil de inte skriver till.
     Trunkering i stället för rename: launchd håller fd:n öppen med O_APPEND,
     så en rename hade bara fått processen att skriva vidare i den flyttade
-    filen medan den nya förblev tom."""
+    filen medan den nya förblev tom.
+
+    Hela läs-kopiera-trunkera-sekvensen hålls under root-loggerns
+    handlerlås (RLock — vår egen "roterad"-rad kan fortfarande skrivas), så
+    en loggrad från en annan tråd inte kan landa mellan svansläsningen och
+    trunkeringen och raderas ur bägge filerna. Råa stderr-skrivningar
+    (agent_status-diagnostiken) går utanför låset; det kvarvarande fönstret
+    är millisekunder mot en strypt rad per 30 s, en gång per 5 MB."""
     path = Path(path) if path else DEFAULT_LOG_PATH
     try:
         st = path.stat()
     except OSError:
         return False  # ingen fil (terminalkörning, färsk installation)
+    handlers = list(logging.getLogger().handlers)
+    for handler in handlers:
+        handler.acquire()
     try:
         if st.st_size <= _LOG_CAP_BYTES:
             return False
@@ -103,16 +113,19 @@ def _maybe_rotate_own_log(path=None, stderr_fd=2):
             return False
         with open(path, "rb+") as fh:
             fh.seek(max(0, st.st_size - _LOG_TAIL_KEEP_BYTES))
-            tail = fh.read()
+            tail = fh.read()  # läser till FAKTISKT EOF — även nyare rader
             path.with_name(path.name + ".old").write_bytes(tail)
             fh.truncate(0)
-        log.info("loggfilen roterad vid start (%d byte > taket %d; svansen "
-                 "ligger i %s.old)", st.st_size, _LOG_CAP_BYTES, path.name)
+        log.info("loggfilen roterad (%d byte > taket %d; svansen ligger i "
+                 "%s.old)", st.st_size, _LOG_CAP_BYTES, path.name)
         return True
     except Exception:
         # Rotering får aldrig fälla tjänsten; att den misslyckades ska synas.
         log.warning("logrotering av %s misslyckades", path, exc_info=True)
         return False
+    finally:
+        for handler in reversed(handlers):
+            handler.release()
 
 
 _LOG_ROTATE_CHECK_S = 3600.0

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -1604,13 +1604,28 @@ class Handler(BaseHTTPRequestHandler):
         """Svara 200 med produce(), annars 500 {"error": ...} — skärmen
         avvisar error-formen per kontrakt och behåller senaste goda värden.
         Orsaken ska ändå alltid synas i loggen: ett tyst 500 var så
-        max-tracker-buggarna förblev osynliga."""
+        max-tracker-buggarna förblev osynliga.
+
+        Producenten och svarsskrivningen bedöms VAR FÖR SIG: ett
+        ConnectionError/TimeoutError från producenten är ett serverfel som
+        ska loggas och bli 500 — bara under själva skrivningen betyder det
+        att klienten försvann."""
         try:
-            self._send(200, produce())
+            payload = produce()
+        except Exception:
+            log.exception("500 på %s", self.path)
+            try:
+                self._send(500, {"error": "internal server error"})
+            except OSError:
+                pass
+            return
+        try:
+            self._send(200, payload)
         except (ConnectionError, TimeoutError):
             pass  # klienten försvann mitt i svaret — inte ett serverfel
         except Exception:
-            log.exception("500 på %s", self.path)
+            # T.ex. oserialiserbar payload — serverfel, inte klientens.
+            log.exception("500 på %s (svarsskrivningen)", self.path)
             try:
                 self._send(500, {"error": "internal server error"})
             except OSError:

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -34,12 +34,14 @@ Autostart: se README.md härintill (launchd-plist medföljer).
 import argparse
 import hashlib
 import json
+import logging
 import math
 import os
 import re
 import select
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import urllib.request
@@ -63,6 +65,54 @@ else:  # direktkörning: python3 tools/tokenserver/tokenserver.py
 
 RECOMPUTE_EVERY_S = 30
 LIMITS_EVERY_S = 120  # rate-limit-proben: snäll mot API:t, färsk nog för hyllan
+
+# Diagnostiken går via logging till stderr med tidsstämplar (basicConfig i
+# main; launchd samlar bägge strömmarna i loggfilen, se plisten). Regeln är
+# ÖVERGÅNGAR, inte tillstånd: en statusändring loggas en gång och sedan är
+# det tyst tills läget ändras igen — filen ska vara läsbar över veckor.
+log = logging.getLogger("tokenserver")
+
+# Loggfilen under launchd (plistens StandardOut/ErrorPath). ~/Library/Logs
+# överlever omstart och syns i Konsol-appen — /tmp gjorde ingetdera. launchd
+# har ingen egen rotation, så servern tar den vid start: se
+# _maybe_rotate_own_log.
+DEFAULT_LOG_PATH = Path.home() / "Library" / "Logs" / "torget-tokenserver.log"
+_LOG_CAP_BYTES = 5 * 1024 * 1024
+_LOG_TAIL_KEEP_BYTES = 256 * 1024
+
+
+def _maybe_rotate_own_log(path=None, stderr_fd=2):
+    """Trunkera loggfilen vid start när den vuxit förbi taket, med svansen
+    bevarad i <namn>.old.
+
+    Bara när stderr faktiskt ÄR filen (launchd-fallet): fstat/stat-jämförelsen
+    skyddar terminalkörningar från att röra en fil de inte skriver till.
+    Trunkering i stället för rename: launchd håller fd:n öppen med O_APPEND,
+    så en rename hade bara fått processen att skriva vidare i den flyttade
+    filen medan den nya förblev tom."""
+    path = Path(path) if path else DEFAULT_LOG_PATH
+    try:
+        st = path.stat()
+    except OSError:
+        return False  # ingen fil (terminalkörning, färsk installation)
+    try:
+        if st.st_size <= _LOG_CAP_BYTES:
+            return False
+        own = os.fstat(stderr_fd)
+        if (own.st_dev, own.st_ino) != (st.st_dev, st.st_ino):
+            return False
+        with open(path, "rb+") as fh:
+            fh.seek(max(0, st.st_size - _LOG_TAIL_KEEP_BYTES))
+            tail = fh.read()
+            path.with_name(path.name + ".old").write_bytes(tail)
+            fh.truncate(0)
+        log.info("loggfilen roterad vid start (%d byte > taket %d; svansen "
+                 "ligger i %s.old)", st.st_size, _LOG_CAP_BYTES, path.name)
+        return True
+    except Exception:
+        # Rotering får aldrig fälla tjänsten; att den misslyckades ska synas.
+        log.warning("logrotering av %s misslyckades", path, exc_info=True)
+        return False
 
 
 def _read_server_rev():
@@ -303,6 +353,7 @@ _probe_headers = []
 _probe_unknown_buckets = []
 _probe_cooldown_until = 0.0
 _probe_failure_streak = 0
+_probe_status_logged = None  # senast loggade status — övergångar loggas, tillstånd inte
 
 
 _CLAUDE_DESKTOP_PROCESS = re.compile(
@@ -653,7 +704,7 @@ def _probe_limits():
         _headers_logged = True
         for name in sorted(headers):
             if "ratelimit" in name.lower():
-                print(f"ratelimit-header: {name}")
+                log.info("ratelimit-header: %s", name)
     # Tre fönster, samma som Claudes egen usage-panel: 5-timmars, veckan
     # (alla modeller) och veckan för tyngsta modellen (Fable/Opus). Fönster-
     # namnet i headern varierar ("5h", "7d", "7d_opus", ...) — mappa på
@@ -681,11 +732,18 @@ def _probe_interval_s():
 
 def _refresh_limits():
     global _last_limits, _last_probed, _limits_refreshing, \
-        _probe_failure_streak
+        _probe_failure_streak, _probe_status_logged
     try:
         refreshed = _probe_limits()
     except Exception:
         refreshed = None
+    # Övergångsloggen: 401 som dyker upp, 429-backoff, återhämtningen.
+    # Läses här på probetråden (enda skrivaren), efter att statussträngen
+    # är färdigbyggd — samma läge står stilla utan att skriva en rad till.
+    if _probe_status != _probe_status_logged:
+        log.info("claude-probe: %s -> %s",
+                 _probe_status_logged or "start", _probe_status)
+        _probe_status_logged = _probe_status
     with _limits_lock:
         _probe_failure_streak = 0 if refreshed else _probe_failure_streak + 1
         _last_limits = refreshed
@@ -1183,10 +1241,13 @@ def _persist_quota_records_async(cache, records):
 _max_tracker_writer_lock = threading.Lock()
 _max_tracker_dirty = False
 _max_tracker_writer_running = False
+_SAVE_ERROR_LOG_INTERVAL_S = 300.0
+_last_save_error_logged = 0.0
 
 
 def _max_tracker_writer(store):
-    global _max_tracker_dirty, _max_tracker_writer_running
+    global _max_tracker_dirty, _max_tracker_writer_running, \
+        _last_save_error_logged
     while True:
         with _max_tracker_writer_lock:
             if not _max_tracker_dirty:
@@ -1196,7 +1257,20 @@ def _max_tracker_writer(store):
         try:
             store.save()
         except Exception:
-            pass
+            # En misslyckad skrivning får inte tappa dirty-signalen: markera
+            # om och avsluta, så NÄSTA observation (eller slutflushen)
+            # försöker igen — ingen het loop, ingen tyst dataförlust.
+            # Loggen är strypt: ett trasigt skrivmål ska inte fylla filen.
+            now = time.monotonic()
+            if now - _last_save_error_logged >= _SAVE_ERROR_LOG_INTERVAL_S:
+                _last_save_error_logged = now
+                log.exception(
+                    "max-tracker: save misslyckades — observationerna står "
+                    "kvar i minnet och nästa försök kommer")
+            with _max_tracker_writer_lock:
+                _max_tracker_dirty = True
+                _max_tracker_writer_running = False
+            return
 
 
 def _mark_max_tracker_dirty(store):
@@ -1491,37 +1565,54 @@ class Handler(BaseHTTPRequestHandler):
             quota_snapshot.get("codexWeekStale"))
         return payload
 
+    def _reply(self, produce):
+        """Svara 200 med produce(), annars 500 {"error": ...} — skärmen
+        avvisar error-formen per kontrakt och behåller senaste goda värden.
+        Orsaken ska ändå alltid synas i loggen: ett tyst 500 var så
+        max-tracker-buggarna förblev osynliga."""
+        try:
+            self._send(200, produce())
+        except (ConnectionError, TimeoutError):
+            pass  # klienten försvann mitt i svaret — inte ett serverfel
+        except Exception:
+            log.exception("500 på %s", self.path)
+            try:
+                self._send(500, {"error": "internal server error"})
+            except OSError:
+                pass
+
     def do_GET(self):
         if self.path == "/api/tokens":
-            try:
-                self._send(200, get_snapshot(
-                    self.projects_dir,
-                    max_tracker_store=self.max_tracker_store))
-            except Exception:  # skärmen avvisar error-formen per kontrakt
-                self._send(500, {"error": "internal server error"})
+            self._reply(lambda: get_snapshot(
+                self.projects_dir,
+                max_tracker_store=self.max_tracker_store))
         elif self.path == "/api/agent-status":
-            self._send(200, self.agent_status.snapshot())
+            self._reply(lambda: self.agent_status.snapshot())
         elif self.path == "/api/max-tracker":
-            try:
-                self._send(200, self._max_tracker_payload())
-            except Exception:  # skärmen avvisar error-formen per kontrakt
-                self._send(500, {"error": "internal server error"})
+            self._reply(self._max_tracker_payload)
         elif self.path == "/":
-            self._send(200, {"service": "torget-tokenserver",
-                             "rev": _SERVER_REV,
-                             "startedAt": _SERVER_STARTED,
-                             "endpoint": "/api/tokens",
-                             "endpoints": ["/api/tokens", "/api/agent-status",
-                                          "/api/max-tracker"],
-                             "claudeProbe": _probe_status,
-                             "ratelimitHeaders": _probe_headers,
-                             "unknownRateLimitBuckets":
-                                 _probe_unknown_buckets})
+            self._reply(lambda: {"service": "torget-tokenserver",
+                                 "rev": _SERVER_REV,
+                                 "startedAt": _SERVER_STARTED,
+                                 "endpoint": "/api/tokens",
+                                 "endpoints": ["/api/tokens",
+                                               "/api/agent-status",
+                                               "/api/max-tracker"],
+                                 "claudeProbe": _probe_status,
+                                 "ratelimitHeaders": _probe_headers,
+                                 "unknownRateLimitBuckets":
+                                     _probe_unknown_buckets})
         else:
             self._send(404, {"error": "not found"})
 
     def log_message(self, fmt, *args):
         pass  # 30 s-pollning ska inte fylla loggen
+
+    def log_error(self, fmt, *args):
+        # BaseHTTPRequestHandler ruttar log_error genom log_message, så den
+        # tystade accessloggen tystade felen med sig. Accessloggen ska vara
+        # tyst; felen ska inte.
+        log.warning("http %s: %s", self.address_string(), fmt % args)
 
 
 def _build_arg_parser():
@@ -1565,15 +1656,39 @@ def main():
     ap = _build_arg_parser()
     args = ap.parse_args()
 
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    _maybe_rotate_own_log()
+    log.info("startar: rev %s", _SERVER_REV)
+
     Handler.projects_dir = Path(args.dir)
     if not Handler.projects_dir.is_dir():
-        raise SystemExit(f"hittar inte {Handler.projects_dir} — finns Claude Code på den här maskinen?")
+        # Var: SystemExit. Under launchd (KeepAlive utan ThrottleInterval)
+        # blev det en tyst respawn var ~10:e sekund som fyllde loggen.
+        # Vänta i stället — katalogen dyker upp när Claude Code körts en
+        # första gång på maskinen.
+        log.warning("hittar inte %s — finns Claude Code på den här "
+                    "maskinen? Väntar på att katalogen dyker upp "
+                    "(Ctrl-C avbryter).", Handler.projects_dir)
+        try:
+            while not Handler.projects_dir.is_dir():
+                time.sleep(30)
+        except KeyboardInterrupt:
+            raise SystemExit(1)
+        log.info("%s finns nu — fortsätter starten.", Handler.projects_dir)
 
     t0 = time.monotonic()
     snap = get_snapshot(Handler.projects_dir)
-    print(f"förstaskanning {time.monotonic() - t0:.1f} s: "
-          f"{snap['dayTokens']:,} tokens idag, {snap['daySessions']} sessioner, "
-          f"{snap['monthTokens']:,} denna månad".replace(",", " "))
+    log.info("förstaskanning %.1f s: %s tokens idag, %d sessioner, "
+             "%s denna månad",
+             time.monotonic() - t0,
+             f"{snap['dayTokens']:,}".replace(",", " "),
+             snap["daySessions"],
+             f"{snap['monthTokens']:,}".replace(",", " "))
 
     status_service = AgentStatusService(
         projects_dir=Handler.projects_dir,
@@ -1602,9 +1717,9 @@ def main():
     srv = None
     try:
         srv = ThreadingHTTPServer(("0.0.0.0", args.port), Handler)
-        print(f"serverar http://0.0.0.0:{args.port}/api/tokens, "
-              f"/api/agent-status och /api/max-tracker "
-              f"(LAN — exponera inte utåt)")
+        log.info("serverar http://0.0.0.0:%d/api/tokens, "
+                 "/api/agent-status och /api/max-tracker "
+                 "(LAN — exponera inte utåt)", args.port)
         srv.serve_forever()
     except KeyboardInterrupt:
         pass
@@ -1614,7 +1729,8 @@ def main():
         try:
             max_tracker_store.save()  # slutlig flush, samma som stop()-flödet
         except Exception:
-            pass
+            log.exception("max-tracker: slutlig flush misslyckades — "
+                          "dagens toppar kan saknas efter omstart")
         status_service.stop()
         if srv is not None:
             srv.server_close()

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -1699,29 +1699,32 @@ class Handler(BaseHTTPRequestHandler):
         elif self.path == "/api/max-tracker":
             self._reply(self._max_tracker_payload)
         elif self.path == "/":
-            self._reply(lambda: {"service": "torget-tokenserver",
-                                 "rev": _SERVER_REV,
-                                 "srcFingerprint": _SERVER_SRC,
-                                 "startedAt": _SERVER_STARTED,
-                                 "endpoint": "/api/tokens",
-                                 "endpoints": ["/api/tokens",
-                                               "/api/agent-status",
-                                               "/api/max-tracker"],
-                                 "claudeProbe": _probe_status,
-                                 "ratelimitHeaders": _probe_headers,
-                                 "unknownRateLimitBuckets":
-                                     _probe_unknown_buckets,
-                                 # GET / parsas aldrig av skärmen — fältet
-                                 # kan läggas till utan kontraktsrisk.
-                                 "usageComputeOk":
-                                     _compute_failing_since is None,
-                                 "usageComputeFailingForS":
-                                     (int(time.monotonic() -
-                                          _compute_failing_since)
-                                      if _compute_failing_since is not None
-                                      else None)})
+            self._reply(self._root_payload)
         else:
             self._send(404, {"error": "not found"})
+
+    def _root_payload(self):
+        # EN läsning av failing_since — ok-flaggan och varaktigheten måste
+        # komma ur samma ögonblick. Två läsningar lät en återhämtning mitt
+        # emellan ge None i subtraktionen (500 på själva diagnostikrutten)
+        # och en nystartad episod ge ok=true med varaktighet bredvid.
+        failing_since = _compute_failing_since
+        return {"service": "torget-tokenserver",
+                "rev": _SERVER_REV,
+                "srcFingerprint": _SERVER_SRC,
+                "startedAt": _SERVER_STARTED,
+                "endpoint": "/api/tokens",
+                "endpoints": ["/api/tokens", "/api/agent-status",
+                              "/api/max-tracker"],
+                "claudeProbe": _probe_status,
+                "ratelimitHeaders": _probe_headers,
+                "unknownRateLimitBuckets": _probe_unknown_buckets,
+                # GET / parsas aldrig av skärmen — fält kan läggas till
+                # utan kontraktsrisk.
+                "usageComputeOk": failing_since is None,
+                "usageComputeFailingForS":
+                    (int(time.monotonic() - failing_since)
+                     if failing_since is not None else None)}
 
     def log_message(self, fmt, *args):
         pass  # 30 s-pollning ska inte fylla loggen

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -146,6 +146,15 @@ _file_cache = {}   # path -> stat, parsed offset, month and compact records
 _last_result = None
 _last_computed = 0.0
 _snapshot_refreshing = False
+# Omräkningens hälsa: kraschar _compute serveras förra snapshotet vidare —
+# rätt beteende, men det får inte ske TYST (då fryser siffrorna för alltid
+# och ser färska ut). failing_since driver usageComputeOk på GET / och
+# röktestets FAIL; loggen får övergången plus ett strypt fel.
+# None = aldrig loggat. Inte 0.0: time.monotonic() räknar från boot, så på
+# en nystartad maskin är "nu - 0.0" MINDRE än strypfönstret och första
+# felet skulle sväljas — CI:ns färska VM fällde exakt det.
+_compute_failing_since = None
+_last_compute_error_logged = None
 _history_lock = threading.Lock()
 _default_usage_history = None
 _quota_cache_lock = threading.Lock()
@@ -1241,8 +1250,10 @@ def _persist_quota_records_async(cache, records):
 _max_tracker_writer_lock = threading.Lock()
 _max_tracker_dirty = False
 _max_tracker_writer_running = False
-_SAVE_ERROR_LOG_INTERVAL_S = 300.0
-_last_save_error_logged = 0.0
+_ERROR_LOG_THROTTLE_S = 300.0  # ihållande fel: en loggrad per 5 min räcker
+_last_save_error_logged = None  # None = aldrig loggat (0.0 sväljer första
+                                # felet på en nystartad maskin — monotonic
+                                # räknar från boot)
 
 
 def _max_tracker_writer(store):
@@ -1262,7 +1273,8 @@ def _max_tracker_writer(store):
             # försöker igen — ingen het loop, ingen tyst dataförlust.
             # Loggen är strypt: ett trasigt skrivmål ska inte fylla filen.
             now = time.monotonic()
-            if now - _last_save_error_logged >= _SAVE_ERROR_LOG_INTERVAL_S:
+            if (_last_save_error_logged is None or
+                    now - _last_save_error_logged >= _ERROR_LOG_THROTTLE_S):
                 _last_save_error_logged = now
                 log.exception(
                     "max-tracker: save misslyckades — observationerna står "
@@ -1355,11 +1367,25 @@ def _add_forecast(result, prefix, forecast):
 
 
 def _refresh_usage_totals(projects_dir, max_tracker_store=None):
-    global _last_result, _last_computed, _snapshot_refreshing
+    global _last_result, _last_computed, _snapshot_refreshing, \
+        _compute_failing_since, _last_compute_error_logged
     try:
         refreshed = _compute(projects_dir, max_tracker_store)
     except Exception:
         refreshed = None
+        now = time.monotonic()
+        if _compute_failing_since is None:
+            _compute_failing_since = now
+        if (_last_compute_error_logged is None or
+                now - _last_compute_error_logged >= _ERROR_LOG_THROTTLE_S):
+            _last_compute_error_logged = now
+            log.exception("usage-omräkningen kraschade — /api/tokens "
+                          "serverar frysta siffror tills den lyckas igen")
+    else:
+        if _compute_failing_since is not None:
+            log.info("usage-omräkningen frisk igen efter %.0f s",
+                     time.monotonic() - _compute_failing_since)
+            _compute_failing_since = None
     with _cache_lock:
         if refreshed is not None:
             _last_result = refreshed
@@ -1601,7 +1627,16 @@ class Handler(BaseHTTPRequestHandler):
                                  "claudeProbe": _probe_status,
                                  "ratelimitHeaders": _probe_headers,
                                  "unknownRateLimitBuckets":
-                                     _probe_unknown_buckets})
+                                     _probe_unknown_buckets,
+                                 # GET / parsas aldrig av skärmen — fältet
+                                 # kan läggas till utan kontraktsrisk.
+                                 "usageComputeOk":
+                                     _compute_failing_since is None,
+                                 "usageComputeFailingForS":
+                                     (int(time.monotonic() -
+                                          _compute_failing_since)
+                                      if _compute_failing_since is not None
+                                      else None)})
         else:
             self._send(404, {"error": "not found"})
 


### PR DESCRIPTION
Follow-up to the launch-post advice: *locate every odd log the system generates and comb through them periodically.* Two commits — first the map and the plan, then the always-on logging half of that plan.

## The documentation set

- **`docs/observability.md`** — the log map: all six evidence sources (device serial, tokenserver stderr/launchd file, `GET /` diagnostics, state files, the screen itself, CI), a table of verbatim known-bad signatures, and the periodic **comb routine** an agent runs on request ("comb the logs").
- **`docs/observability-backlog.md`** — 28 audit findings as stable-ID backlog items in three tiers, each with file:line evidence and a fix sketch. Six are already `done` by this PR (OBS-01, 04, 05, 06, 07, 10).
- **`docs/lessons.md`** — twelve root-caused stories mined from the history (the expired token that outranked a fresh login, the 429 night, NUL-truncation, inverted defaults, USB power…), each with its rule and guards. `CLAUDE.md`/`AGENTS.md` route log/error work at these docs.

## The fixes

- **Firmware boot banner (OBS-01):** `app_main`'s first line logs build timestamp, IDF version, and the decoded reset reason — `PANIK`/`TASKVAKTHUND`/`BROWNOUT` spelled loudly. Takes effect on next flash.
- **Real logger for the tokenserver (OBS-04):** timestamped `logging` on stderr; probe status changes log as `claude-probe: X -> Y` transitions — one line per change, silence in steady state.
- **Un-silenced HTTP layer (OBS-05):** `log_error` works again (the access-log mute had silenced it too), all four routes share one guarded `_reply`, `/api/agent-status` keeps the `{"error": …}` contract instead of leaking tracebacks over LAN, every 500 logs its cause locally, client disconnects stay quiet.
- **Launchd log hygiene (OBS-06/07):** log moves to `~/Library/Logs/torget-tokenserver.log` (survives reboot, visible in Console.app), self-rotated at 5 MB with the tail kept in `.old`; a missing `~/.claude/projects` waits with one warning instead of crash-looping every 10 s; `ThrottleInterval 30` as backstop.
- **No silent data loss on failed saves (OBS-10):** a failed max-tracker save re-marks dirty and retries on the next observation, with a throttled log line.
- **New smoke test:** `python3 tools/tokenserver/smoke.py` — comb steps 1–4 as one command (server identity vs checkout rev, probe status, all three API contracts, log pathologies, state-file corruption). Exit 0/1/2.

## Testing

- 342 tokenserver tests pass (29 new: rotation, transitions, writer retry, route guard, smoke suite — `test_smoke` added to CI and `test/run.sh`).
- Verified end to end against a live server: timestamped boot lines, one probe-transition line, smoke test green against it.
- The firmware change compiles against stock `esp_system` APIs but could not be built in the sandbox — the firmware CI lane on this PR is its verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqtUn8uTm2CutFudxb3BWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqtUn8uTm2CutFudxb3BWr)_