### PR TITLE
Rebase claude/new-session-zpl7cf onto main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,27 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   same non-blocking gate, different syscall — so the 429 guard survives the
   port instead of quietly disappearing with it.
 
-  This is the token half of
-  [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3) only — log
-  paths, state paths and the launchd setup are still macOS-shaped, and the
-  Codex half reads its app-server through `select.select` on a pipe, which
-  Windows does not support. Reported by Erik Elfström, who found it porting
-  a fork to a LilyGO T-Display-S3.
+  The Codex half works there too. Its quota read spawns `codex app-server`
+  and polled stdout with `select.select`, which on Windows accepts sockets
+  and never pipes; it now reads through a queue fed by a daemon thread, the
+  same code on every platform. That path had no test at all — every existing
+  test mocked the reader out and exercised only the parser — so it now has
+  three, driving a real subprocess through the real pipe for the reply,
+  timeout and immediate-death cases. Writing them turned up a leak worth
+  fixing on its own: the pipes were never closed, leaving three descriptors
+  per poll to the garbage collector in a service that polls every 30 s and
+  never restarts.
+
+  State and logs moved off the hardcoded `~/Library` paths to a per-platform
+  directory — `%LOCALAPPDATA%\VibePulse\` on Windows, unchanged on macOS.
+  The old paths worked literally on Windows but planted a `Library` tree in
+  the user profile that nothing else on the machine recognises.
+
+  What remains for [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3)
+  is autostart: the launchd plist has no Windows equivalent, and `smoke.py`
+  now finds the right state directory but still tells you to run `launchctl`.
+  Reported by Erik Elfström, who found it porting a fork to a LilyGO
+  T-Display-S3.
 - The completion alert finally pulses. The accent outline and icon ring
   breathe (full → 39 % → full, ease-in-out, four 1200 ms cycles filling the
   PULSE phase exactly) and then rest; text and the provider icon stay solid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- The tokenserver reads Claude's OAuth token on Windows. Claude Code has no
+  keychain integration there, so `claude login` writes the same
+  `{"claudeAiOauth": {...}}` record the macOS keychain holds to a plain file,
+  `%USERPROFILE%\.claude\.credentials.json`; the probe now reads it when
+  running on Windows and skips the two macOS-only sources (`security`,
+  `pgrep` for Claude Desktop's injected token) that cannot exist there. macOS
+  behaviour is untouched.
+
+  Two things had to give way for that read to be reachable at all: `fcntl`
+  is not importable on Windows, so the module could not even load, and the
+  machine-wide single-probe lock was built on `flock`. The import is now
+  guarded and the lock takes `msvcrt.locking` where `flock` is missing —
+  same non-blocking gate, different syscall — so the 429 guard survives the
+  port instead of quietly disappearing with it.
+
+  This is the token half of
+  [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3) only — log
+  paths, state paths and the launchd setup are still macOS-shaped, and the
+  Codex half reads its app-server through `select.select` on a pipe, which
+  Windows does not support. Reported by Erik Elfström, who found it porting
+  a fork to a LilyGO T-Display-S3.
 - The completion alert finally pulses. The accent outline and icon ring
   breathe (full → 39 % → full, ease-in-out, four 1200 ms cycles filling the
   PULSE phase exactly) and then rest; text and the provider icon stay solid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+### Fixed
+
+- The panel names all three GPT-5.6 variants. `gpt-5.6-sol` had a typeset
+  screen label while its siblings `terra` and `luna` fell through to their
+  raw lowercase ids — the price table knew all three, the screen knew one,
+  so the agent tile read `gpt-5.6-terra` next to a properly set `OPUS 5`. A
+  test now also holds every label inside `TK_AGENT_MODEL_CAP`, reading the
+  cap from the firmware header rather than restating it. Spotted on Erik
+  Elfström's T-Display-S3 fork. The wider fallthrough — ~110 priced models,
+  six named ones, and dated ids that truncate mid-string — is written up as
+  OBS-30 rather than fixed here.
+
 ### Added
 
 - The tokenserver reads Claude's OAuth token on Windows. Claude Code has no

--- a/README.md
+++ b/README.md
@@ -442,14 +442,17 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
 
 ## FAQ
 
-- **Windows or Linux for the Mac service?** Not yet — the log paths, lock
-  paths and launchd setup are macOS-specific. One piece is portable: Claude
-  Code has no keychain on Windows, so `claude login` writes the same
+- **Windows for the Mac service?** The data half works. Claude Code has no
+  keychain there, so `claude login` writes the same
   `{"claudeAiOauth": {...}}` record to
-  `%USERPROFILE%\.claude\.credentials.json`, and the service reads it there
-  instead. Tracked in
-  [#3 (Windows)](https://github.com/niclasvestlund-YT/vibepulse/issues/3)
-  and [#2 (Linux)](https://github.com/niclasvestlund-YT/vibepulse/issues/2);
+  `%USERPROFILE%\.claude\.credentials.json` and the service reads it; the
+  Codex app-server read and the single-probe lock no longer depend on
+  macOS-only syscalls; state and logs live under `%LOCALAPPDATA%\VibePulse\`.
+  What is missing is **autostart** — the launchd plist has no Windows
+  equivalent, so you start it by hand or wire up Task Scheduler yourself.
+  [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3).
+- **Linux for the Mac service?** Not yet —
+  [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2);
   contributions very welcome.
 - **Other boards or panel sizes?** Not yet. The platform is pinned to this
   exact panel so one pixel-perfect build stays pixel-perfect, but a port is

--- a/README.md
+++ b/README.md
@@ -442,8 +442,12 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
 
 ## FAQ
 
-- **Windows or Linux for the Mac service?** Not yet — the log paths and
-  keychain reads are macOS-specific. Tracked in
+- **Windows or Linux for the Mac service?** Not yet — the log paths, lock
+  paths and launchd setup are macOS-specific. One piece is portable: Claude
+  Code has no keychain on Windows, so `claude login` writes the same
+  `{"claudeAiOauth": {...}}` record to
+  `%USERPROFILE%\.claude\.credentials.json`, and the service reads it there
+  instead. Tracked in
   [#3 (Windows)](https://github.com/niclasvestlund-YT/vibepulse/issues/3)
   and [#2 (Linux)](https://github.com/niclasvestlund-YT/vibepulse/issues/2);
   contributions very welcome.

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -36,13 +36,16 @@ are required, and the build gates on their absence:
 Confirm all five before touching anything. Ask the user for anything you
 cannot determine yourself.
 
-1. **macOS?** The tokenserver reads macOS log paths, lock paths and the
-   keychain. On Linux/Windows the firmware still builds and the simulator
-   still runs, but the data service will not work — see issues
-   [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2) /
-   [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3). Only the
-   Claude token read is portable: on Windows the service reads
-   `%USERPROFILE%\.claude\.credentials.json` instead of the keychain.
+1. **macOS or Windows?** Both serve data. On Windows the Claude token comes
+   from `%USERPROFILE%\.claude\.credentials.json` instead of the keychain,
+   and state and logs live under `%LOCALAPPDATA%\VibePulse\` — but there is
+   **no autostart**, so the service must be started by hand or wired into
+   Task Scheduler, and `smoke.py`'s advice still names `launchctl`
+   ([#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3)). On Linux
+   the firmware still builds and the simulator still runs, but the service
+   finds no Claude token at all — there is no keychain and the credential
+   file is read only on Windows
+   ([#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2)).
 2. **Do they have the board?** Waveshare ESP32-S3-Touch-AMOLED-2.16. No
    board → skip to [Simulator only](#simulator-only-no-board).
 3. **Is their WiFi 2.4 GHz?** The ESP32-S3 cannot see 5 GHz at all. This is

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -36,11 +36,13 @@ are required, and the build gates on their absence:
 Confirm all five before touching anything. Ask the user for anything you
 cannot determine yourself.
 
-1. **macOS?** The tokenserver reads macOS log paths and the keychain. On
-   Linux/Windows the firmware still builds and the simulator still runs, but
-   the data service will not work — see issues
+1. **macOS?** The tokenserver reads macOS log paths, lock paths and the
+   keychain. On Linux/Windows the firmware still builds and the simulator
+   still runs, but the data service will not work — see issues
    [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2) /
-   [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3).
+   [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3). Only the
+   Claude token read is portable: on Windows the service reads
+   `%USERPROFILE%\.claude\.credentials.json` instead of the keychain.
 2. **Do they have the board?** Waveshare ESP32-S3-Touch-AMOLED-2.16. No
    board → skip to [Simulator only](#simulator-only-no-board).
 3. **Is their WiFi 2.4 GHz?** The ESP32-S3 cannot see 5 GHz at all. This is
@@ -147,7 +149,7 @@ are not arriving:
 | `not_run` | Probe has not fired yet | It runs every 120 s — wait |
 | `no_claude_oauth_token` | No Claude Desktop / Claude Code token found | Have them sign in to Claude Code on this Mac |
 | `token_expired_…` | Token found but expired | Re-authenticate in Claude Code |
-| `usage_http_401` / `usage_http_403` | Every token source rejected (the probe tries Claude Desktop's process token, then the keychain, and falls back automatically) | Re-authenticate in Claude Code |
+| `usage_http_401` / `usage_http_403` | Every token source rejected (on macOS the probe tries Claude Desktop's process token, then the keychain, and falls back automatically; on Windows there is only `%USERPROFILE%\.claude\.credentials.json`) | Re-authenticate in Claude Code |
 | `usage_http_200 + no_mapped_limits` | Authenticated, but nothing in the usage response mapped (a `; fallback_…` suffix records the header-probe outcome) | Plan may not expose limits; Codex half still works |
 | `usage_request_failed: …` | Network/DNS failure from the Mac | Check the Mac's own connectivity |
 | `usage_http_429 + backoff_until_HH:MM` | Rate-limited by the API; the probe rests until the shown time | Wait — it retries by itself |

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -400,6 +400,22 @@ load. Platform-dependent test assumptions are an established theme
 **Fix:** drive the eviction deterministically in the test (injected clock
 or forced verify schedule) instead of relying on wall-clock behavior.
 
+### OBS-30 · Unmapped models reach the panel as raw ids
+`server · S · open`
+`MODEL_LABELS` (`agent_status.py:56`) names six models; `prices.json`
+prices roughly a hundred and ten. `normalize_model` falls through to the
+raw lowercase id for the rest, so the panel mixes typeset labels
+(`OPUS 5`) with bare ids (`claude-opus-4-8`) depending on which model the
+agent happens to pick. Worse, `_bounded_display` clips at 24 bytes to
+match `TK_AGENT_MODEL_CAP`, so a dated id truncates mid-string:
+`claude-haiku-4-5-20251001` renders as `claude-haiku-4-5-2025100`. Found
+via a fork on a T-Display-S3 showing `gpt-5.6-terra` next to its
+typeset siblings; the three `gpt-5.6-*` variants are now mapped, the
+underlying fallthrough is not.
+**Fix:** derive the label from the id (family + version, uppercased,
+dated suffix dropped) and keep the map for exceptions only — then a new
+model is styled on arrival instead of on the next hand edit.
+
 ### OBS-28 · Pin logging config on purpose
 `firmware · S · open`
 `sdkconfig.defaults` deliberately pins flash, PSRAM, LVGL, and mbedTLS

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -246,12 +246,22 @@ Probelåset — maskinvida enprobe-garantin som håller 429-straffrutan borta �
 finns kvar på Windows: `fcntl` saknas där, så låset tas med
 `msvcrt.locking` i stället. Samma icke-blockerande grind, annat systemanrop.
 
-Resten av tjänsten är fortfarande macOS-formad — loggsökvägar,
-tillståndsfiler och launchd-uppsättningen — och Codex-halvan läser sin
-app-server med `select.select` på en pipe, vilket Windows inte stöder. Detta
-löser alltså Claude-tokendelen av
-[#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3), inte hela
-Windows-stödet.
+Codex-halvan fungerar också. Kvotläsningen startar `codex app-server` och
+läser dess stdout; det gjordes förut med `select.select`, som på Windows
+bara tar sockets — aldrig pipes. Läsningen sker nu i en läsartråd med kö,
+samma kod på alla plattformar.
+
+Tillståndsfilerna (lås, probestatus, kvotcache, historik, max-spårare) och
+loggen bor under `%LOCALAPPDATA%\VibePulse\` i stället för macOS
+`~/Library/Application Support/VibePulse`. Sökvägarna fungerade bokstavligt
+även förut — `Path.home()` löser ut — men lade ett `Library`-träd i
+användarprofilen som ingenting annat på maskinen känner igen.
+
+Kvar på Windows: **autostart**. launchd-plisten härintill har ingen
+motsvarighet; tjänsten måste startas för hand eller läggas i Task
+Scheduler. `smoke.py` känner till tillståndskatalogen men dess råd pratar
+fortfarande om `launchctl`. Se
+[#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3).
 
 Svar (kontraktet appen parsar, `components/app_tokens/tokens_parse.c`;
 null = ärlig frånvaro, skärmen visar streck):

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -22,8 +22,9 @@ sekund. Ren Python 3-stdlib — inget att installera. Tre källor:
 1. **Volymen** — `~/.claude/projects/**/*.jsonl` skannas inkrementellt:
    dagens/månadens tokens, brinntakt, sessioner.
 2. **Claudes tak** (Clawdmeter-mönstret) — tjänsten läser Claude Desktops
-   aktiva, injicerade OAuth-token eller Claude Codes nyckelringsfallback och
-   gör en minimal API-förfrågan
+   aktiva, injicerade OAuth-token eller Claude Codes nyckelringsfallback
+   (på Windows i stället `%USERPROFILE%\.claude\.credentials.json`, samma
+   post — se [Windows](#windows) nedan) och gör en minimal API-förfrågan
    (`max_tokens: 0` — prefill utan output, i praktiken gratis) var 120:e
    sekund; rate-limit-headrarna i svaret bär usage-panelens tre fönster:
    5-timmars, veckan och veckan för tyngsta modellen (Fable/Opus).
@@ -230,6 +231,27 @@ fristående Claude Code kan första körningen fråga macOS om nyckelringsåtkom
 så tjänsten kan probea utan att fråga om. Startloggen skriver dessutom ut de exakta
 `anthropic-ratelimit-*`-headrarna vid första proben — facit om mappningen
 någonsin behöver justeras.
+
+### Windows
+
+Claude Code har ingen nyckelringsintegration på Windows: `claude login`
+skriver i stället exakt samma `{"claudeAiOauth": {...}}`-post till en vanlig
+fil, `%USERPROFILE%\.claude\.credentials.json`. Kör tjänsten på Windows och
+den läser den filen — ingen dialog, ingen konfiguration, samma
+förtroendegräns som nyckelringsläsningen på Macen. Nyckelringen och Claude
+Desktops processtoken frågas inte alls där; `security` och `pgrep` finns
+ändå inte.
+
+Probelåset — maskinvida enprobe-garantin som håller 429-straffrutan borta —
+finns kvar på Windows: `fcntl` saknas där, så låset tas med
+`msvcrt.locking` i stället. Samma icke-blockerande grind, annat systemanrop.
+
+Resten av tjänsten är fortfarande macOS-formad — loggsökvägar,
+tillståndsfiler och launchd-uppsättningen — och Codex-halvan läser sin
+app-server med `select.select` på en pipe, vilket Windows inte stöder. Detta
+löser alltså Claude-tokendelen av
+[#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3), inte hela
+Windows-stödet.
 
 Svar (kontraktet appen parsar, `components/app_tokens/tokens_parse.c`;
 null = ärlig frånvaro, skärmen visar streck):

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -53,11 +53,18 @@ ACTIVITIES = {
     "waiting_approval",
 }
 
+# Skärmetiketter för de modeller agenterna faktiskt rapporterar. Okända
+# id:n faller igenom som råa gemener (se normalize_model) — dvs. sol får
+# "GPT-5.6 SOL" medan dess syskon terra/luna skulle visas som "gpt-5.6-terra".
+# Prislistan känner alla tre; skärmen ska göra det också. (OBS-30 spårar att
+# fallet igenom fortfarande gäller resten av prices.json.)
 MODEL_LABELS = {
     "claude-fable-5": "FABLE 5",
     "claude-opus-5": "OPUS 5",
     "claude-sonnet-5": "SONNET 5",
+    "gpt-5.6-luna": "GPT-5.6 LUNA",
     "gpt-5.6-sol": "GPT-5.6 SOL",
+    "gpt-5.6-terra": "GPT-5.6 TERRA",
 }
 
 

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -23,14 +23,16 @@ import urllib.request
 from pathlib import Path
 
 if __package__:
-    from .tokenserver import (DEFAULT_LOG_PATH, _LOG_CAP_BYTES,
+    from .tokenserver import (DEFAULT_LOG_PATH, _LOG_CAP_BYTES, _state_dir,
                               _read_source_fingerprint)
 else:  # direktkörning: python3 tools/tokenserver/smoke.py
-    from tokenserver import (DEFAULT_LOG_PATH, _LOG_CAP_BYTES,
+    from tokenserver import (DEFAULT_LOG_PATH, _LOG_CAP_BYTES, _state_dir,
                              _read_source_fingerprint)
 
 DEFAULT_BASE_URL = "http://localhost:8737"
-STATE_DIR = Path.home() / "Library" / "Application Support" / "VibePulse"
+# Samma katalog tjänsten faktiskt skriver till, inte en andra gissning på
+# den: röktestet ska inte kunna leta i fel träd på en Windows-maskin.
+STATE_DIR = _state_dir()
 STATE_FILES = ("usage-history.json", "quota-cache.json", "max-tracker.json")
 # Versionsskev-snubbeltråd, inte en andra parser: skärmens parsrar är
 # kontraktsstränga och avvisar HELA svaret vid fel version, saknade

--- a/tools/tokenserver/test_agent_status.py
+++ b/tools/tokenserver/test_agent_status.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import re
 import tempfile
 import threading
 import unittest
@@ -254,6 +255,27 @@ class ClassificationTests(unittest.TestCase):
             effort="XHIGH",
         ))
         self.assertNotIn("nested-private-model", repr(event))
+
+    def test_every_gpt_5_6_variant_gets_a_screen_label(self):
+        """En fork på en T-Display-S3 visade `gpt-5.6-terra` rått bredvid
+        systrarnas typsatta etiketter: prislistan kände modellen, skärmen
+        inte. Alla tre 5.6-varianterna ska se likadana ut."""
+        self.assertEqual(agent_status.normalize_model("gpt-5.6-sol"),
+                         "GPT-5.6 SOL")
+        self.assertEqual(agent_status.normalize_model("gpt-5.6-terra"),
+                         "GPT-5.6 TERRA")
+        self.assertEqual(agent_status.normalize_model("gpt-5.6-luna"),
+                         "GPT-5.6 LUNA")
+
+    def test_screen_labels_fit_the_firmware_model_buffer(self):
+        """TK_AGENT_MODEL_CAP är 25 (24 tecken + NUL). En etikett som
+        spränger den klipps mitt i ordet på panelen."""
+        header = Path(__file__).resolve().parents[2] / (
+            "components/app_tokens/agent_status.h")
+        cap = int(re.search(r"#define TK_AGENT_MODEL_CAP (\d+)",
+                            header.read_text(encoding="utf-8")).group(1))
+        for label in agent_status.MODEL_LABELS.values():
+            self.assertLessEqual(len(label.encode("utf-8")), cap - 1, label)
 
     def test_metadata_is_control_free_and_bounded_by_utf8_bytes(self):
         entry = claude_event("assistant", tool_name="Read")

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -389,6 +389,37 @@ class ClaudeLimitHeaderTests(unittest.TestCase):
         self.assertEqual(found["sessionPct"], 12.0)
         self.assertEqual(found["weekPct"], 47.0)
 
+    def test_state_dir_is_local_app_data_on_windows(self):
+        with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                mock.patch.dict(tokenserver.os.environ,
+                                {"LOCALAPPDATA": r"C:\Users\erik\AppData\Local"}):
+            self.assertEqual(
+                tokenserver._state_dir(),
+                Path(r"C:\Users\erik\AppData\Local") / "VibePulse")
+
+    def test_state_dir_falls_back_when_localappdata_is_unset(self):
+        """En tjänst som startas utan användarmiljö (Task Scheduler under
+        SYSTEM) saknar LOCALAPPDATA — sökvägen ska ändå bli den rätta."""
+        env = dict(tokenserver.os.environ)
+        env.pop("LOCALAPPDATA", None)
+        with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                mock.patch.dict(tokenserver.os.environ, env, clear=True), \
+                mock.patch.object(tokenserver.Path, "home",
+                                  return_value=Path("/home/tester")):
+            self.assertEqual(
+                tokenserver._state_dir(),
+                Path("/home/tester/AppData/Local/VibePulse"))
+
+    def test_state_dir_is_unchanged_on_macos(self):
+        with mock.patch.object(tokenserver, "_IS_WINDOWS", False), \
+                mock.patch.object(tokenserver.Path, "home",
+                                  return_value=Path("/Users/niclas")):
+            self.assertEqual(
+                tokenserver._state_dir(),
+                Path("/Users/niclas/Library/Application Support/VibePulse"))
+            self.assertEqual(
+                tokenserver._log_dir(), Path("/Users/niclas/Library/Logs"))
+
     def test_credentials_file_path_sits_under_home(self):
         with mock.patch.object(tokenserver.Path, "home",
                                return_value=Path("/home/tester")):
@@ -908,6 +939,90 @@ class CodexLimitLogTests(unittest.TestCase):
         self.assertEqual(pct, 57.0)
         self.assertEqual(reset_min, 60)
         self.assertEqual(window_min, 10080)
+
+    def _fake_app_server(self, temp_dir, body):
+        """Ett körbart som talar app-server-protokollet på stdin/stdout.
+
+        Läsvägen mockades bort i varje befintligt test — bara parsern var
+        täckt — så select-bytet hade kunnat gå sönder tyst. Det här kör den
+        på riktigt: process, pipe, tråd, kö.
+        """
+        script = Path(temp_dir) / "codex"
+        script.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            "for line in sys.stdin:\n"
+            "    try:\n"
+            "        msg = json.loads(line)\n"
+            "    except ValueError:\n"
+            "        continue\n"
+            "    got = msg.get('id')\n"
+            "    if got == 1:\n"
+            "        print(json.dumps({'id': 1, 'result': {}}), flush=True)\n"
+            "    elif got == 2:\n"
+            f"        print(json.dumps({body!r}), flush=True)\n",
+            encoding="utf-8")
+        script.chmod(0o755)
+        return str(script)
+
+    def test_app_server_read_talks_to_a_real_process(self):
+        response = {"id": 2, "result": {"rateLimits": {
+            "limitId": "codex",
+            "limitName": None,
+            "primary": {"usedPercent": 62, "windowDurationMins": 10080,
+                        "resetsAt": 1_900_000_000},
+        }}}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            executable = self._fake_app_server(temp_dir, response)
+            with mock.patch.object(tokenserver, "_codex_app_server_command",
+                                   return_value=executable):
+                found = tokenserver._read_codex_app_server_limits(
+                    timeout_s=20)
+
+        self.assertEqual(found["codexWeekPct"], 62.0)
+        self.assertEqual(found["codexWeekResetAt"], 1_900_000_000)
+
+    def test_app_server_read_gives_up_when_the_process_says_nothing(self):
+        """Deadlinen måste hålla utan select: en app-server som svarar
+        aldrig får inte hänga probecykeln."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script = Path(temp_dir) / "codex"
+            script.write_text(
+                "#!/usr/bin/env python3\n"
+                "import time\n"
+                "time.sleep(30)\n", encoding="utf-8")
+            script.chmod(0o755)
+
+            with mock.patch.object(tokenserver, "_codex_app_server_command",
+                                   return_value=str(script)):
+                started = time.monotonic()
+                found = tokenserver._read_codex_app_server_limits(
+                    timeout_s=1)
+                elapsed = time.monotonic() - started
+
+        self.assertEqual(found, {})
+        self.assertLess(elapsed, 10)
+
+    def test_app_server_read_returns_when_the_process_dies_at_once(self):
+        """EOF-vakten: strömmen stängs direkt, och läsaren ska returnera på
+        en gång i stället för att vänta ut hela sin deadline."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script = Path(temp_dir) / "codex"
+            script.write_text(
+                "#!/usr/bin/env python3\n"
+                "raise SystemExit(1)\n", encoding="utf-8")
+            script.chmod(0o755)
+
+            with mock.patch.object(tokenserver, "_codex_app_server_command",
+                                   return_value=str(script)):
+                started = time.monotonic()
+                found = tokenserver._read_codex_app_server_limits(
+                    timeout_s=20)
+                elapsed = time.monotonic() - started
+
+        self.assertEqual(found, {})
+        self.assertLess(elapsed, 10)
 
     def test_app_server_rate_limit_maps_remaining_38_to_used_62(self):
         response = {

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -252,6 +252,150 @@ class ClaudeLimitHeaderTests(unittest.TestCase):
         self.assertEqual(
             candidates, [("standalone-token", 1_900_000_000_000)])
 
+    def test_windows_reads_the_credentials_file_claude_login_writes(self):
+        """Windows har ingen nyckelring — `claude login` skriver samma
+        claudeAiOauth-post till %USERPROFILE%\\.claude\\.credentials.json."""
+        credentials = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "windows-file-token",
+                "expiresAt": 1_900_000_000_000,
+                "refreshToken": "not-ours-to-touch",
+            },
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".claude" / ".credentials.json"
+            path.parent.mkdir(parents=True)
+            path.write_text(credentials, encoding="utf-8")
+
+            with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                    mock.patch.object(tokenserver.Path, "home",
+                                      return_value=Path(temp_dir)), \
+                    mock.patch.object(tokenserver.subprocess, "run",
+                                      side_effect=AssertionError(
+                                          "no subprocess on Windows")):
+                candidates = tokenserver._read_oauth_candidates()
+
+        # Filen är enda källan: ingen pgrep, inget `security`, ingen
+        # utgången processtoken att sortera bort.
+        self.assertEqual(
+            candidates, [("windows-file-token", 1_900_000_000_000)])
+
+    def test_windows_without_a_credentials_file_has_no_candidates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                    mock.patch.object(tokenserver.Path, "home",
+                                      return_value=Path(temp_dir)):
+                self.assertEqual(tokenserver._read_oauth_candidates(), [])
+
+    def test_windows_credentials_file_that_is_garbage_is_not_a_candidate(self):
+        """Halvskriven fil under `claude login` ska ge tystnad, inte krasch."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".claude" / ".credentials.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"claudeAiOauth": {"accessTok',
+                            encoding="utf-8")
+
+            with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                    mock.patch.object(tokenserver.Path, "home",
+                                      return_value=Path(temp_dir)):
+                self.assertEqual(tokenserver._read_oauth_candidates(), [])
+
+    def test_macos_ignores_a_credentials_file(self):
+        """Macen läser nyckelringen. En kvarglömd .credentials.json på samma
+        maskin får inte smyga in en tredje kandidat."""
+        keychain = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "keychain-token",
+                "expiresAt": 1_900_000_000_000,
+            },
+        })
+
+        def run(command, **_kwargs):
+            if command[0] == "pgrep":
+                return mock.Mock(stdout="")
+            if command[0] == "security":
+                return mock.Mock(stdout=keychain)
+            raise AssertionError(command)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".claude" / ".credentials.json"
+            path.parent.mkdir(parents=True)
+            path.write_text(json.dumps({
+                "claudeAiOauth": {"accessToken": "stale-file-token"},
+            }), encoding="utf-8")
+
+            with mock.patch.object(tokenserver, "_IS_WINDOWS", False), \
+                    mock.patch.object(tokenserver.Path, "home",
+                                      return_value=Path(temp_dir)), \
+                    mock.patch.object(tokenserver.subprocess, "run",
+                                      side_effect=run):
+                candidates = tokenserver._read_oauth_candidates()
+
+        self.assertEqual(
+            candidates, [("keychain-token", 1_900_000_000_000)])
+
+    def test_windows_probe_reaches_the_api_with_the_file_token(self):
+        """Hela Windows-kedjan i ett svep: fil → kandidat → lås → API-svar.
+        Enhetstesten ovan kan alla passera medan kedjan ändå är bruten."""
+        calls = []
+
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.get_header("Authorization"))
+            return _FakeUsageResponse({"limits": [
+                {"kind": "session", "percent": 12,
+                 "resets_at": "2100-01-01T00:00:00+00:00"},
+                {"kind": "weekly_all", "percent": 47,
+                 "resets_at": "2100-01-02T00:00:00+00:00"},
+            ]})
+
+        class FakeMsvcrt:
+            LK_NBLCK = 1
+
+            @staticmethod
+            def locking(fd, mode, nbytes):
+                pass
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            credentials = home / ".claude" / ".credentials.json"
+            credentials.parent.mkdir(parents=True)
+            credentials.write_text(json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "windows-file-token",
+                    "expiresAt": 1_900_000_000_000,
+                },
+            }), encoding="utf-8")
+
+            with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                    mock.patch.object(tokenserver, "fcntl", None), \
+                    mock.patch.object(tokenserver, "msvcrt", FakeMsvcrt), \
+                    mock.patch.object(tokenserver, "_PROBE_LOCK_PATH",
+                                      home / "claude-probe.lock"), \
+                    mock.patch.object(tokenserver, "_probe_cooldown_until",
+                                      0.0), \
+                    mock.patch.object(tokenserver, "_dead_tokens", {}), \
+                    mock.patch.object(tokenserver.Path, "home",
+                                      return_value=home), \
+                    mock.patch.object(tokenserver.subprocess, "run",
+                                      side_effect=AssertionError(
+                                          "no subprocess on Windows")), \
+                    mock.patch.object(tokenserver.urllib.request, "urlopen",
+                                      side_effect=fake_urlopen):
+                found = tokenserver._probe_limits()
+
+        self.assertEqual(tokenserver._probe_status, "usage_http_200 + ok")
+        self.assertEqual(calls, ["Bearer windows-file-token"])
+        self.assertEqual(found["sessionPct"], 12.0)
+        self.assertEqual(found["weekPct"], 47.0)
+
+    def test_credentials_file_path_sits_under_home(self):
+        with mock.patch.object(tokenserver.Path, "home",
+                               return_value=Path("/home/tester")):
+            self.assertEqual(
+                tokenserver._credentials_file_path(),
+                Path("/home/tester/.claude/.credentials.json"))
+
     def test_probe_falls_back_to_keychain_when_process_token_rejected(self):
         calls = []
 
@@ -335,6 +479,47 @@ class ClaudeLimitHeaderTests(unittest.TestCase):
         self.assertIsNone(found)
         self.assertEqual(tokenserver._probe_status,
                          "probe_held_by_other_instance")
+
+    def test_probe_lock_uses_msvcrt_when_there_is_no_fcntl(self):
+        """Windows saknar fcntl. Enprobe-grinden får inte tyst försvinna där
+        — den tas med msvcrt.locking i stället, samma icke-blockerande
+        semantik."""
+        calls = []
+
+        class FakeMsvcrt:
+            LK_NBLCK = 1
+
+            @staticmethod
+            def locking(fd, mode, nbytes):
+                calls.append((mode, nbytes))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "claude-probe.lock"
+            with mock.patch.object(tokenserver, "_PROBE_LOCK_PATH", path), \
+                    mock.patch.object(tokenserver, "fcntl", None), \
+                    mock.patch.object(tokenserver, "msvcrt", FakeMsvcrt):
+                handle = tokenserver._hold_probe_lock()
+
+            self.assertIsNotNone(handle)
+            handle.close()
+            self.assertEqual(calls, [(FakeMsvcrt.LK_NBLCK, 1)])
+            # Låset måste ha en byte att sätta tänderna i.
+            self.assertEqual(path.read_text(encoding="utf-8"), "1")
+
+    def test_probe_lock_yields_when_msvcrt_reports_a_held_range(self):
+        class FakeMsvcrt:
+            LK_NBLCK = 1
+
+            @staticmethod
+            def locking(fd, mode, nbytes):
+                raise OSError(13, "Permission denied")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "claude-probe.lock"
+            with mock.patch.object(tokenserver, "_PROBE_LOCK_PATH", path), \
+                    mock.patch.object(tokenserver, "fcntl", None), \
+                    mock.patch.object(tokenserver, "msvcrt", FakeMsvcrt):
+                self.assertIsNone(tokenserver._hold_probe_lock())
 
     def test_probe_retries_a_refreshed_token_value(self):
         """Dödmarkeringen sitter på VÄRDET: när källan levererar en ny

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -32,7 +32,6 @@ Autostart: se README.md härintill (launchd-plist medföljer).
 """
 
 import argparse
-import fcntl
 import hashlib
 import json
 import logging
@@ -51,6 +50,18 @@ import weakref
 from datetime import datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+
+# Probelåset tas med olika systemanrop på olika plattformar; ingen av
+# modulerna finns på båda. Importen får inte fälla hela tjänsten — utan lås
+# är beteendet som före låset fanns, inte "startar inte alls".
+try:
+    import fcntl
+except ImportError:  # Windows
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # macOS/Linux
+    msvcrt = None
 
 if __package__:
     from .agent_status import AgentStatusService
@@ -486,6 +497,9 @@ _CLAUDE_DESKTOP_PROCESS = re.compile(
 _CLAUDE_PROCESS_TOKEN = re.compile(
     r"(?:^|\s)CLAUDE_CODE_OAUTH_TOKEN=([^\s]+)"
 )
+# Vilken token-källa som finns beror på plattformen, inte på konfiguration.
+# Testerna patchar konstanten för att köra Windows-grenen på en Mac.
+_IS_WINDOWS = sys.platform == "win32"
 
 
 def _read_process_oauth_token():
@@ -542,17 +556,54 @@ def _read_keychain_oauth():
         return None, None
 
 
+def _credentials_file_path():
+    """Windows' credential store: ``%USERPROFILE%\\.claude\\.credentials.json``.
+
+    Claude Code has no keychain integration on Windows, so ``claude login``
+    writes the same ``{"claudeAiOauth": {...}}`` shape the macOS keychain
+    holds to a plain file instead. ``Path.home()`` resolves to
+    ``%USERPROFILE%`` there, so one expression covers both.
+    """
+    return Path.home() / ".claude" / ".credentials.json"
+
+
+def _read_credentials_file_oauth():
+    """The Windows credential file as ``(token, expires_at_ms)``.
+
+    Same record ``/login`` writes, same field names as the keychain — only
+    the store differs. A missing or malformed file is not an error worth
+    logging: it just means this host has no credential file, which is the
+    normal case everywhere except Windows.
+    """
+    try:
+        raw = _credentials_file_path().read_text(encoding="utf-8")
+        oauth = json.loads(raw).get("claudeAiOauth") or {}
+        return oauth.get("accessToken"), oauth.get("expiresAt")
+    except Exception:
+        return None, None
+
+
 def _read_oauth_candidates():
     """Distinct token candidates as ``[(token, expires_at_ms), ...]``.
 
-    Claude Desktop's injected process token is listed first (Desktop
-    refreshes OAuth itself while the keychain record can lag), but ``ps eww``
-    shows the environment as of process launch: a Desktop child that outlives
-    its token keeps serving the frozen, expired value even after a fresh
-    ``/login`` has updated the keychain. Neither source is reliably the
-    freshest, so the probe must try them in order rather than trust the
-    first.
+    Which sources exist is a property of the platform. On Windows there is
+    no keychain and no bundled Claude Desktop process to read an injected
+    token from, so the credential file ``/login`` writes is the only source
+    — asking ``pgrep``/``security`` there would only spawn doomed processes
+    every probe cycle.
+
+    On macOS both sources are live. Claude Desktop's injected process token
+    is listed first (Desktop refreshes OAuth itself while the keychain
+    record can lag), but ``ps eww`` shows the environment as of process
+    launch: a Desktop child that outlives its token keeps serving the
+    frozen, expired value even after a fresh ``/login`` has updated the
+    keychain. Neither source is reliably the freshest, so the probe must try
+    them in order rather than trust the first.
     """
+    if _IS_WINDOWS:
+        file_token, expires_at = _read_credentials_file_oauth()
+        return [(file_token, expires_at)] if file_token else []
+
     candidates = []
     process_token = _read_process_oauth_token()
     if process_token:
@@ -816,11 +867,24 @@ def _ota_available_version():
 
 
 def _hold_probe_lock():
-    """Icke-blockerande flock; returnerar filobjektet (= låset) eller None."""
+    """Icke-blockerande exklusivt lås; returnerar filobjektet eller None.
+
+    ``flock`` på macOS/Linux, ``msvcrt.locking`` på Windows — samma grind,
+    olika systemanrop. Båda släpps när filen stängs.
+    """
     try:
         _PROBE_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
         handle = open(_PROBE_LOCK_PATH, "w")
-        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if fcntl is not None:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt is not None:
+            # LK_NBLCK låser ett byte utan att blockera och höjer OSError om
+            # en annan instans redan äger det. Filen måste ha en byte att
+            # låsa, annars lyckas anropet utan att grinden betyder något.
+            handle.write("1")
+            handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
         return handle
     except OSError:
         try:

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -37,8 +37,8 @@ import json
 import logging
 import math
 import os
+import queue
 import re
-import select
 import shutil
 import socket
 import subprocess
@@ -89,6 +89,34 @@ LIMITS_EVERY_S = 240  # rate-limit-proben: 15 anrop/h — kontots bucket delas
                       # med Claude Code självt, och kvoten rör sig långsamt;
                       # panelens 30 s-pollar får ändå cachat svar direkt
 
+# Vilka token-källor och systemanrop som finns beror på plattformen, inte på
+# konfiguration. Testerna patchar konstanten för att köra Windows-grenarna
+# på en Mac.
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def _state_dir():
+    """Tjänstens tillståndskatalog — låset, cachen, historiken, spåraren.
+
+    ``~/Library/Application Support`` är macOS-konventionen; Windows
+    motsvarighet är ``%LOCALAPPDATA%``. Sökvägarna FUNGERAR bokstavligt på
+    Windows (``Path.home()`` löser ut), men skulle lägga ett ``Library``-träd
+    i användarprofilen som ingenting annat på maskinen känner igen.
+    """
+    if _IS_WINDOWS:
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        base = (Path(local_app_data) if local_app_data
+                else Path.home() / "AppData" / "Local")
+        return base / "VibePulse"
+    return Path.home() / "Library" / "Application Support" / "VibePulse"
+
+
+def _log_dir():
+    """Loggkatalogen. macOS har ~/Library/Logs; Windows har ingen egen
+    logg-konvention för användartjänster, så loggen bor i tillståndsträdet."""
+    return Path.home() / "Library" / "Logs" if not _IS_WINDOWS else (
+        _state_dir() / "Logs")
+
 # Diagnostiken går via logging till stderr med tidsstämplar (basicConfig i
 # main; launchd samlar bägge strömmarna i loggfilen, se plisten). Regeln är
 # ÖVERGÅNGAR, inte tillstånd: en statusändring loggas en gång och sedan är
@@ -99,7 +127,7 @@ log = logging.getLogger("tokenserver")
 # överlever omstart och syns i Konsol-appen — /tmp gjorde ingetdera. launchd
 # har ingen egen rotation, så servern tar den vid start: se
 # _maybe_rotate_own_log.
-DEFAULT_LOG_PATH = Path.home() / "Library" / "Logs" / "torget-tokenserver.log"
+DEFAULT_LOG_PATH = _log_dir() / "torget-tokenserver.log"
 _LOG_CAP_BYTES = 5 * 1024 * 1024
 _LOG_TAIL_KEEP_BYTES = 256 * 1024
 
@@ -259,8 +287,7 @@ def _get_usage_history(path=None):
     with _history_lock:
         if _default_usage_history is None:
             _default_usage_history = UsageHistory(
-                Path.home() / "Library" / "Application Support" /
-                "VibePulse" / "usage-history.json")
+                _state_dir() / "usage-history.json")
         return _default_usage_history
 
 
@@ -271,8 +298,7 @@ def _get_quota_cache(path=None):
     with _quota_cache_lock:
         if _default_quota_cache is None:
             _default_quota_cache = QuotaCache(
-                Path.home() / "Library" / "Application Support" /
-                "VibePulse" / "quota-cache.json")
+                _state_dir() / "quota-cache.json")
         return _default_quota_cache
 
 
@@ -497,9 +523,6 @@ _CLAUDE_DESKTOP_PROCESS = re.compile(
 _CLAUDE_PROCESS_TOKEN = re.compile(
     r"(?:^|\s)CLAUDE_CODE_OAUTH_TOKEN=([^\s]+)"
 )
-# Vilken token-källa som finns beror på plattformen, inte på konfiguration.
-# Testerna patchar konstanten för att köra Windows-grenen på en Mac.
-_IS_WINDOWS = sys.platform == "win32"
 
 
 def _read_process_oauth_token():
@@ -778,15 +801,13 @@ def _usage_request(token):
 # api.anthropic.com. Båda 429-incidenterna 2026-08-13/14 var i grunden
 # överflödig upstream-trafik — den här grinden gör varianten "en instans
 # till" strukturellt ofarlig i stället för att lita på att ingen startar en.
-_PROBE_LOCK_PATH = (Path.home() / "Library" / "Application Support" /
-                    "VibePulse" / "claude-probe.lock")
+_PROBE_LOCK_PATH = _state_dir() / "claude-probe.lock"
 
 # Straffrutan ÖVERLEVER omstarter: cooldownen var ren minnesstat, så varje
 # serveromstart glömde pågående backoff och petade direkt på den heta
 # bucketen igen (sett två gånger 2026-08-14, båda självförvållade). Filen
 # bor bredvid probelåset och läses lat vid första probecykeln.
-_PROBE_STATE_PATH = (Path.home() / "Library" / "Application Support" /
-                     "VibePulse" / "claude-probe-state.json")
+_PROBE_STATE_PATH = _state_dir() / "claude-probe-state.json"
 _probe_state_loaded = False
 
 
@@ -1261,6 +1282,38 @@ def _codex_app_server_command():
     return None
 
 
+def _pump_lines(stream):
+    """Rader från ``stream`` i en kö, lästa av en daemon-tråd.
+
+    ``select`` dög inte: på Windows tar ``select()`` bara sockets, aldrig
+    pipes, så app-server-läsningen kastade där i stället för att hämta
+    Codex-kvoten. En tråd som blockerar i ``readline`` ger samma
+    icke-blockerande läsning på alla plattformar.
+
+    Tråden är daemon och äger inget: dör app-servern — eller dödar vi den i
+    ``finally`` — returnerar ``readline`` tomt och tråden tar slut av sig
+    själv. ``None`` i kön är EOF-vakten, så läsaren slipper vänta ut hela
+    sin deadline när strömmen redan är stängd.
+    """
+    lines = queue.Queue()
+
+    def pump():
+        try:
+            while True:
+                line = stream.readline()
+                if not line:
+                    break
+                lines.put(line)
+        except (OSError, ValueError):
+            pass  # stängd ström under nedstängning är väntat, inte ett fel
+        finally:
+            lines.put(None)
+
+    threading.Thread(target=pump, daemon=True,
+                     name="codex-app-server-reader").start()
+    return lines
+
+
 def _read_codex_app_server_limits(timeout_s=5):
     """Read Codex's current quota snapshot through its local app protocol."""
     executable = _codex_app_server_command()
@@ -1285,18 +1338,20 @@ def _read_codex_app_server_limits(timeout_s=5):
                 "capabilities": {},
             },
         })
+        lines = _pump_lines(process.stdout)
         requested = False
         deadline = time.monotonic() + timeout_s
-        while time.monotonic() < deadline:
-            ready, _, _ = select.select(
-                [process.stdout], [], [],
-                min(0.25, max(0, deadline - time.monotonic())))
-            if not ready:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                line = lines.get(timeout=min(0.25, remaining))
+            except queue.Empty:
                 if process.poll() is not None:
                     break
                 continue
-            line = process.stdout.readline()
-            if not line:
+            if line is None:  # EOF-vakten: strömmen är slut
                 break
             try:
                 message = json.loads(line)
@@ -1313,13 +1368,25 @@ def _read_codex_app_server_limits(timeout_s=5):
     except (OSError, ValueError, BrokenPipeError):
         return {}
     finally:
-        if process is not None and process.poll() is None:
-            process.terminate()
-            try:
-                process.wait(timeout=1)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=1)
+        if process is not None:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=1)
+            # Rören stängs uttryckligen, i den här ordningen: processen är
+            # redan död, så läsartråden har lämnat readline och kan inte
+            # väckas mitt i en stängd ström. Utan det här hängde tre
+            # deskriptorer per cykel på GC:n — en gång var 30:e sekund,
+            # dygnet runt, i en tjänst som aldrig startar om.
+            for pipe in (process.stdin, process.stdout, process.stderr):
+                if pipe is not None:
+                    try:
+                        pipe.close()
+                    except OSError:
+                        pass
     return {}
 
 
@@ -2394,8 +2461,7 @@ def main():
     Handler.agent_status = status_service
 
     max_tracker_store = MaxTrackerStore(
-        Path.home() / "Library" / "Application Support" / "VibePulse" /
-        "max-tracker.json",
+        _state_dir() / "max-tracker.json",
         CODEX_SESSIONS, Handler.projects_dir)
     Handler.max_tracker_store = max_tracker_store
     Handler.plans = {"claude": args.claude_plan, "codex": args.codex_plan}

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -39,6 +39,7 @@ import math
 import os
 import queue
 import re
+import select
 import shutil
 import socket
 import subprocess


### PR DESCRIPTION
As discussed in #3 — the working-session branch rebased onto current main, so the Windows/Linux work in #2/#3 has a base.

One thing the rebase needed that git couldn't flag. The rebase is textually clean, as you found. But it's semantically broken, and the last commit here fixes it.

When the branch was cut, select.select had exactly one caller — the Codex app-server read — so replacing that with a reader thread left import select dead and it was dropped. main has since grown a second caller: Handler._hook_client_gone, which came in with the Needs You endpoints and polls a parked hook's socket to notice a client that hung up. The two edits sit far apart in the file, so there's no conflict and the NameError only appears at runtime.

_hook_client_gone catches (OSError, ValueError), and NameError is neither, so the reaper never reports a dead client — exactly the failure its own docstring warns about: a ghost entry shadows real prompts for the rest of its timeout, and at MAX_PENDING = 8 enough of them fill the queue.

It doesn't show up in the tokenserver CI job because test_interactions isn't among its seven modules. That's presumably why your test-rebase looked green. With test_interactions included it fails immediately; with the import restored, 553 tokenserver tests pass.

On 90a26c6 ("name every GPT-5.6 variant") — unrelated to Windows, but part of the branch, so I've kept it rather than quietly dropping your work. Happy to drop it if you'd rather it went in separately.