### PR TITLE
Fix LVGL render wedge from stale 96 KiB pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.12"
       - name: Run tokenserver unit tests
         run: |
-          # Same eleven modules as test/run.sh, same order. The lists
+          # Same twelve modules as test/run.sh, same order. The lists
           # drifting apart is how a green CI hid a runtime NameError in
           # PR #11 (test_interactions was missing) — keep them in sync.
           python -m unittest \
@@ -43,7 +43,10 @@ jobs:
             tools.tokenserver.test_update_prices \
             tools.tokenserver.test_codex_usage \
             tools.tokenserver.test_interactions \
+            tools.tokenserver.test_publisher \
             tools.tokenserver.test_smoke -v
+      - name: Run relay mailbox merge tests
+        run: node --test tools/relay/test.mjs
 
   firmware:
     name: ESP32-S3 firmware build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   2026-08-14 freeze). The `secrets.h` networks stay as an immutable floor
   underneath, so no entry can ever cost a USB rescue, and the setup window
   can never write firmware. Full reference: `docs/wifi.md`.
+- The panel half of the **relay fallback**: fetches try the LAN service
+  first and fall back to a mailbox on the internet
+  (`TK_VIBEPULSE_RELAY_URL` in `secrets.h` — commented out by default, and
+  without it nothing changes). Born the same evening as the travel work:
+  a guest network's client isolation kept the panel from reaching the Mac
+  while internet worked fine, and no code on the panel could fix that. The
+  boundary is deliberate and test-enforced (`test/test_relay_boundary.py`):
+  the relay carries *numbers* (quota, burn rate, Max Tracker, GitHub),
+  never *activity* (agent status, Needs You, the device key's answer path
+  — those stay on the LAN). The service-side publisher and the mailbox
+  itself are not built yet; until they land the fallback is inert.
 - The glass explains a missing network instead of showing dashes. After 60 s
   without an IP it names the network being hunted and translates the radio's
   own disconnect reason — "NOT SEEN - 2.4 GHZ ONLY", "WRONG PASSWORD". The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   never *activity* (agent status, Needs You, the device key's answer path
   — those stay on the LAN). The service-side publisher and the mailbox
   itself are not built yet; until they land the fallback is inert.
+- **Hold KEY3 twice to reach WiFi setup on a connected panel.** The setup
+  window used to open only when the panel had no network — you could not
+  pre-load the phone hotspot at home before a trip. Now a second full 3 s
+  hold while the update window is open switches to WIFI SETUP. Any release
+  before three seconds still just closes (the 2026-08-16 escape hatch is
+  untouched); the port-80 handover between the two windows' HTTP servers is
+  owned by the setup guard, so they never collide.
 - The glass explains a missing network instead of showing dashes. After 60 s
   without an IP it names the network being hunted and translates the radio's
   own disconnect reason — "NOT SEEN - 2.4 GHZ ONLY", "WRONG PASSWORD". The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,10 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   wedged the panel twice (2026-08-17; rolled back to the previous release
   over USB). Suspected DMA starvation by the access point — the exact
   2026-08-16 freeze anatomy — pending the incident's serial log.
-  `window_open()` is now bracketed by two host-tested DMA gates (refuse
-  below 4x the flush's contiguous block, abort below 2x after the APSTA
-  switch) with per-stage DMA logging. The gates are defensive, not a
+  `window_open()` is now bracketed by two host-tested DMA gates (refuse below 3x
+  the flush's contiguous block — calibrated against v0.5.0's measured
+  40-47 kB healthy baseline, so a healthy panel is never refused — abort
+  below 2x after the APSTA switch) with per-stage DMA logging. The gates are defensive, not a
   verification: the setup window stays unproven on hardware until a
   supervised run passes.
 - The glass explains a missing network instead of showing dashes. After 60 s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   before three seconds still just closes (the 2026-08-16 escape hatch is
   untouched); the port-80 handover between the two windows' HTTP servers is
   owned by the setup guard, so they never collide.
+
+  **Hardware status, honestly:** the first physical exercise of this path
+  wedged the panel twice (2026-08-17; rolled back to the previous release
+  over USB). Suspected DMA starvation by the access point — the exact
+  2026-08-16 freeze anatomy — pending the incident's serial log.
+  `window_open()` is now bracketed by two host-tested DMA gates (refuse
+  below 4x the flush's contiguous block, abort below 2x after the APSTA
+  switch) with per-stage DMA logging. The gates are defensive, not a
+  verification: the setup window stays unproven on hardware until a
+  supervised run passes.
 - The glass explains a missing network instead of showing dashes. After 60 s
   without an IP it names the network being hunted and translates the radio's
   own disconnect reason — "NOT SEEN - 2.4 GHZ ONLY", "WRONG PASSWORD". The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,35 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+### Added
+
+- **The panel travels.** It remembers six places in NVS and joins the one
+  that worked most recently; arriving somewhere new no longer means editing
+  `secrets.h`, rebuilding and flashing over USB — which OTA could never fix,
+  since OTA needs the network the panel cannot reach. Two ways to teach it a
+  place: `tools/wifi-here.sh` on the Mac hands over the network it is
+  already on (reading the password from the keychain, one prompt, nothing
+  typed), or the panel raises `VibePulse-setup` with the password on the
+  glass and serves a captive portal listing what its *own* radio can see.
+  The window opens by itself after 90 s without an IP, or on a 3 s KEY3
+  hold, and closes after ten minutes — the access point, HTTP server and DNS
+  responder do not exist outside it (the lazy-surface rule from the
+  2026-08-14 freeze). The `secrets.h` networks stay as an immutable floor
+  underneath, so no entry can ever cost a USB rescue, and the setup window
+  can never write firmware. Full reference: `docs/wifi.md`.
+- The glass explains a missing network instead of showing dashes. After 60 s
+  without an IP it names the network being hunted and translates the radio's
+  own disconnect reason — "NOT SEEN - 2.4 GHZ ONLY", "WRONG PASSWORD". The
+  reason codes were already in the serial log; a shelf gadget nobody has a
+  cable to could not show them.
+
 ### Fixed
+
+- Open networks were refused in silence. Every network was applied with
+  `threshold.authmode = WIFI_AUTH_WPA2_PSK`, so an open café or airport
+  network — the common case on the road — was rejected before it was tried,
+  with nothing in the log pointing at the threshold. The authmode now
+  follows each network: open where the password is blank.
 
 - The panel names all three GPT-5.6 variants. `gpt-5.6-sol` had a typeset
   screen label while its siblings `terra` and `luna` fell through to their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,33 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   2026-08-14 freeze). The `secrets.h` networks stay as an immutable floor
   underneath, so no entry can ever cost a USB rescue, and the setup window
   can never write firmware. Full reference: `docs/wifi.md`.
-- The panel half of the **relay fallback**: fetches try the LAN service
-  first and fall back to a mailbox on the internet
-  (`TK_VIBEPULSE_RELAY_URL` in `secrets.h` — commented out by default, and
-  without it nothing changes). Born the same evening as the travel work:
-  a guest network's client isolation kept the panel from reaching the Mac
-  while internet worked fine, and no code on the panel could fix that. The
-  boundary is deliberate and test-enforced (`test/test_relay_boundary.py`):
-  the relay carries *numbers* (quota, burn rate, Max Tracker, GitHub),
-  never *activity* (agent status, Needs You, the device key's answer path
-  — those stay on the LAN). The service-side publisher and the mailbox
-  itself are not built yet; until they land the fallback is inert.
+- The **relay**, end to end: the panel can now get its numbers from
+  anywhere with internet, instead of only from the same LAN as the
+  service. Born the same evening as the travel work: a guest network's
+  client isolation kept the panel from reaching the Mac while internet
+  worked fine, and no code on the panel could fix that. Three parts, one
+  boundary:
+  - *Panel*: fetches try the LAN first and fall back to the mailbox
+    (`TK_VIBEPULSE_RELAY_URL` in `secrets.h` — commented out by default;
+    without it nothing changes).
+  - *Service*: `--publish <url>` POSTs the same three payloads the LAN
+    endpoints serve — send-on-change plus a 5-minute heartbeat, staying
+    inside Cloudflare KV's 1 000 free writes/day by design. Several
+    machines may publish to one mailbox; every send names its publisher.
+  - *Mailbox*: a ~150-line Cloudflare Worker (`tools/relay/`) that merges
+    freshest-per-pool on read using the observation stamps the staleness
+    logic already carries — Claude from whichever machine asked Anthropic
+    last, Codex from whichever machine ran Codex last.
+  The boundary is enforced from three directions
+  (`test/test_relay_boundary.py`, `test_publisher.py`, the Worker's path
+  allowlist): the relay carries *numbers* (quota, burn rate, Max Tracker,
+  GitHub), never *activity* (agent status, Needs You, the device key's
+  answer path — those stay on the LAN). Full design: `docs/relay.md`.
+- **Windows autostart** for the tokenserver
+  (`tools/tokenserver/install-windows-task.ps1`): a scheduled task running
+  as the logged-in user (never SYSTEM — the credential file lives in the
+  user profile), restarting on failure, logs in `%LOCALAPPDATA%\VibePulse\`.
+  Closes the gap in issue #3.
 - **Hold KEY3 twice to reach WiFi setup on a connected panel.** The setup
   window used to open only when the panel had no network — you could not
   pre-load the phone hotspot at home before a trip. Now a second full 3 s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ Day-to-day firmware goes over the air: `idf.py build && tools/ota-flash.sh`
 (device IP from git-ignored `.ota-device`). The full loop, consent model and
 troubleshooting live in `docs/ota.md` — read it before touching anything
 OTA. Non-negotiables: the maintenance window opens ONLY from the device (a
-3 s KEY3 hold, or the UPDATE pill on the takeover) — never claim or imply a
+3 s KEY3 hold — with an IP; without one the same hold opens the WiFi setup
+window instead, see `docs/wifi.md` — or the UPDATE pill on the takeover) —
+never claim or imply a
 script can; the sender gates (newest-binary-at-send, version printed,
 -dirty refused) exist because a stale archived build once froze the panel —
 never bypass them with TG_OTA_ALLOW_DIRTY without the user saying so; and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(torget)
 
+# sdkconfig.defaults only seeds a new sdkconfig; it does not update an old
+# generated file. A stale 96 KiB LVGL pool wedges the LVGL task in its default
+# out-of-memory assert while rendering the 164 px quota glyphs. Refuse to
+# produce that image instead of discovering the mismatch on the glass.
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/torget_lvgl_memory_guard.cmake")
+torget_require_lvgl_pool("${CONFIG_LV_MEM_SIZE_KILOBYTES}")
+
 # LVGL:s minnespool till PSRAM (frysfix 2026-08-16, se docs/lessons.md och
 # main/lv_psram_pool.c). LVGL:s inbyggda allokator lägger annars sin
 # LV_MEM_SIZE-pool i internt BSS; på panelen tryckte det största

--- a/README.md
+++ b/README.md
@@ -392,6 +392,16 @@ your phone's hotspot, with *Maximize Compatibility* on. Teach the panel
 that one once and it follows you everywhere. Full reference:
 [docs/wifi.md](docs/wifi.md).
 
+And for the networks that *do* connect but wall the panel off from your
+machine (client isolation, IoT VLANs): the optional **relay** puts the
+numbers in a tiny mailbox on the internet — a ~150-line Cloudflare Worker
+on your own account — and the panel falls back to it whenever the LAN
+does not answer. Quota, burn rate, Max Tracker and the GitHub pulse
+follow you anywhere with WiFi; agent activity and Needs You deliberately
+never leave your LAN. Several machines can feed the same mailbox
+(a Mac that sleeps, an always-on PC) and the freshest source wins per
+number. Setup and the full privacy boundary: [docs/relay.md](docs/relay.md).
+
 ## No hardware? Run the simulator
 
 ```

--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ opens a ten-minute maintenance window (the glass shows an UPDATES ON ring
 with the lease draining clockwise), a **64-hex token** from `secrets.h`
 authenticates the upload, and the window **closes itself** — a short KEY3
 press closes it early. No button, no update; a script can never open the
-window for you.
+window for you. (The same hold on a panel *without* a network opens the
+WiFi setup window instead — the window that can actually help there. See
+[Take it with you](#take-it-with-you).)
 
 ```
 idf.py build

--- a/README.md
+++ b/README.md
@@ -374,6 +374,11 @@ stops being coy: it names the network it is hunting and what the radio
 actually answered ("NOT SEEN - 2.4 GHZ ONLY", "WRONG PASSWORD") instead of
 showing dashes and letting you guess.
 
+On a panel that already *has* a network, hold twice: the first 3-second
+hold opens the update window, a second full hold switches it to WIFI
+SETUP. That is how you pre-load the phone hotspot at home before a trip —
+no need to wait until the panel is stranded somewhere.
+
 Two things stay true by design. The networks in `secrets.h` remain an
 **immutable floor** — setup can add places, never remove your home network,
 so a bad entry can never cost you a USB rescue. And the setup window

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 **A little always-on screen for your shelf that shows what your AI coding
 agents are doing — taps you on the shoulder when one is stuck waiting for
-you, and (if you want) lets you answer it with a tap on the glass.**
+you, and (if you want) lets you answer it with a tap on the glass. It packs
+too: one command moves it onto whatever WiFi you are on today.**
 
 Claude Code and Codex usage, live agent activity, and a full-screen
 **NEEDS YOU** alert you can answer with a tap. A ~$30 ESP32-S3 panel plus a
@@ -344,6 +345,45 @@ where `partitions.csv` still has a single `factory` partition. The OTA
 foundation replaced that table (A/B slots + `otadata`) — check the branch
 you are on before concluding anything, and never assume the flash layout
 without reading `partitions.csv` in the checkout you are actually building.
+
+## Take it with you
+
+The panel remembers up to six places. Arrive somewhere new and it needs the
+network once; every visit after that it joins by itself.
+
+```
+tools/wifi-here.sh                 # on the Mac. That is the whole thing.
+```
+
+The script reads the network your Mac is already on, takes that password
+out of your keychain (macOS asks you — that prompt is the consent), hands
+it to the panel over its own access point, and gives your WiFi back. About
+twenty seconds offline, nothing typed.
+
+No Mac at hand? The panel raises **VibePulse-setup** and puts the password
+on the glass. Join it from your phone, the captive portal opens by itself,
+and you pick from what the *panel's* radio can see — which is the list that
+matters, since the ESP32-S3 cannot hear 5 GHz no matter how many bars your
+phone shows.
+
+The setup window opens on its own after 90 seconds without a network, or
+immediately on a 3-second KEY3 hold. Before that, at 60 seconds, the glass
+stops being coy: it names the network it is hunting and what the radio
+actually answered ("NOT SEEN - 2.4 GHZ ONLY", "WRONG PASSWORD") instead of
+showing dashes and letting you guess.
+
+Two things stay true by design. The networks in `secrets.h` remain an
+**immutable floor** — setup can add places, never remove your home network,
+so a bad entry can never cost you a USB rescue. And the setup window
+**cannot write firmware**: it touches the network list and nothing else,
+while OTA keeps its own token and its own gate.
+
+Honest limits: captive portals (the panel cannot click "I agree"), guest
+networks with client isolation, and WPA2-Enterprise are all still out of
+reach. The network that always works on the road is the one you bring —
+your phone's hotspot, with *Maximize Compatibility* on. Teach the panel
+that one once and it follows you everywhere. Full reference:
+[docs/wifi.md](docs/wifi.md).
 
 ## No hardware? Run the simulator
 

--- a/cmake/torget_lvgl_memory_guard.cmake
+++ b/cmake/torget_lvgl_memory_guard.cmake
@@ -1,0 +1,18 @@
+set(TORGET_LVGL_POOL_MIN_KIB 256)
+
+function(torget_require_lvgl_pool actual_kib)
+  if("${actual_kib}" STREQUAL "" OR NOT "${actual_kib}" MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+      "LVGL pool size is missing or invalid: '${actual_kib}'")
+  endif()
+
+  if(actual_kib LESS TORGET_LVGL_POOL_MIN_KIB)
+    message(FATAL_ERROR
+      "LVGL pool is ${actual_kib} KiB; Torget requires at least "
+      "${TORGET_LVGL_POOL_MIN_KIB} KiB. The generated sdkconfig is stale: "
+      "edit sdkconfig and set "
+      "CONFIG_LV_MEM_SIZE_KILOBYTES=${TORGET_LVGL_POOL_MIN_KIB} "
+      "(matching sdkconfig.defaults), then run: "
+      "idf.py reconfigure && idf.py build")
+  endif()
+endfunction()

--- a/components/app_tokens/app_tokens_config.h
+++ b/components/app_tokens/app_tokens_config.h
@@ -5,6 +5,30 @@
 #include "secrets.h"
 #endif
 
+/*
+ * Reläets adresser, härledda ur EN valfri bas i secrets.h.
+ *
+ * Reläet är en brevlåda på internet dit tjänsten LÄGGER sina färdiga
+ * siffror, så panelen kan hämta dem utan att dela nät med värden. Utan
+ * TK_VIBEPULSE_RELAY_URL blir varje adress NULL och hämtningarna beter sig
+ * exakt som förut — LAN eller ingenting.
+ *
+ * GRÄNSEN, medveten och testad: reläet bär SIFFROR, aldrig AKTIVITET.
+ * Kvot, burn rate, Max Tracker och GitHub går den vägen. Agentstatus och
+ * Needs You gör det INTE — de bär projektnamn, frågetexter och kommandon,
+ * och de lämnar aldrig LAN:et. Enhetsnyckelns svarsväg är av samma skäl
+ * LAN-only: panelen kan svara på en fråga hemma, aldrig via en brevlåda.
+ */
+#ifdef TK_VIBEPULSE_RELAY_URL
+#define TK_TOKENS_RELAY_URL      TK_VIBEPULSE_RELAY_URL "/api/tokens"
+#define TK_MAX_TRACKER_RELAY_URL TK_VIBEPULSE_RELAY_URL "/api/max-tracker"
+#define TK_GITHUB_RELAY_URL      TK_VIBEPULSE_RELAY_URL "/api/github"
+#else
+#define TK_TOKENS_RELAY_URL      NULL
+#define TK_MAX_TRACKER_RELAY_URL NULL
+#define TK_GITHUB_RELAY_URL      NULL
+#endif
+
 /* The GitHub page and star popup are deliberately independent. A fresh clone
  * remains Claude/Codex-only until the user opts in through secrets.h. */
 #ifndef TK_GITHUB_SCREEN_ENABLED

--- a/components/app_tokens/github_net.c
+++ b/components/app_tokens/github_net.c
@@ -33,7 +33,8 @@ static void github_net_task(void *arg) {
 
   for (;;) {
     tk_github_status status;
-    if (torget_http_get(TK_GITHUB_URL, body, sizeof body, &len) &&
+    if (torget_http_get_failover(TK_GITHUB_URL, TK_GITHUB_RELAY_URL,
+                                 body, sizeof body, &len) &&
         tk_github_status_parse(body, len, &status)) {
       torget_ui_lock();
       tokens_apply_github(&status);

--- a/components/app_tokens/net.c
+++ b/components/app_tokens/net.c
@@ -16,6 +16,7 @@
 #include "esp_log.h"
 
 #include "app_tokens.h"
+#include "app_tokens_config.h"
 #ifdef ESP_PLATFORM
 #include "secrets.h"
 #endif
@@ -46,7 +47,8 @@ static void net_task(void *arg) {
 
   for (;;) {
     tk_tokens t;
-    if (torget_http_get(TK_TOKENS_URL, body, sizeof body, &len)
+    if (torget_http_get_failover(TK_TOKENS_URL, TK_TOKENS_RELAY_URL,
+                                body, sizeof body, &len)
         && tk_tokens_parse(body, len, &t)) {
       torget_ui_lock();
       tokens_apply(&t);
@@ -100,7 +102,8 @@ static void max_tracker_task(void *arg) {
 
   for (;;) {
     tk_max_tracker t;
-    if (torget_http_get(TK_MAX_TRACKER_URL, body, sizeof body, &len)
+    if (torget_http_get_failover(TK_MAX_TRACKER_URL, TK_MAX_TRACKER_RELAY_URL,
+                                body, sizeof body, &len)
         && tk_max_tracker_parse(body, len, &t)) {
       torget_ui_lock();
       tokens_apply_max_tracker(&t);

--- a/components/torget_net/CMakeLists.txt
+++ b/components/torget_net/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Glance-mönstrets HTTP-klient: en begränsad GET, hela kroppen eller
-# ingenting. Bara targetet — simulatorn läser fixtures från disk.
+# ingenting — nu med reläet som reservväg när LAN:et inte går att nå.
+# net_source_policy är den rena kärnan och värdtestas i test/run.sh.
 idf_component_register(
-  SRCS "torget_http.c"
+  SRCS "torget_http.c" "net_source_policy.c"
   INCLUDE_DIRS "."
-  PRIV_REQUIRES esp_http_client esp-tls)
+  PRIV_REQUIRES esp_http_client esp-tls esp_timer)

--- a/components/torget_net/net_source_policy.c
+++ b/components/torget_net/net_source_policy.c
@@ -1,0 +1,46 @@
+#include "net_source_policy.h"
+
+tg_net_source tg_net_source_first(const tg_net_source_state *state,
+                                  int64_t now_us) {
+  if (!state || !state->relay_won) return TG_NET_SOURCE_LOCAL;
+
+  /* Reläet levererar. Prova LAN igen med jämna mellanrum så en hemkomst
+   * upptäcks — men inte varje hämtning, för varje förlorat försök kostar
+   * en timeout innan reläet ens tillfrågas. */
+  if (state->last_local_try_us == 0) return TG_NET_SOURCE_LOCAL;
+  if (now_us - state->last_local_try_us >= TG_NET_LOCAL_REPROBE_US)
+    return TG_NET_SOURCE_LOCAL;
+  return TG_NET_SOURCE_RELAY;
+}
+
+int tg_net_source_timeout_ms(const tg_net_source_state *state,
+                             tg_net_source source) {
+  if (source != TG_NET_SOURCE_LOCAL) return TG_NET_LOCAL_TIMEOUT_MS;
+  /* Ett återprov medan reläet fungerar får inte hålla upp en hämtning som
+   * annars hade landat: två sekunder räcker gott på ett LAN, och missar vi
+   * hemkomsten just den gången tas den om fem minuter senare. */
+  if (state && state->relay_won) return TG_NET_REPROBE_TIMEOUT_MS;
+  return TG_NET_LOCAL_TIMEOUT_MS;
+}
+
+bool tg_net_source_may_fall_back(tg_net_source tried) {
+  return tried == TG_NET_SOURCE_LOCAL;
+}
+
+void tg_net_source_note(tg_net_source_state *state, tg_net_source tried,
+                        bool ok, int64_t now_us) {
+  if (!state) return;
+
+  if (tried == TG_NET_SOURCE_LOCAL) {
+    /* Stämpla ALLTID försöket, lyckat som misslyckat — annars provas LAN om
+     * och om igen i varje hämtning så fort återprovsfönstret öppnat sig. */
+    state->last_local_try_us = now_us;
+    if (ok) state->relay_won = false; /* hemma igen: LAN äger */
+    return;
+  }
+
+  /* Reläet lyckades = det är den som gäller tills LAN svarar igen. Ett
+   * misslyckat relä ändrar ingenting: då är BÅDA nere, och nästa hämtning
+   * ska börja om från LAN i stället för att fastna på reläet. */
+  if (ok) state->relay_won = true;
+}

--- a/components/torget_net/net_source_policy.h
+++ b/components/torget_net/net_source_policy.h
@@ -1,0 +1,72 @@
+#ifndef TORGET_NET_SOURCE_POLICY_H
+#define TORGET_NET_SOURCE_POLICY_H
+
+/*
+ * Vilken källa hämtningarna ska fråga: tjänsten på LAN:et, eller reläet på
+ * internet. Ren policy utan ESP-IDF — värdtestad i test/run.sh
+ * (test_net_source_policy.c).
+ *
+ * Varför två källor alls: panelen kunde bara nå tokenservern på samma nät.
+ * Ett gästnät med klientisolering, ett IoT-VLAN eller en Mac som bytt IP
+ * räckte för att glaset skulle visa streck fast allt annat fungerade
+ * (verkligt fall 2026-08-17: Solelkollen hämtade glatt över internet medan
+ * VibePulse stod tomt). Reläet är en brevlåda dit tjänsten LÄGGER sina
+ * färdiga siffror; panelen hämtar därifrån när LAN:et inte svarar.
+ *
+ * Två egenskaper som INTE får glida:
+ *
+ *  - Reläet är LÄSNING ONLY. Needs You-verdikt signeras med enhetsnyckeln
+ *    och postas alltid till LAN-tjänsten, aldrig till reläet. Kan panelen
+ *    inte nå LAN:et kan den inte svara — och då faller frågan tillbaka till
+ *    terminalen, precis som när panelen är avstängd. Det är den befintliga,
+ *    ärliga semantiken; den ska inte tänjas för bekvämlighet.
+ *  - LAN först när LAN finns. Hemma ska datan komma från hemmet.
+ *
+ * Kostnaden att prova en död LAN-adress är en timeout per hämtning, och
+ * fyra endpoints som var och en bränner tio sekunder gör panelen trög. När
+ * reläet vunnit provas därför LAN bara med jämna mellanrum, och då med kort
+ * tålamod.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+  TG_NET_SOURCE_LOCAL = 0, /* tokenservern på LAN:et */
+  TG_NET_SOURCE_RELAY = 1, /* brevlådan på internet  */
+} tg_net_source;
+
+/* Hur ofta LAN provas igen när reläet är den som fungerar. Fem minuter:
+ * kort nog att en hemkomst märks innan man hunnit undra, långt nog att en
+ * bortarest inte betalar en timeout var 30:e sekund. */
+#define TG_NET_LOCAL_REPROBE_US (300LL * 1000000LL)
+
+/* Tålamod med LAN-adressen. Full väntan medan LAN är den som gäller; kort
+ * väntan när det bara är ett återprov och reläet redan levererar. */
+#define TG_NET_LOCAL_TIMEOUT_MS  10000
+#define TG_NET_REPROBE_TIMEOUT_MS 2000
+
+typedef struct {
+  bool relay_won;          /* reläet är den som levererar just nu     */
+  int64_t last_local_try_us; /* när LAN senast provades (0 = aldrig) */
+} tg_net_source_state;
+
+/* Vilken källa hämtningen ska börja med. */
+tg_net_source tg_net_source_first(const tg_net_source_state *state,
+                                  int64_t now_us);
+
+/* Hur länge den källan får ta på sig. */
+int tg_net_source_timeout_ms(const tg_net_source_state *state,
+                             tg_net_source source);
+
+/* Får vi falla vidare till reläet efter ett misslyckat försök? Bara om det
+ * var LAN som föll — ett dött relä ska inte studsa tillbaka till ett LAN vi
+ * just konstaterat är borta, i en evig runda. */
+bool tg_net_source_may_fall_back(tg_net_source tried);
+
+/* Bokför utfallet. Anropas EN gång per försök, i den ordning försöken
+ * gjordes. */
+void tg_net_source_note(tg_net_source_state *state, tg_net_source tried,
+                        bool ok, int64_t now_us);
+
+#endif

--- a/components/torget_net/torget_http.c
+++ b/components/torget_net/torget_http.c
@@ -1,10 +1,14 @@
 #include "torget_http.h"
 
+#include <stdatomic.h>
 #include <string.h>
 
 #include "esp_crt_bundle.h"
 #include "esp_http_client.h"
 #include "esp_log.h"
+#include "esp_timer.h"
+
+#include "net_source_policy.h"
 
 static const char *TAG = "torget-http";
 
@@ -30,7 +34,8 @@ static esp_err_t on_event(esp_http_client_event_t *evt) {
   return ESP_OK;
 }
 
-bool torget_http_get(const char *url, char *buf, size_t cap, size_t *len_out) {
+static bool http_get_timeout(const char *url, char *buf, size_t cap,
+                             size_t *len_out, int timeout_ms) {
   body_t body = { .buf = buf, .cap = cap };
 
   esp_http_client_config_t cfg = {
@@ -39,7 +44,7 @@ bool torget_http_get(const char *url, char *buf, size_t cap, size_t *len_out) {
     .event_handler = on_event,
     .user_data = &body,
     .crt_bundle_attach = esp_crt_bundle_attach,
-    .timeout_ms = 10000,
+    .timeout_ms = timeout_ms,
     /* Följ en eventuell omdirigering (apex → www och liknande) men inte i
      * all evighet. */
     .max_redirection_count = 3,
@@ -65,5 +70,51 @@ bool torget_http_get(const char *url, char *buf, size_t cap, size_t *len_out) {
   }
 
   esp_http_client_cleanup(client);
+  return ok;
+}
+
+bool torget_http_get(const char *url, char *buf, size_t cap, size_t *len_out) {
+  return http_get_timeout(url, buf, cap, len_out, TG_NET_LOCAL_TIMEOUT_MS);
+}
+
+/*
+ * Växlingstillståndet delas av alla hämttasker, och avsiktligt utan lås:
+ * fälten är två, båda skrivs bara med hela värden, och en kapad läsning av
+ * tidsstämpeln kostar som mest ETT extra LAN-återprov. Ett mutex här hade
+ * lagt en låsordning mellan apptaskarna för att skydda en optimering —
+ * dyrare än felet det förhindrar. Atomära fält räcker för att undvika
+ * odefinierat beteende på de 64 bitarna.
+ */
+static _Atomic bool s_relay_won;
+static _Atomic int64_t s_last_local_try_us;
+
+bool torget_http_get_failover(const char *lan_url, const char *relay_url,
+                              char *buf, size_t cap, size_t *len_out) {
+  if (!relay_url || !relay_url[0])
+    return torget_http_get(lan_url, buf, cap, len_out);
+
+  const int64_t now = esp_timer_get_time();
+  tg_net_source_state state = {
+    .relay_won = atomic_load(&s_relay_won),
+    .last_local_try_us = atomic_load(&s_last_local_try_us),
+  };
+
+  tg_net_source source = tg_net_source_first(&state, now);
+  const char *url = (source == TG_NET_SOURCE_LOCAL) ? lan_url : relay_url;
+  bool ok = http_get_timeout(url, buf, cap, len_out,
+                             tg_net_source_timeout_ms(&state, source));
+
+  tg_net_source_note(&state, source, ok, now);
+  atomic_store(&s_relay_won, state.relay_won);
+  atomic_store(&s_last_local_try_us, state.last_local_try_us);
+
+  if (ok || !tg_net_source_may_fall_back(source)) return ok;
+
+  /* LAN föll — reläet är hela poängen med att vara på resa. */
+  ESP_LOGI(TAG, "LAN svarade inte, provar reläet");
+  ok = http_get_timeout(relay_url, buf, cap, len_out,
+                        TG_NET_LOCAL_TIMEOUT_MS);
+  tg_net_source_note(&state, TG_NET_SOURCE_RELAY, ok, now);
+  atomic_store(&s_relay_won, state.relay_won);
   return ok;
 }

--- a/components/torget_net/torget_http.h
+++ b/components/torget_net/torget_http.h
@@ -23,4 +23,17 @@
  */
 bool torget_http_get(const char *url, char *buf, size_t cap, size_t *len_out);
 
+/*
+ * Samma hämtning, men med en reservadress: tjänsten på LAN:et först, reläet
+ * på internet om LAN inte svarar. relay_url får vara NULL — då är det här
+ * exakt torget_http_get.
+ *
+ * Vilken som provas först, och hur länge den får ta på sig, avgörs av
+ * net_source_policy (värdtestad). Tillståndet delas av alla anropare: har
+ * en hämtning redan konstaterat att LAN är borta ska nästa inte betala
+ * samma timeout om igen.
+ */
+bool torget_http_get_failover(const char *lan_url, const char *relay_url,
+                              char *buf, size_t cap, size_t *len_out);
+
 #endif

--- a/components/torget_wifi/CMakeLists.txt
+++ b/components/torget_wifi/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Nätverkslistan och setupfönstret. Samma skiktning som torget_ota: den rena
+# policyfilen (wifi_slots) värdtestas i test/run.sh utan ESP-IDF; adaptrarna
+# får röra NVS och radion men aldrig bära ett beslut som inte redan är låst
+# i policyn.
+idf_component_register(
+  SRCS "wifi_slots.c" "wifi_form.c"
+       "wifi_creds.c" "wifi_setup.c" "wifi_setup_ui.c"
+  INCLUDE_DIRS "."
+  # torget_app: designsystemets fonter (extern lv_font_t) + torget.h-låset.
+  # torget_ota: setupfönstret måste kunna stänga ett OTA-fönster som håller
+  # port 80 — utan nät kan det ändå aldrig ta emot en uppladdning.
+  REQUIRES torget_app torget_ota
+  # secrets.h (TG_OTA_TOKEN) bor i repytroten, gitignorad — därav "../..".
+  PRIV_INCLUDE_DIRS "../.."
+  PRIV_REQUIRES nvs_flash esp_wifi esp_netif esp_http_server esp_timer
+                esp_hw_support mbedtls lwip)

--- a/components/torget_wifi/idf_component.yml
+++ b/components/torget_wifi/idf_component.yml
@@ -1,0 +1,5 @@
+## Nätlagret ritar med samma LVGL-serie som resten av plattformen (9.5 via
+## BSP:n; sim pinnar exakt samma, P20).
+dependencies:
+  idf: ">=5.5"
+  lvgl/lvgl: "9.*"

--- a/components/torget_wifi/wifi_creds.c
+++ b/components/torget_wifi/wifi_creds.c
@@ -1,0 +1,118 @@
+#include "wifi_creds.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+static const char *TAG = "wifi-creds";
+
+/* NVS-nycklar har ett tak på 15 tecken — båda ligger med marginal under. */
+#define CREDS_NAMESPACE "tgwifi"
+#define CREDS_KEY       "slots"
+
+static bool open_ns(nvs_open_mode_t mode, nvs_handle_t *out) {
+  esp_err_t err = nvs_open(CREDS_NAMESPACE, mode, out);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "kunde inte öppna %s: %s", CREDS_NAMESPACE,
+             esp_err_to_name(err));
+    return false;
+  }
+  return true;
+}
+
+void tg_wifi_creds_load(tg_wifi_slot out[TG_WIFI_SLOTS]) {
+  memset(out, 0, sizeof(tg_wifi_slot) * TG_WIFI_SLOTS);
+
+  nvs_handle_t handle;
+  if (!open_ns(NVS_READONLY, &handle)) return;
+
+  size_t len = sizeof(tg_wifi_slot) * TG_WIFI_SLOTS;
+  esp_err_t err = nvs_get_blob(handle, CREDS_KEY, out, &len);
+  nvs_close(handle);
+
+  if (err == ESP_ERR_NVS_NOT_FOUND) return; /* färsk panel, inte ett fel */
+  if (err != ESP_OK || len != sizeof(tg_wifi_slot) * TG_WIFI_SLOTS) {
+    /* Fel storlek = annat format än det här bygget känner. Hellre tom
+     * lista (och secrets.h-botten) än fält tolkade på fel offset. */
+    ESP_LOGW(TAG, "listan förkastad (%s, %u byte) — kör på secrets.h",
+             esp_err_to_name(err), (unsigned)len);
+    memset(out, 0, sizeof(tg_wifi_slot) * TG_WIFI_SLOTS);
+    return;
+  }
+
+  /* Upstream är fientlig, även när upstream är vår egen flash: NUL-terminera
+   * varje sträng innan någon annan läser dem som text (läxan 2026-08-13). */
+  for (int i = 0; i < TG_WIFI_SLOTS; i++) {
+    out[i].ssid[TG_WIFI_SSID_CAP - 1] = '\0';
+    out[i].pass[TG_WIFI_PASS_CAP - 1] = '\0';
+  }
+}
+
+static bool save(const tg_wifi_slot *slots) {
+  nvs_handle_t handle;
+  if (!open_ns(NVS_READWRITE, &handle)) return false;
+
+  esp_err_t err =
+      nvs_set_blob(handle, CREDS_KEY, slots,
+                   sizeof(tg_wifi_slot) * TG_WIFI_SLOTS);
+  if (err == ESP_OK) err = nvs_commit(handle);
+  nvs_close(handle);
+
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "listan kunde inte sparas: %s", esp_err_to_name(err));
+    return false;
+  }
+  return true;
+}
+
+bool tg_wifi_creds_remember(const char *ssid, const char *pass) {
+  if (!tg_wifi_ssid_valid(ssid) || !tg_wifi_pass_valid(pass)) {
+    /* SSID:t loggas inte här: en ogiltig sträng är per definition en
+     * sträng vi inte vill skriva ut. Storleken räcker som diagnos. */
+    ESP_LOGW(TAG, "avvisade ogiltiga uppgifter");
+    return false;
+  }
+
+  tg_wifi_slot slots[TG_WIFI_SLOTS];
+  tg_wifi_creds_load(slots);
+
+  int idx = tg_wifi_slot_for_write(slots, TG_WIFI_SLOTS, ssid);
+  if (idx < 0) return false;
+
+  uint32_t seq = tg_wifi_seq_next(slots, TG_WIFI_SLOTS);
+  memset(&slots[idx], 0, sizeof slots[idx]);
+  strncpy(slots[idx].ssid, ssid, TG_WIFI_SSID_CAP - 1);
+  strncpy(slots[idx].pass, pass, TG_WIFI_PASS_CAP - 1);
+  slots[idx].seq = seq;
+
+  if (!save(slots)) return false;
+  /* Lösenordet skrivs aldrig ut; nätets namn gör felsökning möjlig. */
+  ESP_LOGI(TAG, "minns \"%s\" på plats %d", ssid, idx);
+  return true;
+}
+
+void tg_wifi_creds_mark_ok(const char *ssid) {
+  tg_wifi_slot slots[TG_WIFI_SLOTS];
+  tg_wifi_creds_load(slots);
+
+  int idx = tg_wifi_slot_find(slots, TG_WIFI_SLOTS, ssid);
+  if (idx < 0) return; /* secrets.h-botten hamnar aldrig i NVS */
+
+  uint32_t seq = tg_wifi_seq_next(slots, TG_WIFI_SLOTS);
+  /* Ligger den redan överst är skrivningen ren flashslitage: listan
+   * sorterar likadant vare sig seq är 9 eller 10. */
+  if (slots[idx].seq >= seq - 1) return;
+  slots[idx].seq = seq;
+  save(slots);
+}
+
+int tg_wifi_creds_count(void) {
+  tg_wifi_slot slots[TG_WIFI_SLOTS];
+  tg_wifi_creds_load(slots);
+  int n = 0;
+  for (int i = 0; i < TG_WIFI_SLOTS; i++)
+    if (slots[i].seq != 0 && slots[i].ssid[0] != '\0') n++;
+  return n;
+}

--- a/components/torget_wifi/wifi_creds.h
+++ b/components/torget_wifi/wifi_creds.h
@@ -1,0 +1,44 @@
+#ifndef TORGET_WIFI_CREDS_H
+#define TORGET_WIFI_CREDS_H
+
+/*
+ * NVS-adaptern för nätverkslistan. All beslutslogik bor i wifi_slots.h —
+ * den här filen gör ingenting annat än att läsa och skriva blobben.
+ *
+ * Lagring: EN blob (namnrymd "tgwifi", nyckel "slots") med hela
+ * tg_wifi_slot-arrayen. En skrivning, en commit, ingen halvskriven lista
+ * om strömmen går mitt i. Storleken kontrolleras vid läsning; ett blobb
+ * med fel storlek (äldre eller nyare format) behandlas som tom lista i
+ * stället för att tolkas fel.
+ *
+ * NVS-partitionen är INTE krypterad, så lösenorden ligger i klartext i
+ * flashen. Det är samma exponering som secrets.h redan har (README:
+ * "a stolen or lost screen leaks your WiFi password") — inte en ny klass
+ * av risk, men skälet att en borttappad panel ska få sina nät roterade.
+ *
+ * OTA rör aldrig NVS (docs/ota.md), så listan överlever varje uppdatering.
+ */
+
+#include <stdbool.h>
+
+#include "wifi_slots.h"
+
+/* Läser hela listan. Saknad eller trasig blob ger en nollad array — en
+ * panel utan minne är en panel som kör på secrets.h-botten, inte en panel
+ * som fallerar. */
+void tg_wifi_creds_load(tg_wifi_slot out[TG_WIFI_SLOTS]);
+
+/* Skriver ett nät på rätt plats (uppdaterar ett känt, vräker det äldsta
+ * när listan är full) och stämplar det som det senast lyckade. Validerar
+ * via wifi_slots innan något rör flashen. */
+bool tg_wifi_creds_remember(const char *ssid, const char *pass);
+
+/* Höjer seq för ett nät som just gett IP, så listan sorterar sig själv
+ * med det som faktiskt fungerar först. Okänt SSID (t.ex. hemnätet ur
+ * secrets.h) är en tyst no-op — botten ska aldrig hamna i NVS. */
+void tg_wifi_creds_mark_ok(const char *ssid);
+
+/* Antal ihågkomna nät just nu — bara för loggen vid boot. */
+int tg_wifi_creds_count(void);
+
+#endif

--- a/components/torget_wifi/wifi_form.c
+++ b/components/torget_wifi/wifi_form.c
@@ -1,0 +1,99 @@
+#include "wifi_form.h"
+
+#include <string.h>
+
+#include "wifi_slots.h"
+
+static int hex_nibble(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  return -1;
+}
+
+bool tg_wifi_url_decode(char *s) {
+  if (!s) return false;
+  char *out = s;
+  for (char *p = s; *p; p++) {
+    if (*p == '+') {
+      *out++ = ' ';
+    } else if (*p == '%') {
+      if (!p[1] || !p[2]) return false;
+      int hi = hex_nibble(p[1]);
+      int lo = hex_nibble(p[2]);
+      if (hi < 0 || lo < 0) return false;
+      /* %00 skulle klippa strängen mitt itu och göra resten osynlig för
+       * varje längdkontroll efteråt — samma trunkeringsfälla som NUL:en i
+       * agentnamnen 2026-08-13. Avvisa i stället för att smyga igenom. */
+      if (hi == 0 && lo == 0) return false;
+      *out++ = (char)((hi << 4) | lo);
+      p += 2;
+    } else {
+      *out++ = *p;
+    }
+  }
+  *out = '\0';
+  return true;
+}
+
+bool tg_wifi_form_field(const char *body, const char *name, char *out,
+                        size_t cap) {
+  if (!body || !name || !out || cap == 0) return false;
+  size_t namelen = strlen(name);
+
+  for (const char *p = body; *p;) {
+    const char *eq = strchr(p, '=');
+    const char *amp = strchr(p, '&');
+    if (!eq || (amp && eq > amp)) {
+      /* Ett par utan '=' är inget fält; hoppa till nästa om det finns. */
+      if (!amp) break;
+      p = amp + 1;
+      continue;
+    }
+    size_t keylen = (size_t)(eq - p);
+    const char *val = eq + 1;
+    size_t vallen = amp ? (size_t)(amp - val) : strlen(val);
+
+    if (keylen == namelen && strncmp(p, name, namelen) == 0) {
+      char raw[TG_WIFI_PASS_CAP * 3];
+      if (vallen >= sizeof raw) return false;
+      memcpy(raw, val, vallen);
+      raw[vallen] = '\0';
+      if (!tg_wifi_url_decode(raw)) return false;
+      size_t decoded = strlen(raw);
+      if (decoded >= cap) return false;
+      memcpy(out, raw, decoded + 1);
+      return true;
+    }
+    if (!amp) break;
+    p = amp + 1;
+  }
+  return false;
+}
+
+void tg_wifi_html_escape(const char *in, char *out, size_t cap) {
+  if (!out || cap == 0) return;
+  size_t o = 0;
+  if (!in) { out[0] = '\0'; return; }
+
+  for (const char *p = in; *p; p++) {
+    const char *rep = NULL;
+    size_t replen = 0;
+    switch (*p) {
+      case '&': rep = "&amp;";  replen = 5; break;
+      case '<': rep = "&lt;";   replen = 4; break;
+      case '>': rep = "&gt;";   replen = 4; break;
+      case '"': rep = "&quot;"; replen = 6; break;
+      default: break;
+    }
+    if (rep) {
+      if (o + replen >= cap) break;
+      memcpy(out + o, rep, replen);
+      o += replen;
+    } else {
+      if (o + 1 >= cap) break;
+      out[o++] = *p;
+    }
+  }
+  out[o] = '\0';
+}

--- a/components/torget_wifi/wifi_form.h
+++ b/components/torget_wifi/wifi_form.h
@@ -1,0 +1,32 @@
+#ifndef TORGET_WIFI_FORM_H
+#define TORGET_WIFI_FORM_H
+
+/*
+ * Setupportalens textkvarn: procentavkodning, fältplock ur en
+ * formulärkodad kropp och HTML-escape av namn som kommer utifrån.
+ *
+ * Ren kod utan ESP-IDF, värdtestad i test/run.sh (test_wifi_form.c). Det
+ * är HIT den fientliga indatan kommer — ett SSID i luften är någon annans
+ * sträng, och en trasig procentsekvens ska ge ett nej, inte en gissning
+ * (läxan 2026-08-13: "Upstream data is hostile").
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Avkodar procentkodning och '+' på plats. false = trasig indata; bufferten
+ * är då odefinierad och ska kastas, inte användas halvavkodad. */
+bool tg_wifi_url_decode(char *s);
+
+/* Kopierar det avkodade värdet för name ur en formulärkodad kropp.
+ * Längden mäts EFTER avkodningen — annars förkastas ett fullängds fält
+ * vars tecken råkar behöva kodas. false = fältet saknas eller får inte
+ * plats. Kroppen muteras inte. */
+bool tg_wifi_form_field(const char *body, const char *name, char *out,
+                        size_t cap);
+
+/* Escapar &, <, > och " så ett nätnamn inte kan bryta ut ur portalens
+ * HTML. Trunkerar hellre än spiller över; out NUL-termineras alltid. */
+void tg_wifi_html_escape(const char *in, char *out, size_t cap);
+
+#endif

--- a/components/torget_wifi/wifi_setup.c
+++ b/components/torget_wifi/wifi_setup.c
@@ -1,0 +1,509 @@
+#include "wifi_setup.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "lwip/sockets.h"
+
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_random.h"
+#include "esp_timer.h"
+#include "esp_wifi.h"
+#include "mbedtls/sha256.h"
+
+#include "ota_service.h"
+#include "secrets.h"
+#include "wifi_creds.h"
+#include "wifi_form.h"
+#include "wifi_setup_ui.h"
+#include "wifi_slots.h"
+
+static const char *TAG = "wifi-setup";
+
+#define AP_SSID     "VibePulse-setup"
+#define AP_ADDRESS  "192.168.4.1" /* esp_netif:s default för AP-gränssnittet */
+#define AP_CHANNEL  1
+#define AP_MAX_CONN 2
+
+/* Så många nät setupsidan listar. Fler än så är en rullningslista ingen
+ * orkar läsa, och listan bor i .bss — inte på en tasks stack. */
+#define SCAN_MAX 16
+
+static struct {
+  char ssid[SCAN_MAX][TG_WIFI_SSID_CAP];
+  int8_t rssi[SCAN_MAX];
+  int n;
+} s_scan;
+
+static const tg_wifi_setup_hooks *s_hooks;
+static httpd_handle_t s_server;
+static esp_netif_t *s_ap_netif;
+static char s_ap_pass[13]; /* 12 hex + NUL */
+
+/* Fönstrets tillstånd ägs av vakttasken; flaggorna korsar taskgränser och
+ * är därför atomära (samma disciplin som ota_service). */
+static atomic_bool s_open;
+static atomic_bool s_want_open;
+static atomic_bool s_want_close;
+static atomic_bool s_dns_stop;
+static _Atomic int64_t s_joined_at_us; /* satt av POST /join, läst av vakten */
+static char s_joined_ssid[TG_WIFI_SSID_CAP];
+
+/* ------------------------------------------------------ AP-lösenordet */
+
+/*
+ * Med TG_OTA_TOKEN i secrets.h HÄRLEDS lösenordet ur token, så
+ * tools/wifi-here.sh kan räkna fram exakt samma sträng på Macen och
+ * ansluta utan att någon läser av glaset. Det ger ingen ny behörighet:
+ * den som redan har token kan skriva firmware till panelen.
+ *
+ * Utan token blir lösenordet slumpat per fönster och finns bara på glaset.
+ * Domänsträngen gör härledningen skild från token självt — samma hemlighet,
+ * två separata nycklar.
+ */
+static void derive_ap_password(void) {
+#ifdef TG_OTA_TOKEN
+  static const char domain[] = "vibepulse-softap-v1";
+  unsigned char digest[32];
+  mbedtls_sha256_context ctx;
+  mbedtls_sha256_init(&ctx);
+  mbedtls_sha256_starts(&ctx, 0);
+  mbedtls_sha256_update(&ctx, (const unsigned char *)domain, sizeof domain - 1);
+  mbedtls_sha256_update(&ctx, (const unsigned char *)TG_OTA_TOKEN,
+                        strlen(TG_OTA_TOKEN));
+  mbedtls_sha256_finish(&ctx, digest);
+  mbedtls_sha256_free(&ctx);
+  for (int i = 0; i < 6; i++)
+    snprintf(s_ap_pass + i * 2, 3, "%02x", digest[i]);
+#else
+  for (int i = 0; i < 6; i++)
+    snprintf(s_ap_pass + i * 2, 3, "%02x", (unsigned)(esp_random() & 0xFF));
+#endif
+  s_ap_pass[12] = '\0';
+}
+
+/* ------------------------------------------------------------- skanning */
+
+static void scan_networks(void) {
+  s_scan.n = 0;
+  if (esp_wifi_scan_start(NULL, true) != ESP_OK) {
+    ESP_LOGW(TAG, "skanningen gick inte att starta");
+    return;
+  }
+  static wifi_ap_record_t ap[SCAN_MAX]; /* .bss, inte stacken */
+  uint16_t n = SCAN_MAX;
+  if (esp_wifi_scan_get_ap_records(&n, ap) != ESP_OK) return;
+
+  for (int i = 0; i < (int)n && s_scan.n < SCAN_MAX; i++) {
+    const char *ssid = (const char *)ap[i].ssid;
+    /* Dolda nät har tomt SSID och kan inte väljas ur en lista; ett SSID
+     * med styrtecken hör inte hemma i HTML:en (upstream är fientlig). */
+    if (!tg_wifi_ssid_valid(ssid)) continue;
+    bool dupe = false;
+    for (int j = 0; j < s_scan.n; j++)
+      if (strcmp(s_scan.ssid[j], ssid) == 0) dupe = true;
+    if (dupe) continue;
+    snprintf(s_scan.ssid[s_scan.n], TG_WIFI_SSID_CAP, "%s", ssid);
+    s_scan.rssi[s_scan.n] = ap[i].rssi;
+    s_scan.n++;
+  }
+
+  /* Starkast först. Nätet man står bredvid ska ligga överst i listan, inte
+   * på plats nio bland grannarnas — och det är panelens signalstyrka som
+   * gäller, inte telefonens. Insättningssortering på högst 16 poster. */
+  for (int i = 1; i < s_scan.n; i++) {
+    char ssid[TG_WIFI_SSID_CAP];
+    snprintf(ssid, sizeof ssid, "%s", s_scan.ssid[i]);
+    int8_t rssi = s_scan.rssi[i];
+    int j = i - 1;
+    while (j >= 0 && s_scan.rssi[j] < rssi) {
+      snprintf(s_scan.ssid[j + 1], TG_WIFI_SSID_CAP, "%s", s_scan.ssid[j]);
+      s_scan.rssi[j + 1] = s_scan.rssi[j];
+      j--;
+    }
+    snprintf(s_scan.ssid[j + 1], TG_WIFI_SSID_CAP, "%s", ssid);
+    s_scan.rssi[j + 1] = rssi;
+  }
+  ESP_LOGI(TAG, "setupfönstret ser %d nät", s_scan.n);
+}
+
+/* ------------------------------------------------------------ http-sidan */
+
+static const char PAGE_HEAD[] =
+    "<!doctype html><html><head><meta charset=\"utf-8\">"
+    "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+    "<title>VibePulse</title><style>"
+    "body{font-family:-apple-system,system-ui,sans-serif;background:#0b0b0c;"
+    "color:#eaeaea;margin:0;padding:28px 20px;max-width:420px}"
+    "h1{font-size:19px;letter-spacing:.08em;text-transform:uppercase}"
+    "p{color:#9298a2;font-size:14px;line-height:1.5}"
+    "select,input,button{font-size:17px;padding:12px;width:100%;"
+    "box-sizing:border-box;margin:6px 0;border-radius:10px;"
+    "border:1px solid #303238;background:#151517;color:#eaeaea}"
+    "button{background:#eaeaea;color:#0b0b0c;font-weight:600;border:0;"
+    "margin-top:14px}"
+    "</style></head><body><h1>VibePulse</h1>"
+    "<p>Pick the network this panel should join. It is remembered, so the "
+    "next time you are here it joins by itself.</p>"
+    "<form method=\"POST\" action=\"/join\">"
+    "<select name=\"ssid\">";
+
+static const char PAGE_TAIL[] =
+    "</select>"
+    "<input name=\"pass\" type=\"password\" autocapitalize=\"off\" "
+    "autocorrect=\"off\" placeholder=\"Password (leave blank if open)\">"
+    "<button type=\"submit\">Join</button></form></body></html>";
+
+static esp_err_t page_get(httpd_req_t *req) {
+  httpd_resp_set_type(req, "text/html");
+  httpd_resp_send_chunk(req, PAGE_HEAD, HTTPD_RESP_USE_STRLEN);
+
+  char escaped[TG_WIFI_SSID_CAP * 6 + 1];
+  char option[sizeof escaped + 64];
+  for (int i = 0; i < s_scan.n; i++) {
+    tg_wifi_html_escape(s_scan.ssid[i], escaped, sizeof escaped);
+    int len = snprintf(option, sizeof option, "<option>%s</option>", escaped);
+    if (len > 0) httpd_resp_send_chunk(req, option, (ssize_t)len);
+  }
+  if (s_scan.n == 0)
+    httpd_resp_send_chunk(req, "<option></option>", HTTPD_RESP_USE_STRLEN);
+
+  httpd_resp_send_chunk(req, PAGE_TAIL, HTTPD_RESP_USE_STRLEN);
+  httpd_resp_send_chunk(req, NULL, 0);
+  return ESP_OK;
+}
+
+static esp_err_t join_post(httpd_req_t *req) {
+  /* Taket är generöst mot ett långt SSID + PSK och snålt mot allt annat:
+   * kroppen bor på stacken i httpd-tasken. */
+  char body[320];
+  if (req->content_len <= 0 || req->content_len >= (int)sizeof body) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "body size");
+    return ESP_FAIL;
+  }
+  int got = httpd_req_recv(req, body, (size_t)req->content_len);
+  if (got <= 0) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "short body");
+    return ESP_FAIL;
+  }
+  body[got] = '\0';
+
+  char ssid[TG_WIFI_SSID_CAP] = {0};
+  char pass[TG_WIFI_PASS_CAP] = {0};
+  if (!tg_wifi_form_field(body, "ssid", ssid, sizeof ssid)) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "ssid missing");
+    return ESP_FAIL;
+  }
+  /* Lösenordet får saknas helt — det är ett öppet nät, inte ett fel. */
+  if (!tg_wifi_form_field(body, "pass", pass, sizeof pass)) pass[0] = '\0';
+
+  if (!tg_wifi_ssid_valid(ssid) || !tg_wifi_pass_valid(pass)) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid credentials");
+    return ESP_FAIL;
+  }
+  if (!tg_wifi_creds_remember(ssid, pass)) {
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "store failed");
+    return ESP_FAIL;
+  }
+
+  /* Vakten äger radion: den läser flaggan vid nästa poll och byter nät.
+   * Att koppla om härifrån vore att röra WiFi-stacken från httpd-tasken. */
+  snprintf(s_joined_ssid, sizeof s_joined_ssid, "%s", ssid);
+  atomic_store(&s_joined_at_us, esp_timer_get_time());
+
+  char escaped[TG_WIFI_SSID_CAP * 6 + 1];
+  tg_wifi_html_escape(ssid, escaped, sizeof escaped);
+  char page[sizeof escaped + 512];
+  snprintf(page, sizeof page,
+           "<!doctype html><html><head><meta charset=\"utf-8\"><title>VibePulse"
+           "</title></head><body style=\"font-family:-apple-system,system-ui,"
+           "sans-serif;background:#0b0b0c;color:#eaeaea;padding:28px\">"
+           "<h1 style=\"font-size:19px\">Joining %s</h1>"
+           "<p style=\"color:#9298a2\">Watch the panel. This network is "
+           "remembered.</p></body></html>",
+           escaped);
+  httpd_resp_set_type(req, "text/html");
+  httpd_resp_sendstr(req, page);
+  ESP_LOGI(TAG, "nya uppgifter för \"%s\" mottagna", ssid);
+  return ESP_OK;
+}
+
+/* Allt annat pekas tillbaka till sidan. Det är det som får iOS och Android
+ * att öppna portalen av sig själva i stället för att bara varna om att
+ * nätet saknar internet. */
+static esp_err_t catch_all_get(httpd_req_t *req) {
+  httpd_resp_set_status(req, "302 Found");
+  httpd_resp_set_hdr(req, "Location", "http://" AP_ADDRESS "/");
+  httpd_resp_send(req, NULL, 0);
+  return ESP_OK;
+}
+
+/* ------------------------------------------------------------------- dns */
+
+/*
+ * En DNS-lögnare som svarar 192.168.4.1 på ALLT. Bara medan fönstret är
+ * öppet, bara på accesspunktens eget nät — den lämnar aldrig glasets
+ * räckvidd, och utan den blir portalen en IP-adress man måste skriva av
+ * från skärmen.
+ */
+static void dns_task(void *arg) {
+  (void)arg;
+  int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (sock < 0) {
+    ESP_LOGW(TAG, "ingen DNS-socket — portalen nås via " AP_ADDRESS);
+    vTaskDelete(NULL);
+    return;
+  }
+  struct sockaddr_in addr = {
+    .sin_family = AF_INET,
+    .sin_port = htons(53),
+    .sin_addr.s_addr = htonl(INADDR_ANY),
+  };
+  struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof addr) < 0) {
+    ESP_LOGW(TAG, "DNS-porten kunde inte tas — portalen nås via " AP_ADDRESS);
+    close(sock);
+    vTaskDelete(NULL);
+    return;
+  }
+
+  uint8_t pkt[256];
+  while (!atomic_load(&s_dns_stop)) {
+    struct sockaddr_in from;
+    socklen_t fromlen = sizeof from;
+    int n = recvfrom(sock, pkt, sizeof pkt, 0, (struct sockaddr *)&from,
+                     &fromlen);
+    if (n < 12) continue; /* timeout eller för kort för ett DNS-huvud */
+
+    /* Bara vanliga frågor med exakt en fråga besvaras. Allt annat
+     * ignoreras hellre än gissas på. */
+    if ((pkt[2] & 0x80) != 0) continue;          /* redan ett svar */
+    if (pkt[4] != 0 || pkt[5] != 1) continue;    /* QDCOUNT != 1   */
+
+    /* Hoppa QNAME: längdprefixade etiketter fram till nollbyten. */
+    int p = 12;
+    while (p < n && pkt[p] != 0) {
+      if ((pkt[p] & 0xC0) != 0) { p = n; break; } /* pekare i en fråga */
+      p += pkt[p] + 1;
+    }
+    if (p >= n - 4) continue;
+    int qend = p + 1 + 4; /* nollbyte + QTYPE + QCLASS */
+    if (qend > n || qend + 16 > (int)sizeof pkt) continue;
+
+    pkt[2] = 0x84; /* QR=1, AA=1 */
+    pkt[3] = 0x00; /* ingen rekursion, ingen felkod */
+    pkt[6] = 0x00; pkt[7] = 0x01; /* ANCOUNT = 1 */
+    pkt[8] = 0x00; pkt[9] = 0x00; /* NSCOUNT = 0 */
+    pkt[10] = 0x00; pkt[11] = 0x00; /* ARCOUNT = 0 */
+
+    uint8_t *a = pkt + qend;
+    a[0] = 0xC0; a[1] = 0x0C;             /* pekare till frågans namn */
+    a[2] = 0x00; a[3] = 0x01;             /* TYPE A                   */
+    a[4] = 0x00; a[5] = 0x01;             /* CLASS IN                 */
+    a[6] = 0; a[7] = 0; a[8] = 0; a[9] = 60; /* TTL 60 s              */
+    a[10] = 0x00; a[11] = 0x04;           /* RDLENGTH 4               */
+    a[12] = 192; a[13] = 168; a[14] = 4; a[15] = 1;
+
+    sendto(sock, pkt, qend + 16, 0, (struct sockaddr *)&from, fromlen);
+  }
+  close(sock);
+  vTaskDelete(NULL);
+}
+
+/* --------------------------------------------------------------- fönstret */
+
+static void server_start(void) {
+  httpd_config_t cfg = HTTPD_DEFAULT_CONFIG();
+  cfg.server_port = 80;
+  cfg.lru_purge_enable = true;
+  cfg.max_uri_handlers = 4;
+  cfg.uri_match_fn = httpd_uri_match_wildcard;
+  cfg.stack_size = 4096;
+
+  if (httpd_start(&s_server, &cfg) != ESP_OK) {
+    ESP_LOGE(TAG, "http-servern startade inte — glaset visar ändå nätet");
+    s_server = NULL;
+    return;
+  }
+  static const httpd_uri_t root = {
+    .uri = "/", .method = HTTP_GET, .handler = page_get };
+  static const httpd_uri_t join = {
+    .uri = "/join", .method = HTTP_POST, .handler = join_post };
+  static const httpd_uri_t rest = {
+    .uri = "/*", .method = HTTP_GET, .handler = catch_all_get };
+  httpd_register_uri_handler(s_server, &root);
+  httpd_register_uri_handler(s_server, &join);
+  httpd_register_uri_handler(s_server, &rest);
+}
+
+static void window_open(void) {
+  /* Port 80 kan bara ha en ägare. Ett OTA-fönster utan nät kan ändå inte
+   * ta emot en uppladdning, så nätlagret vinner den konflikten — och
+   * säger det i loggen i stället för att tyst misslyckas. */
+  if (torget_ota_service_maintenance_open()) {
+    ESP_LOGI(TAG, "stänger OTA-fönstret: utan nät kan det inte leverera");
+    torget_ota_service_close_maintenance();
+    vTaskDelay(pdMS_TO_TICKS(1200)); /* låt OTA-vakten lämna tillbaka porten */
+  }
+
+  if (s_hooks->sta_pause) s_hooks->sta_pause(true);
+  esp_wifi_disconnect();
+  vTaskDelay(pdMS_TO_TICKS(200));
+
+  scan_networks();
+  derive_ap_password();
+
+  if (!s_ap_netif) s_ap_netif = esp_netif_create_default_wifi_ap();
+
+  wifi_config_t ap = {0};
+  snprintf((char *)ap.ap.ssid, sizeof ap.ap.ssid, "%s", AP_SSID);
+  ap.ap.ssid_len = (uint8_t)strlen(AP_SSID);
+  snprintf((char *)ap.ap.password, sizeof ap.ap.password, "%s", s_ap_pass);
+  ap.ap.channel = AP_CHANNEL;
+  ap.ap.max_connection = AP_MAX_CONN;
+  ap.ap.authmode = WIFI_AUTH_WPA2_PSK;
+
+  esp_err_t err = esp_wifi_set_mode(WIFI_MODE_APSTA);
+  if (err == ESP_OK) err = esp_wifi_set_config(WIFI_IF_AP, &ap);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "accesspunkten kom inte upp: %s", esp_err_to_name(err));
+    if (s_hooks->sta_pause) s_hooks->sta_pause(false);
+    return;
+  }
+
+  atomic_store(&s_dns_stop, false);
+  if (xTaskCreate(dns_task, "tg-wifi-dns", 3072, NULL, 4, NULL) != pdPASS)
+    ESP_LOGW(TAG, "DNS-lögnaren startade inte — portalen nås via " AP_ADDRESS);
+  server_start();
+
+  atomic_store(&s_open, true);
+  /* Lösenordet står på glaset, inte i loggen: den som läser serieloggen
+   * har redan kabeln, men loggen kan hamna i en bugrapport. */
+  ESP_LOGI(TAG, "setupfönstret öppet i tio minuter (%s)", AP_SSID);
+}
+
+static void window_close(void) {
+  if (s_server) {
+    httpd_stop(s_server);
+    s_server = NULL;
+  }
+  atomic_store(&s_dns_stop, true);
+  /* DNS-tasken vaknar ur sin sekundtimeout, ser flaggan och tar bort sig
+   * själv; sockeln stängs där, inte här. */
+  vTaskDelay(pdMS_TO_TICKS(1200));
+
+  esp_wifi_set_mode(WIFI_MODE_STA);
+  atomic_store(&s_open, false);
+  atomic_store(&s_joined_at_us, 0);
+  s_joined_ssid[0] = '\0';
+  if (s_hooks->sta_pause) s_hooks->sta_pause(false);
+  ESP_LOGI(TAG, "setupfönstret stängt");
+}
+
+/* ----------------------------------------------------------------- vakten */
+
+static void guard_task(void *arg) {
+  (void)arg;
+  int64_t no_ip_since = esp_timer_get_time();
+  int64_t opened_us = 0;
+  int64_t last_close_us = 0;
+  int64_t got_ip_us = 0;
+  bool applied = false;
+
+  for (;;) {
+    vTaskDelay(pdMS_TO_TICKS(500));
+
+    const int64_t now = esp_timer_get_time();
+    const bool have_ip = s_hooks->have_ip && s_hooks->have_ip();
+    const bool open = atomic_load(&s_open);
+
+    if (have_ip) {
+      /* Flanken false->true är den enda gången listan behöver skrivas om;
+       * att göra det varje halvsekund vore rent flashslitage. */
+      if (no_ip_since != 0 && s_hooks->ip_acquired) s_hooks->ip_acquired();
+      no_ip_since = 0;
+      if (open && got_ip_us == 0) got_ip_us = now;
+    } else if (no_ip_since == 0) {
+      no_ip_since = now;
+      got_ip_us = 0;
+    }
+
+    if (!open) {
+      bool asked = atomic_exchange(&s_want_open, false);
+      atomic_store(&s_want_close, false);
+      if (asked ||
+          tg_wifi_setup_should_open(have_ip, now, no_ip_since, last_close_us)) {
+        opened_us = now;
+        got_ip_us = 0;
+        applied = false;
+        window_open();
+        if (!atomic_load(&s_open)) { /* öppningen föll — försök inte i loop */
+          opened_us = 0;
+          last_close_us = now;
+        }
+      }
+    } else {
+      /* Uppgifter mottagna: bygg om kandidatlistan EN gång och släpp
+       * STA:n fri mot det nya nätet. */
+      if (!applied && atomic_load(&s_joined_at_us) != 0) {
+        applied = true;
+        if (s_hooks->sta_pause) s_hooks->sta_pause(false);
+        if (s_hooks->creds_changed) s_hooks->creds_changed(s_joined_ssid);
+      }
+      if (atomic_exchange(&s_want_close, false) ||
+          tg_wifi_setup_should_close(now, opened_us, got_ip_us)) {
+        window_close();
+        last_close_us = now;
+        opened_us = 0;
+      }
+    }
+
+    /* Glaset: nätlagret syns bara när det finns något att säga. En panel
+     * med IP har inget ärende här — då äger apparna skärmen. */
+    const bool now_open = atomic_load(&s_open);
+    if (have_ip && !now_open) {
+      torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
+    } else if (now_open && atomic_load(&s_joined_at_us) != 0) {
+      torget_wifi_ui_set(have_ip ? TG_WIFI_UI_JOINED : TG_WIFI_UI_JOINING,
+                         s_joined_ssid, NULL, NULL, 0);
+    } else if (now_open) {
+      int left = (int)((TG_WIFI_SETUP_WINDOW_US - (now - opened_us)) / 1000000);
+      torget_wifi_ui_set(TG_WIFI_UI_OPEN, AP_SSID, s_ap_pass, NULL, left);
+    } else if (tg_wifi_search_ui_visible(have_ip, now, no_ip_since)) {
+      /* Den ärliga nätsidan: vilket nät jagas, vad radion svarade, och hur
+       * länge det är kvar tills fönstret öppnar sig självt. Först efter
+       * TG_WIFI_SEARCH_UI_US — bootskärmen äger uppstarten. */
+      const char *ssid = s_hooks->current_ssid ? s_hooks->current_ssid() : NULL;
+      const char *reason = s_hooks->last_reason ? s_hooks->last_reason() : NULL;
+      int64_t until = TG_WIFI_SETUP_AUTO_US - (now - no_ip_since);
+      int left = until > 0 ? (int)(until / 1000000) : 0;
+      torget_wifi_ui_set(TG_WIFI_UI_SEARCHING, ssid, NULL, reason, left);
+    } else {
+      /* Kort svacka eller pågående boot: apparna behåller glaset. */
+      torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
+    }
+  }
+}
+
+void torget_wifi_setup_start(const tg_wifi_setup_hooks *hooks) {
+  if (!hooks) return;
+  s_hooks = hooks;
+  ESP_LOGI(TAG, "%d ihågkomna nät i NVS", tg_wifi_creds_count());
+  /* 5 kB, inte 4: vakten är den som får röra NVS åt värdlagret, och en
+   * hel slotlista är 600 byte på stacken innan NVS ens börjat. */
+  if (xTaskCreate(guard_task, "tg-wifi-setup", 5120, NULL, 4, NULL) != pdPASS)
+    ESP_LOGE(TAG, "setupvakten kunde inte skapas — nya nät kräver USB");
+}
+
+void torget_wifi_setup_request_open(void) { atomic_store(&s_want_open, true); }
+void torget_wifi_setup_request_close(void) { atomic_store(&s_want_close, true); }
+bool torget_wifi_setup_is_open(void) { return atomic_load(&s_open); }

--- a/components/torget_wifi/wifi_setup.c
+++ b/components/torget_wifi/wifi_setup.c
@@ -472,9 +472,19 @@ static void guard_task(void *arg) {
     }
 
     /* Glaset: nätlagret syns bara när det finns något att säga. En panel
-     * med IP har inget ärende här — då äger apparna skärmen. */
+     * med IP har inget ärende här — då äger apparna skärmen.
+     *
+     * OTA-overlayn har alltid företräde: efter en OTA-omstart utan nät är
+     * BÅDE underhållsfönstret (återväpnat av PENDING_VERIFY-booten) och
+     * nätsökningen aktiva, och båda lagren flyttar sig främst vid varje
+     * uppdatering — utan den här spärren flimrar de om förgrunden en gång
+     * i sekunden. Ringen vinner; nätsidan väntar tills fönstret stängt.
+     * Setupfönstret är undantaget: window_open() stängde OTA-fönstret för
+     * port 80, så konflikten kan inte uppstå där. */
     const bool now_open = atomic_load(&s_open);
-    if (have_ip && !now_open) {
+    if (!now_open && torget_ota_service_maintenance_open()) {
+      torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
+    } else if (have_ip && !now_open) {
       torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
     } else if (now_open && atomic_load(&s_joined_at_us) != 0) {
       torget_wifi_ui_set(have_ip ? TG_WIFI_UI_JOINED : TG_WIFI_UI_JOINING,

--- a/components/torget_wifi/wifi_setup.c
+++ b/components/torget_wifi/wifi_setup.c
@@ -117,18 +117,22 @@ static void scan_networks(void) {
 
   /* Starkast först. Nätet man står bredvid ska ligga överst i listan, inte
    * på plats nio bland grannarnas — och det är panelens signalstyrka som
-   * gäller, inte telefonens. Insättningssortering på högst 16 poster. */
+   * gäller, inte telefonens. Insättningssortering på högst 16 poster.
+   *
+   * memcpy, inte snprintf: raderna är fasta och åtskilda, men båda bor i
+   * s_scan och GCC:s restrict-analys avvisar (med rätta) en strängkopiering
+   * där käll- och målobjekt är samma. En radflytt är en blockkopia. */
   for (int i = 1; i < s_scan.n; i++) {
     char ssid[TG_WIFI_SSID_CAP];
-    snprintf(ssid, sizeof ssid, "%s", s_scan.ssid[i]);
+    memcpy(ssid, s_scan.ssid[i], TG_WIFI_SSID_CAP);
     int8_t rssi = s_scan.rssi[i];
     int j = i - 1;
     while (j >= 0 && s_scan.rssi[j] < rssi) {
-      snprintf(s_scan.ssid[j + 1], TG_WIFI_SSID_CAP, "%s", s_scan.ssid[j]);
+      memmove(s_scan.ssid[j + 1], s_scan.ssid[j], TG_WIFI_SSID_CAP);
       s_scan.rssi[j + 1] = s_scan.rssi[j];
       j--;
     }
-    snprintf(s_scan.ssid[j + 1], TG_WIFI_SSID_CAP, "%s", ssid);
+    memcpy(s_scan.ssid[j + 1], ssid, TG_WIFI_SSID_CAP);
     s_scan.rssi[j + 1] = rssi;
   }
   ESP_LOGI(TAG, "setupfönstret ser %d nät", s_scan.n);

--- a/components/torget_wifi/wifi_setup.c
+++ b/components/torget_wifi/wifi_setup.c
@@ -10,6 +10,7 @@
 
 #include "lwip/sockets.h"
 
+#include "esp_heap_caps.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_netif.h"
@@ -349,14 +350,37 @@ static void server_start(void) {
   httpd_register_uri_handler(s_server, &rest);
 }
 
+/* DMA-läget i loggen vid varje steg av öppningen: accesspunkten är den
+ * enda ytan i firmwaren vars minneskostnad aldrig mätts på hårdvara, och
+ * kilningen 2026-08-17 (första fysiska körningen) obducerades i blindo.
+ * Nästa incident ska peka ut exakt vilket steg som åt blocket. */
+static size_t dma_log(const char *stage) {
+  size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_DMA);
+  ESP_LOGI(TAG, "DMA största block %s: %u byte", stage, (unsigned)largest);
+  return largest;
+}
+
 static void window_open(void) {
+  /* GRIND 1, före allt: ryms accesspunkten utan att närma sig flushens
+   * DMA-tak? Ett vägrat fönster är en loggrad och ett nytt försök om en
+   * stund; en fryst panel är en USB-räddning. */
+  size_t largest = dma_log("före öppning");
+  if (!tg_wifi_setup_dma_ok_to_open(largest, s_hooks->flush_dma_bytes)) {
+    ESP_LOGW(TAG, "setupfönstret VÄGRAR öppna: DMA-blocket %u byte < "
+             "%d x flushens %u — hellre stängt än fryst glas",
+             (unsigned)largest, TG_WIFI_SETUP_DMA_OPEN_FACTOR,
+             (unsigned)s_hooks->flush_dma_bytes);
+    return;
+  }
+
   /* Port 80 kan bara ha en ägare. Ett OTA-fönster utan nät kan ändå inte
    * ta emot en uppladdning, så nätlagret vinner den konflikten — och
    * säger det i loggen i stället för att tyst misslyckas. */
   if (torget_ota_service_maintenance_open()) {
-    ESP_LOGI(TAG, "stänger OTA-fönstret: utan nät kan det inte leverera");
+    ESP_LOGI(TAG, "stänger OTA-fönstret: porten och minnet behövs här");
     torget_ota_service_close_maintenance();
     vTaskDelay(pdMS_TO_TICKS(1200)); /* låt OTA-vakten lämna tillbaka porten */
+    dma_log("efter OTA-stopp");
   }
 
   if (s_hooks->sta_pause) s_hooks->sta_pause(true);
@@ -365,6 +389,7 @@ static void window_open(void) {
 
   scan_networks();
   derive_ap_password();
+  dma_log("efter skanning");
 
   if (!s_ap_netif) s_ap_netif = esp_netif_create_default_wifi_ap();
 
@@ -380,6 +405,21 @@ static void window_open(void) {
   if (err == ESP_OK) err = esp_wifi_set_config(WIFI_IF_AP, &ap);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "accesspunkten kom inte upp: %s", esp_err_to_name(err));
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    if (s_hooks->sta_pause) s_hooks->sta_pause(false);
+    return;
+  }
+
+  /* GRIND 2, efter APSTA-bytet — den dyra biten. Föll blocket under x2 av
+   * flushen är NÄSTA flush i farozonen: riv hellre fönstret medan glaset
+   * fortfarande lever än fortsätt stapla httpd + DNS ovanpå. */
+  largest = dma_log("efter APSTA");
+  if (!tg_wifi_setup_dma_ok_to_continue(largest, s_hooks->flush_dma_bytes)) {
+    ESP_LOGE(TAG, "setupfönstret AVBRYTER: DMA-blocket %u byte < "
+             "%d x flushens %u efter AP-start — river innan glaset fryser",
+             (unsigned)largest, TG_WIFI_SETUP_DMA_ABORT_FACTOR,
+             (unsigned)s_hooks->flush_dma_bytes);
+    esp_wifi_set_mode(WIFI_MODE_STA);
     if (s_hooks->sta_pause) s_hooks->sta_pause(false);
     return;
   }
@@ -388,6 +428,7 @@ static void window_open(void) {
   if (xTaskCreate(dns_task, "tg-wifi-dns", 3072, NULL, 4, NULL) != pdPASS)
     ESP_LOGW(TAG, "DNS-lögnaren startade inte — portalen nås via " AP_ADDRESS);
   server_start();
+  dma_log("fönstret uppe");
 
   atomic_store(&s_open, true);
   /* Lösenordet står på glaset, inte i loggen: den som läser serieloggen

--- a/components/torget_wifi/wifi_setup.h
+++ b/components/torget_wifi/wifi_setup.h
@@ -1,0 +1,60 @@
+#ifndef TORGET_WIFI_SETUP_H
+#define TORGET_WIFI_SETUP_H
+
+/*
+ * Setupfönstret: panelen reser sin egen accesspunkt så ett nytt nät kan
+ * läggas till UTAN ombygge och USB-flashning. Fönstret är den enda vägen
+ * in — det finns ingen endpoint på det vanliga LAN:et som kan ändra
+ * nätverkslistan.
+ *
+ * Samtyckesmodellen ärvs från OTA (docs/ota.md), med en skillnad som är
+ * medveten: fönstret kan också öppna sig SJÄLVT efter TG_WIFI_SETUP_AUTO_US
+ * utan IP. Det försvagar ingenting — utan nät finns ingen fjärr som kunde
+ * ha öppnat det, och en panel på ett hotellrum ska inte kräva att man vet
+ * en hemlig gest för att bli användbar igen. Faktorerna är kvar:
+ *
+ *  1. Fysisk närvaro — accesspunktens lösenord står på glaset. Utan att se
+ *     skärmen (eller ha secrets.h på sin Mac) kommer ingen in.
+ *  2. Tid — fönstret stänger sig självt efter tio minuter, och allt minne
+ *     det kostade lämnas tillbaka. Http-servern och accesspunkten existerar
+ *     bara medan fönstret är öppet (lata ytan, frysläxan 2026-08-14).
+ *
+ * Fönstret kan ALDRIG skriva firmware. Det rör nätverkslistan i NVS och
+ * ingenting annat; OTA:s uppladdning har kvar sin egen grind och sitt eget
+ * token.
+ */
+
+#include <stdbool.h>
+
+typedef struct {
+  /* Har STA:n en IP just nu? Vakten frågar var halvsekund. */
+  bool (*have_ip)(void);
+  /* En uppkoppling lyckades just. Anropas från VAKTENS task, inte från
+   * event-loopen: det är här värdlagret får röra flashen (flytta upp nätet
+   * i listan) utan att blockera eventhanteringen eller spränga dess
+   * stack. Får vara NULL. */
+  void (*ip_acquired)(void);
+  /* Pausa STA-jakten medan radion skannar och håller accesspunkten. */
+  void (*sta_pause)(bool paused);
+  /* Nya uppgifter ligger i NVS: bygg om kandidatlistan och prova ssid NU. */
+  void (*creds_changed)(const char *ssid);
+  /* Nätet STA:n jagar just nu, för den ärliga nätsidan (får vara NULL). */
+  const char *(*current_ssid)(void);
+  /* Senaste frånkopplingsorsaken i klartext, eller NULL. */
+  const char *(*last_reason)(void);
+} tg_wifi_setup_hooks;
+
+/* Startar vakten. Hooks måste överleva anropet (statisk struct). */
+void torget_wifi_setup_start(const tg_wifi_setup_hooks *hooks);
+
+/* KEY3-hållets väg in. Vakten öppnar vid nästa poll. */
+void torget_wifi_setup_request_open(void);
+
+/* Kort KEY3-tryck medan fönstret är öppet: stäng i förtid. */
+void torget_wifi_setup_request_close(void);
+
+/* Äger nätlagret glaset just nu? main.c använder det för att avgöra vad
+ * ett KEY3-håll ska betyda. */
+bool torget_wifi_setup_is_open(void);
+
+#endif

--- a/components/torget_wifi/wifi_setup.h
+++ b/components/torget_wifi/wifi_setup.h
@@ -25,8 +25,13 @@
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct {
+  /* Panelflushens DMA-behov i byte (DISPLAY_FLUSH_ROWS x 480 x 2) — golvet
+   * DMA-grindarna mäter mot. 0 = grindarna vägrar öppna (hellre ett stängt
+   * fönster än en frusen panel). */
+  size_t flush_dma_bytes;
   /* Har STA:n en IP just nu? Vakten frågar var halvsekund. */
   bool (*have_ip)(void);
   /* En uppkoppling lyckades just. Anropas från VAKTENS task, inte från

--- a/components/torget_wifi/wifi_setup_ui.c
+++ b/components/torget_wifi/wifi_setup_ui.c
@@ -1,0 +1,190 @@
+#include "wifi_setup_ui.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "lvgl.h"
+
+#include "torget.h"
+
+/*
+ * Samma raster som OTA-ringen: äkta svart, lägesordet överst i
+ * attention-fonten, muted för det som är sammanhang och vitt för det som
+ * är svaret. Ingen provideraccent — det här är plattformens läge, inte en
+ * apps. Native fontstorlekar, aldrig transformer (lagerläxan 2026-08-16).
+ *
+ * Fontvalen mot verklig glyftäckning (platform/fonts/fetch-and-convert.sh):
+ * lägesordet i plex_attention_52 (bara versaler + mellanslag — därför är
+ * varje ord i state_word() A-Z), nätnamnet i plex_body_27 (full ASCII: ett
+ * SSID kan innehålla vad som helst), lösenordet i plex_mono_40 (mono, full
+ * ASCII — samma hjälte-mono som kommandoraden i Needs You) och de små
+ * raderna i plex_ui_21.
+ */
+
+extern const lv_font_t plex_attention_52;
+extern const lv_font_t plex_body_27;
+extern const lv_font_t plex_mono_40;
+extern const lv_font_t plex_ui_21;
+
+#define COL_MUTED lv_color_hex(0x9298A2) /* palette.muted */
+
+/* Innehållet hålls i en mittkolumn: glaset har klippta hörn, så text som
+ * söker kanterna tappar tecken (hörnlärdomen från brödsmulorna). */
+#define CONTENT_W 400
+
+static struct {
+  lv_obj_t *overlay;
+  lv_obj_t *word;      /* WIFI SETUP / NO NETWORK / JOINING / ON THE NET  */
+  lv_obj_t *lead;      /* liten muted rad ovanför nätnamnet               */
+  lv_obj_t *primary;   /* nätnamnet                                       */
+  lv_obj_t *secondary; /* setupfönstrets lösenord (mono)                  */
+  lv_obj_t *hint1;     /* "THEN OPEN 192.168.4.1"                         */
+  lv_obj_t *hint2;     /* "OR RUN tools/wifi-here.sh"                     */
+  lv_obj_t *detail;    /* ärlig orsaksrad                                 */
+  lv_obj_t *foot;      /* nedräkning + utgången                           */
+  tg_wifi_ui_state rendered_state;
+  char rendered_primary[64];
+  char rendered_secondary[32];
+  char rendered_detail[64];
+  int rendered_seconds;
+} ui;
+
+static lv_obj_t *line(lv_obj_t *parent, const lv_font_t *font, lv_color_t color,
+                      int y) {
+  lv_obj_t *label = lv_label_create(parent);
+  lv_obj_set_style_text_font(label, font, 0);
+  lv_obj_set_style_text_color(label, color, 0);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  /* Bredd + LV_LABEL_LONG_DOT: ett SSID kan vara 32 tecken och får
+   * klippas snyggt i stället för att spilla ut över de klippta hörnen. */
+  lv_obj_set_width(label, CONTENT_W);
+  lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);
+  lv_obj_align(label, LV_ALIGN_TOP_MID, 0, y);
+  lv_label_set_text(label, "");
+  return label;
+}
+
+void torget_wifi_ui_create(void) {
+  /* Topplagret, inte appträdet — samma regel som OTA-overlayn. Kallas
+   * under anroparens UI-lås. */
+  ui.overlay = lv_obj_create(lv_layer_top());
+  lv_obj_remove_style_all(ui.overlay);
+  lv_obj_set_size(ui.overlay, 480, 480);
+  lv_obj_set_pos(ui.overlay, 0, 0);
+  lv_obj_set_style_bg_color(ui.overlay, lv_color_black(), 0);
+  lv_obj_set_style_bg_opa(ui.overlay, LV_OPA_COVER, 0);
+  /* Slukar touch: fingret ska inte nå apparna bakom svart glas. Lagret
+   * bär medvetet INGEN knapp — allt som kan ändra nätet ska ske via
+   * accesspunkten, aldrig via en tapp som råkar landa fel. */
+  lv_obj_add_flag(ui.overlay, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_flag(ui.overlay, LV_OBJ_FLAG_HIDDEN);
+
+  ui.word = line(ui.overlay, &plex_attention_52, lv_color_white(), 52);
+  ui.lead = line(ui.overlay, &plex_ui_21, COL_MUTED, 140);
+  ui.primary = line(ui.overlay, &plex_body_27, lv_color_white(), 170);
+  ui.secondary = line(ui.overlay, &plex_mono_40, lv_color_white(), 214);
+  ui.hint1 = line(ui.overlay, &plex_ui_21, COL_MUTED, 278);
+  ui.hint2 = line(ui.overlay, &plex_ui_21, COL_MUTED, 306);
+  ui.detail = line(ui.overlay, &plex_ui_21, COL_MUTED, 214);
+  ui.foot = line(ui.overlay, &plex_ui_21, COL_MUTED, 396);
+
+  lv_obj_set_style_text_letter_space(ui.lead, 2, 0);
+  lv_obj_set_style_text_letter_space(ui.hint1, 2, 0);
+  lv_obj_set_style_text_letter_space(ui.hint2, 2, 0);
+  lv_obj_set_style_text_letter_space(ui.foot, 2, 0);
+
+  ui.rendered_state = TG_WIFI_UI_HIDDEN;
+}
+
+static const char *state_word(tg_wifi_ui_state state) {
+  /* Bara A-Z och mellanslag: plex_attention_52 bär inga andra glyfer. */
+  switch (state) {
+    case TG_WIFI_UI_SEARCHING: return "NO NETWORK";
+    case TG_WIFI_UI_OPEN:      return "WIFI SETUP";
+    case TG_WIFI_UI_JOINING:   return "JOINING";
+    case TG_WIFI_UI_JOINED:    return "ON THE NET";
+    default:                   return "";
+  }
+}
+
+static void show(lv_obj_t *obj, bool visible) {
+  if (visible) lv_obj_remove_flag(obj, LV_OBJ_FLAG_HIDDEN);
+  else lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+}
+
+static bool same(const char *rendered, const char *incoming) {
+  return strcmp(rendered, incoming ? incoming : "") == 0;
+}
+
+static void store(char *dst, size_t cap, const char *src) {
+  snprintf(dst, cap, "%s", src ? src : "");
+}
+
+void torget_wifi_ui_set(tg_wifi_ui_state state, const char *primary,
+                        const char *secondary, const char *detail,
+                        int seconds_left) {
+  if (!ui.overlay) return;
+  if (seconds_left < 0) seconds_left = 0;
+  if (seconds_left > 99 * 60 + 59) seconds_left = 99 * 60 + 59;
+
+  /* Tidsbegränsat lås: får vi inte UI-låset på 200 ms hoppar vi över den
+   * här bildrutan i stället för att blockera. Samma regel som
+   * torget_ota_ui_set — en vakt som står fast i ett evigt låsförsök var
+   * exakt så panelen frös 2026-08-14. */
+  if (!torget_ui_try_lock(200)) return;
+
+  /* Vakten pollar varje halvsekund och får inte invalidera pixlar som inte
+   * bytt värde. Nyckeln läses under låset. */
+  if (state == ui.rendered_state && same(ui.rendered_primary, primary) &&
+      same(ui.rendered_secondary, secondary) &&
+      same(ui.rendered_detail, detail) && seconds_left == ui.rendered_seconds) {
+    torget_ui_unlock();
+    return;
+  }
+  ui.rendered_state = state;
+  store(ui.rendered_primary, sizeof ui.rendered_primary, primary);
+  store(ui.rendered_secondary, sizeof ui.rendered_secondary, secondary);
+  store(ui.rendered_detail, sizeof ui.rendered_detail, detail);
+  ui.rendered_seconds = seconds_left;
+
+  if (state == TG_WIFI_UI_HIDDEN) {
+    lv_obj_add_flag(ui.overlay, LV_OBJ_FLAG_HIDDEN);
+    torget_ui_unlock();
+    return;
+  }
+
+  lv_label_set_text(ui.word, state_word(state));
+  lv_label_set_text(ui.primary, primary ? primary : "");
+  lv_label_set_text(ui.secondary, secondary ? secondary : "");
+  lv_label_set_text(ui.detail, detail ? detail : "");
+
+  const bool open = (state == TG_WIFI_UI_OPEN);
+  lv_label_set_text(ui.lead, open ? "JOIN THIS NETWORK" : "");
+  lv_label_set_text(ui.hint1, open ? "THEN OPEN  192.168.4.1" : "");
+  lv_label_set_text(ui.hint2, open ? "OR RUN  tools/wifi-here.sh" : "");
+
+  show(ui.lead, open);
+  show(ui.secondary, open && secondary && secondary[0]);
+  show(ui.hint1, open);
+  show(ui.hint2, open);
+  /* Orsaksraden och lösenordsraden delar y — bara ett av lägena har båda. */
+  show(ui.detail, !open && detail && detail[0]);
+
+  /* Foten: nedräkningen är ärlig data i båda lägena — kvarvarande lucktid
+   * när fönstret är öppet, tid kvar tills det öppnar sig självt när
+   * panelen letar. Utgången nämns bara när det finns en. */
+  if (seconds_left > 0) {
+    char foot[48];
+    snprintf(foot, sizeof foot, open ? "%02d:%02d   KEY3 CLOSES" : "%02d:%02d",
+             seconds_left / 60, seconds_left % 60);
+    lv_label_set_text(ui.foot, foot);
+  } else {
+    lv_label_set_text(ui.foot, open ? "KEY3 CLOSES" : "HOLD KEY3 FOR SETUP");
+  }
+
+  lv_obj_remove_flag(ui.overlay, LV_OBJ_FLAG_HIDDEN);
+  /* Framför apparna, men OTA-overlayn skapas EFTER det här lagret och
+   * hämtar sig själv längst fram i sin egen set() — READY-ringen vinner. */
+  lv_obj_move_foreground(ui.overlay);
+  torget_ui_unlock();
+}

--- a/components/torget_wifi/wifi_setup_ui.h
+++ b/components/torget_wifi/wifi_setup_ui.h
@@ -1,0 +1,42 @@
+#ifndef TORGET_WIFI_SETUP_UI_H
+#define TORGET_WIFI_SETUP_UI_H
+
+/*
+ * Glasets nätverkslager. Två jobb i ETT lager:
+ *
+ *  1. Den ärliga nätsidan. Utan nät visade panelen förut bara streck och
+ *     NO DATA, utan ett ord om varför (docs/agent-setup.md: "shows dashes
+ *     forever, with no error anywhere to tell you why"). Nu står det vilket
+ *     nät den jagar och vad radion faktiskt svarade.
+ *  2. Setupfönstret. När panelen rest sin egen accesspunkt står nätnamnet
+ *     och lösenordet i läsbar typ på glaset — det är den fysiska närvaron
+ *     som är grinden, precis som KEY3-hållet är det för OTA.
+ *
+ * Lagerordning: skapas på lv_layer_top FÖRE torget_ota_ui_create, så en
+ * OTA-omstarts READY-ring alltid vinner över nätlagret.
+ *
+ * Trådregel: set() tar UI-låset självt med samma 200 ms-tålamod som
+ * torget_ota_ui_set — anropas från setupvakten, aldrig LVGL-tasken.
+ */
+
+typedef enum {
+  TG_WIFI_UI_HIDDEN = 0,
+  TG_WIFI_UI_SEARCHING, /* inget nät än; fönstret är inte öppet          */
+  TG_WIFI_UI_OPEN,      /* accesspunkten uppe, väntar på uppgifter       */
+  TG_WIFI_UI_JOINING,   /* uppgifter mottagna, provar dem                */
+  TG_WIFI_UI_JOINED,    /* IP! lagret kliver av om ett ögonblick         */
+} tg_wifi_ui_state;
+
+void torget_wifi_ui_create(void);
+
+/*
+ * primary  — nätnamnet raden handlar om (jagat, erbjudet eller anslutet).
+ * secondary— setupfönstrets lösenord, eller NULL.
+ * detail   — en ärlig rad om varför det inte gick, eller NULL.
+ * seconds_left — nedräkning i foten; <= 0 döljer den.
+ */
+void torget_wifi_ui_set(tg_wifi_ui_state state, const char *primary,
+                        const char *secondary, const char *detail,
+                        int seconds_left);
+
+#endif

--- a/components/torget_wifi/wifi_slots.c
+++ b/components/torget_wifi/wifi_slots.c
@@ -119,6 +119,18 @@ bool tg_wifi_setup_should_open(bool have_ip, int64_t now_us,
   return true;
 }
 
+bool tg_wifi_setup_dma_ok_to_open(size_t largest_dma, size_t flush_bytes) {
+  /* flush_bytes == 0 vore en felkonfiguration som gjorde grinden till en
+   * papperstiger — behandla den som "vet inte" och vägra. */
+  if (flush_bytes == 0) return false;
+  return largest_dma / TG_WIFI_SETUP_DMA_OPEN_FACTOR >= flush_bytes;
+}
+
+bool tg_wifi_setup_dma_ok_to_continue(size_t largest_dma, size_t flush_bytes) {
+  if (flush_bytes == 0) return false;
+  return largest_dma / TG_WIFI_SETUP_DMA_ABORT_FACTOR >= flush_bytes;
+}
+
 bool tg_wifi_search_ui_visible(bool have_ip, int64_t now_us,
                                int64_t no_ip_since_us) {
   if (have_ip) return false;

--- a/components/torget_wifi/wifi_slots.c
+++ b/components/torget_wifi/wifi_slots.c
@@ -1,0 +1,136 @@
+#include "wifi_slots.h"
+
+#include <string.h>
+
+bool tg_wifi_ssid_valid(const char *ssid) {
+  if (!ssid) return false;
+  size_t n = strlen(ssid);
+  if (n < 1 || n > TG_WIFI_SSID_CAP - 1) return false;
+  for (size_t i = 0; i < n; i++) {
+    unsigned char c = (unsigned char)ssid[i];
+    /* Styrtecken och DEL kan aldrig komma från en riktig nätverksnamn-ruta;
+     * de kommer från en trasig klient eller ett försök att smuggla in en
+     * radbrytning i något som senare loggas. */
+    if (c < 0x20 || c == 0x7F) return false;
+  }
+  return true;
+}
+
+bool tg_wifi_pass_valid(const char *pass) {
+  if (!pass) return false;
+  size_t n = strlen(pass);
+  if (n == 0) return true; /* öppet nät */
+  if (n < 8 || n > TG_WIFI_PASS_CAP - 1) return false;
+  for (size_t i = 0; i < n; i++) {
+    unsigned char c = (unsigned char)pass[i];
+    if (c < 0x20 || c == 0x7F) return false;
+  }
+  return true;
+}
+
+int tg_wifi_slot_find(const tg_wifi_slot *slots, int n, const char *ssid) {
+  if (!slots || !ssid || !ssid[0]) return -1;
+  for (int i = 0; i < n; i++) {
+    if (slots[i].seq == 0 || slots[i].ssid[0] == '\0') continue;
+    if (strncmp(slots[i].ssid, ssid, TG_WIFI_SSID_CAP) == 0) return i;
+  }
+  return -1;
+}
+
+int tg_wifi_slot_for_write(const tg_wifi_slot *slots, int n, const char *ssid) {
+  if (!slots || n <= 0) return -1;
+
+  int existing = tg_wifi_slot_find(slots, n, ssid);
+  if (existing >= 0) return existing;
+
+  for (int i = 0; i < n; i++)
+    if (slots[i].seq == 0 || slots[i].ssid[0] == '\0') return i;
+
+  /* Fullt: vräk den som varit oanvänd längst. */
+  int oldest = 0;
+  for (int i = 1; i < n; i++)
+    if (slots[i].seq < slots[oldest].seq) oldest = i;
+  return oldest;
+}
+
+uint32_t tg_wifi_seq_next(const tg_wifi_slot *slots, int n) {
+  uint32_t max = 0;
+  for (int i = 0; i < n; i++)
+    if (slots[i].seq > max) max = slots[i].seq;
+  /* Mättnad, inte wrap: en seq som slår runt till 1 skulle göra den
+   * nyaste platsen till vräkningskandidat vid nästa nya nät. */
+  if (max == UINT32_MAX) return UINT32_MAX;
+  return max + 1;
+}
+
+static bool already_listed(const tg_wifi_slot *const *out, int n,
+                           const char *ssid) {
+  for (int i = 0; i < n; i++)
+    if (strncmp(out[i]->ssid, ssid, TG_WIFI_SSID_CAP) == 0) return true;
+  return false;
+}
+
+int tg_wifi_candidates(const tg_wifi_slot *remembered, int n_remembered,
+                       const tg_wifi_slot *fixed, int n_fixed,
+                       const tg_wifi_slot **out, int out_max) {
+  if (!out || out_max <= 0) return 0;
+  int n = 0;
+
+  /* Ihågkomna först, högst seq först. Urvalssortering på plats: listan är
+   * sex poster lång, så enkelheten är värd mer än ordo. */
+  if (remembered) {
+    for (;;) {
+      int best = -1;
+      for (int i = 0; i < n_remembered; i++) {
+        const tg_wifi_slot *s = &remembered[i];
+        if (s->seq == 0 || s->ssid[0] == '\0') continue;
+        if (already_listed(out, n, s->ssid)) continue;
+        if (best < 0 || s->seq > remembered[best].seq) best = i;
+      }
+      if (best < 0 || n >= out_max) break;
+      out[n++] = &remembered[best];
+    }
+  }
+
+  /* Sedan botten ur secrets.h, i sin ordning. */
+  if (fixed) {
+    for (int i = 0; i < n_fixed && n < out_max; i++) {
+      if (fixed[i].ssid[0] == '\0') continue;
+      if (already_listed(out, n, fixed[i].ssid)) continue;
+      out[n++] = &fixed[i];
+    }
+  }
+  return n;
+}
+
+bool tg_wifi_should_switch(int misses) {
+  return misses >= TG_WIFI_MISSES_BEFORE_SWITCH;
+}
+
+bool tg_wifi_setup_should_open(bool have_ip, int64_t now_us,
+                               int64_t no_ip_since_us, int64_t last_close_us) {
+  if (have_ip) return false;
+  if (no_ip_since_us <= 0) return false;
+  if (now_us - no_ip_since_us < TG_WIFI_SETUP_AUTO_US) return false;
+  /* Kylperioden gäller bara om ett fönster FAKTISKT stängts (0 = inget
+   * har stängts än, och då ska första öppningen inte fördröjas). */
+  if (last_close_us > 0 && now_us - last_close_us < TG_WIFI_SETUP_COOLDOWN_US)
+    return false;
+  return true;
+}
+
+bool tg_wifi_search_ui_visible(bool have_ip, int64_t now_us,
+                               int64_t no_ip_since_us) {
+  if (have_ip) return false;
+  if (no_ip_since_us <= 0) return false;
+  return now_us - no_ip_since_us >= TG_WIFI_SEARCH_UI_US;
+}
+
+bool tg_wifi_setup_should_close(int64_t now_us, int64_t opened_us,
+                                int64_t joined_ip_us) {
+  if (opened_us <= 0) return false;
+  if (now_us - opened_us >= TG_WIFI_SETUP_WINDOW_US) return true;
+  if (joined_ip_us > 0 && now_us - joined_ip_us >= TG_WIFI_SETUP_LINGER_US)
+    return true;
+  return false;
+}

--- a/components/torget_wifi/wifi_slots.h
+++ b/components/torget_wifi/wifi_slots.h
@@ -114,13 +114,21 @@ bool tg_wifi_search_ui_visible(bool have_ip, int64_t now_us,
  * system bakom (obducerat 2026-08-16, och huvudmisstänkt i kilningen
  * 2026-08-17 när accesspunkten kördes första gången på riktig hårdvara).
  *
- * ÖPPNA kräver x4: AP-läget, httpd:n och DNS-tasken ska få plats UTAN att
- * närma sig flushens tak. FORTSÄTT (mätt igen efter APSTA-bytet, den dyra
- * biten) kräver x2 — under det river vi hellre fönstret än fryser glaset.
- * Ett vägrat fönster är en loggrad och ett nytt försök senare; en fryst
- * panel är en USB-räddning.
+ * ÖPPNA kräver x3, FORTSÄTT (mätt igen efter APSTA-bytet, den dyra biten)
+ * kräver x2 — under det river vi hellre fönstret än fryser glaset. Ett
+ * vägrat fönster är en loggrad och ett nytt försök senare; en fryst panel
+ * är en USB-räddning.
+ *
+ * Kalibrering mot UPPMÄTT verklighet, inte känsla: v0.5.0:s friska
+ * baslinje på torget-home-01 är 40960-47104 byte största DMA-block
+ * (serielogg 2026-08-18). Den första faktorn var 4 — men 4 x 11520 =
+ * 46080 hade rutinmässigt vägrat en FRISK panel på 40 kB, och en grind
+ * som dödar funktionen den skyddar är fel grind. x3 = 34560 släpper
+ * baslinjen igenom med marginal; x2-avbrottet efter APSTA är samma
+ * tröskel som heap-larmet i main.c redan varnar vid. Faktorerna omprövas
+ * mot daa6bf1:s uppmätta tal när den övervakade körningen görs.
  */
-#define TG_WIFI_SETUP_DMA_OPEN_FACTOR  4
+#define TG_WIFI_SETUP_DMA_OPEN_FACTOR  3
 #define TG_WIFI_SETUP_DMA_ABORT_FACTOR 2
 
 bool tg_wifi_setup_dma_ok_to_open(size_t largest_dma, size_t flush_bytes);

--- a/components/torget_wifi/wifi_slots.h
+++ b/components/torget_wifi/wifi_slots.h
@@ -1,0 +1,116 @@
+#ifndef TORGET_WIFI_SLOTS_H
+#define TORGET_WIFI_SLOTS_H
+
+/*
+ * Nätverkslistans rena kärna: validering, platsval, vräkning och ordningen
+ * kandidaterna provas i. INGEN ESP-IDF här — filen värdtestas i
+ * test/run.sh (test_wifi_slots.c), precis som ota_policy och button_policy.
+ * Adaptrarna (wifi_creds.c mot NVS, wifi_setup.c mot radion) får röra
+ * hårdvara men aldrig bära ett beslut som inte redan är låst här.
+ *
+ * Modellen: panelen minns upp till TG_WIFI_SLOTS platser i NVS. Varje
+ * lyckad uppkoppling höjer platsens seq, så listan sorterar sig själv med
+ * det som senast fungerade först och vräker det som varit oanvänt längst
+ * när en ny plats ska in. Näten ur secrets.h är INTE med i NVS — de läggs
+ * sist som en oföränderlig botten, så ingen felkonfiguration någonsin kan
+ * göra hemnätet oåtkomligt och panelen ounderhållbar.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* 32 byte SSID och 63 byte WPA2-PSK är 802.11:s tak; +1 för NUL. */
+#define TG_WIFI_SSID_CAP 33
+#define TG_WIFI_PASS_CAP 64
+
+/* Sex ihågkomna platser: hem, kontor, telefonens hotspot och tre resor
+ * ryms utan att någon vräks. Blobben blir 6 x 101 byte — struntsumma i en
+ * NVS-partition på 64 kB. */
+#define TG_WIFI_SLOTS 6
+
+typedef struct {
+  char ssid[TG_WIFI_SSID_CAP];
+  char pass[TG_WIFI_PASS_CAP]; /* tom sträng = öppet nät */
+  uint32_t seq;                /* 0 = tom plats; högre = senare lyckad */
+} tg_wifi_slot;
+
+/* Missar i rad på ETT nät innan nästa kandidat provas. Fyra ≈ 10-15 s:
+ * snabbt nog för bilen, trögt nog att inte fladdra när hemnätet har en
+ * dålig stund (beslut 2026-08-07, oförändrat). */
+#define TG_WIFI_MISSES_BEFORE_SWITCH 4
+
+/* Setupfönstrets tider. AUTO: så länge utan IP innan glaset självt öppnar
+ * fönstret — långt nog att en routeromstart hemma aldrig hinner dit,
+ * kort nog att man inte står och väntar på ett hotellrum. COOLDOWN: paus
+ * efter ett stängt fönster så vakten inte tuggar upp och ner. WINDOW: tio
+ * minuter, samma tak som OTA-fönstret. LINGER: efter IP hålls AP:n kvar en
+ * stund så klienten hinner läsa svaret innan nätet byts under den. */
+#define TG_WIFI_SETUP_AUTO_US     (90LL * 1000000LL)
+#define TG_WIFI_SETUP_COOLDOWN_US (120LL * 1000000LL)
+#define TG_WIFI_SETUP_WINDOW_US   (600LL * 1000000LL)
+#define TG_WIFI_SETUP_LINGER_US   (5LL * 1000000LL)
+
+/* Så länge utan IP innan nätsidan tar glaset. Sextio sekunder är valt mot
+ * två grannar: bootskärmen äger de första 45 (den ger upp där, och två
+ * lager som slåss om samma pixlar hjälper ingen), och en router som startar
+ * om ska hinna tillbaka utan att hela skärmen svartnar. Efter det står
+ * apparnas NO DATA kvar bakom — men glaset säger också VARFÖR. */
+#define TG_WIFI_SEARCH_UI_US      (60LL * 1000000LL)
+
+/* 1-32 byte, inga styrtecken. SSID är en bytesträng, inte text: skiftläge
+ * är signifikant och jämförs exakt. */
+bool tg_wifi_ssid_valid(const char *ssid);
+
+/* Tom sträng (öppet nät) ELLER 8-63 skrivbara ASCII-tecken. En PSK som är
+ * kortare än 8 kan aldrig ha fungerat — att lagra den vore att spara en
+ * plats som garanterat aldrig ansluter. */
+bool tg_wifi_pass_valid(const char *pass);
+
+/* Index för ssid i listan, annars -1. Tomma platser hoppas över. */
+int tg_wifi_slot_find(const tg_wifi_slot *slots, int n, const char *ssid);
+
+/* Platsen ett nytt nät ska skrivas på: samma SSID om det redan finns
+ * (uppdatering, inte dubblett), annars första tomma, annars den med lägst
+ * seq — den som varit oanvänd längst. Returnerar alltid ett giltigt index
+ * för n > 0. */
+int tg_wifi_slot_for_write(const tg_wifi_slot *slots, int n, const char *ssid);
+
+/* Nästa seq att stämpla en lyckad uppkoppling med. Mättar vid UINT32_MAX
+ * i stället för att slå runt och göra den nyaste platsen till den äldsta. */
+uint32_t tg_wifi_seq_next(const tg_wifi_slot *slots, int n);
+
+/* Bygger provordningen: ihågkomna platser med högst seq först, därefter de
+ * fasta näten ur secrets.h i sin ordning. Tomma SSID hoppas över och ett
+ * SSID som redan lagts in tas inte igen — så ett hemnät som BÅDE står i
+ * secrets.h och hunnit hamna i NVS provas en gång, inte två. Pekarna i out
+ * pekar in i indataarrayerna; inget kopieras. Returnerar antalet. */
+int tg_wifi_candidates(const tg_wifi_slot *remembered, int n_remembered,
+                       const tg_wifi_slot *fixed, int n_fixed,
+                       const tg_wifi_slot **out, int out_max);
+
+/* Dags att byta kandidat? */
+bool tg_wifi_should_switch(int misses);
+
+/* Ska setupfönstret öppna sig självt? Sant först när panelen varit utan IP
+ * i TG_WIFI_SETUP_AUTO_US och inget fönster stängdes alldeles nyss. En
+ * panel med IP öppnar aldrig — då finns det inget att laga.
+ *
+ * no_ip_since_us: när nuvarande IP-lösa period började (0 = har IP nu).
+ * last_close_us: när förra fönstret stängdes (0 = inget har stängts). */
+bool tg_wifi_setup_should_open(bool have_ip, int64_t now_us,
+                               int64_t no_ip_since_us, int64_t last_close_us);
+
+/* Ska den ärliga nätsidan synas? Bara efter TG_WIFI_SEARCH_UI_US utan IP,
+ * så bootskärmen får äga uppstarten ostört och en kort routersvacka aldrig
+ * svartnar hela glaset. */
+bool tg_wifi_search_ui_visible(bool have_ip, int64_t now_us,
+                               int64_t no_ip_since_us);
+
+/* Ska ett öppet fönster stängas? Antingen har tiden runnit ut, eller så
+ * har uppkopplingen lyckats och klienten fått sina LINGER-sekunder.
+ * joined_ip_us: när IP:t kom under fönstret (0 = ingen uppkoppling än). */
+bool tg_wifi_setup_should_close(int64_t now_us, int64_t opened_us,
+                                int64_t joined_ip_us);
+
+#endif

--- a/components/torget_wifi/wifi_slots.h
+++ b/components/torget_wifi/wifi_slots.h
@@ -107,6 +107,25 @@ bool tg_wifi_setup_should_open(bool have_ip, int64_t now_us,
 bool tg_wifi_search_ui_visible(bool have_ip, int64_t now_us,
                                int64_t no_ip_since_us);
 
+/*
+ * DMA-grindarna för setupfönstret. Panelflushen behöver ETT sammanhängande
+ * DMA-block (flush_bytes); faller största fria blocket under det dör nästa
+ * flush i NO_MEM och hela ritpipen fastnar tyst — glaset fryser med levande
+ * system bakom (obducerat 2026-08-16, och huvudmisstänkt i kilningen
+ * 2026-08-17 när accesspunkten kördes första gången på riktig hårdvara).
+ *
+ * ÖPPNA kräver x4: AP-läget, httpd:n och DNS-tasken ska få plats UTAN att
+ * närma sig flushens tak. FORTSÄTT (mätt igen efter APSTA-bytet, den dyra
+ * biten) kräver x2 — under det river vi hellre fönstret än fryser glaset.
+ * Ett vägrat fönster är en loggrad och ett nytt försök senare; en fryst
+ * panel är en USB-räddning.
+ */
+#define TG_WIFI_SETUP_DMA_OPEN_FACTOR  4
+#define TG_WIFI_SETUP_DMA_ABORT_FACTOR 2
+
+bool tg_wifi_setup_dma_ok_to_open(size_t largest_dma, size_t flush_bytes);
+bool tg_wifi_setup_dma_ok_to_continue(size_t largest_dma, size_t flush_bytes);
+
 /* Ska ett öppet fönster stängas? Antingen har tiden runnit ut, eller så
  * har uppkopplingen lyckats och klienten fått sina LINGER-sekunder.
  * joined_ip_us: när IP:t kom under fönstret (0 = ingen uppkoppling än). */

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -63,7 +63,11 @@ cp secrets.h.example secrets.h
 
 Then edit `secrets.h`. Two separate things must be right:
 
-- `TG_WIFI_SSID` / `TG_WIFI_PASS` — their 2.4 GHz network.
+- `TG_WIFI_SSID` / `TG_WIFI_PASS` — their 2.4 GHz network. This one still
+  belongs here: it is the **immutable floor** the panel falls back to, and
+  the only network it knows before it has ever been anywhere. Every network
+  *after* the first is taught to the panel at the place itself, with no
+  rebuild — see [wifi.md](wifi.md).
 - **Replace `DIN-MAC` in `TK_VIBEPULSE_BASE_URL`** with their Mac's Bonjour
   name.
 
@@ -264,7 +268,10 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 | Screen boots, everything is dashes, forever | `DIN-MAC` never replaced in `secrets.h`, or the `TK_*` defines were removed | Set the real Bonjour name, rebuild, reflash |
 | Dashes, and the Mac's URL is set | tokenserver not running, or Mac asleep, or firewall | Start it; check `curl localhost:8737/` |
 | Dashes only for Claude, Codex fine (or vice versa) | That provider's source is unavailable | Check `claudeProbe`; the other half working is by design |
-| Never joins WiFi | Network is 5 GHz | 2.4 GHz only. iPhone hotspot: enable "Maximize Compatibility" |
+| Never joins WiFi | Network is 5 GHz | 2.4 GHz only. iPhone hotspot: enable "Maximize Compatibility". The glass names the reason itself after 60 s |
+| Moved to a new place; panel finds nothing | The new network was never taught to it | It raises `VibePulse-setup` after 90 s (or a 3 s KEY3 hold). Run `tools/wifi-here.sh` on the Mac, or join the AP from a phone. Remembered afterwards — [docs/wifi.md](wifi.md) |
+| `wifi-here.sh` cannot join the setup AP | The window is closed, or `TG_OTA_TOKEN` is missing so the password is random | Check the glass says WIFI SETUP; without a token run `TG_AP_PASS=<what the glass shows> tools/wifi-here.sh` |
+| Panel joined the venue WiFi but still shows dashes | Client isolation, or a captive portal the panel cannot pass | Not fixable on the device. Use the phone hotspot instead |
 | "This project has no OTA" / partitions.csv shows one factory partition | Reading a tree from before the OTA foundation (A/B slots + otadata + `components/torget_ota/`) | Check which branch/commit the checkout is on; read `partitions.csv` in THAT tree before concluding. OTA workflow: `tools/ota-flash.sh <ip>` + a 3 s KEY3 hold |
 | Panel shows stale quota / empty Fable weekly in the morning | Upstream 429 penalty from the shared account bucket | Self-heals: dead tokens are never resent, the penalty persists across restarts, deltas serve from cache. Check `claudeProbe` on `curl localhost:8737/` |
 | Panel shows stale while powered from the computer USB port | The Mac port cannot feed WiFi TX bursts — fetches time out | Expected on Mac USB; run from wall power. Logs stay valid on Mac USB, data does not |

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -89,10 +89,15 @@ scutil --get LocalHostName     # e.g. "Niclas-MacBook" -> Niclas-MacBook.local
 
 ```sh
 grep -q 'DIN-MAC' secrets.h && echo "PLACEHOLDER STILL THERE" || echo "hostname set"
+grep -nE 'http://[0-9]' secrets.h && echo "WARNING: raw IP in a URL" || echo "no raw IPs"
 ```
 
-prints `hostname set`. If it still says the placeholder is there, the board
-will look for a host that does not exist and every page will stay on dashes.
+prints `hostname set` and `no raw IPs`. If the placeholder is still there,
+the board will look for a host that does not exist and every page will stay
+on dashes. If the second line finds a raw IP: that is a snapshot of a DHCP
+lease, and it *will* go stale — it cost an entire evening of network
+debugging in the wrong direction before anyone read what the URL actually
+contained (`docs/lessons.md` 2026-08-17). Use the Bonjour name.
 
 Ask the user for the WiFi password. Do not guess it, and do not commit
 `secrets.h` — it is gitignored, keep it that way.

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,42 @@ point at the backlog item.
 
 ---
 
+## 2026-08-17 · A global auth threshold refused every open network
+
+**What happened:** on the road the panel would never join a café or
+airport network. The serial log showed the SSID being tried and a
+disconnect, with nothing pointing at why. **Root cause:**
+`wifi_apply()` set `cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK`
+for *every* network. The threshold means "refuse anything weaker", and
+open (`WIFI_AUTH_OPEN`) is weaker — so an open network was rejected
+before it was ever attempted. The line was written when there were
+exactly two networks, both WPA2; it silently became a policy about all
+future networks. **The rule:** a per-connection setting derived from
+one network's properties must move with the network, not sit as a
+global. Here the threshold now follows each candidate: WPA2 where there
+is a password, open where there is not. **Guards:**
+`wifi_apply_current()` in `main/main.c` derives it per slot;
+`tg_wifi_pass_valid` treats an empty password as a valid open network
+(`test/test_wifi_slots.c`). **Watch for:** any other `cfg.sta.*` field
+set once at boot that describes *a* network rather than *the* radio.
+
+## 2026-08-17 · The escape hatch needed the network it was escaping
+
+**What happened:** designing WiFi provisioning, the first instinct was
+to deliver it over the air like everything else. **Root cause:** OTA
+needs the network the panel cannot reach — a fix for "no network" can
+never arrive through the network, so the feature had to be recoverable
+from the device alone. **The rule now:** the compiled-in `secrets.h`
+networks stay an **immutable floor** that stored credentials can only be
+added on top of, never replace. No entry written at a hotel can strand
+the panel, so the worst case is "it does not join here", never "it needs
+a USB flash to come home". **Guards:**
+`tg_wifi_candidates()` always appends the fixed networks
+(`test/test_wifi_slots.c` has an explicit empty-store case);
+`test/test_wifi_setup_wiring.py` asserts the floor stays in the
+candidate build. **Watch for:** any future store that *replaces* a
+compiled-in fallback instead of layering over it.
+
 ## 2026-08-16 · LVGL's pool starved the flush's DMA and the glass froze
 
 **What happened:** the Needs You build froze the panel intermittently on

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,22 @@ point at the backlog item.
 
 ---
 
+## 2026-08-19 · `sdkconfig.defaults` did not migrate the existing LVGL pool
+
+**What happened:** v0.6 froze on any full redraw while the LVGL task held
+the adapter lock. JTAG caught the exact failure rendering `61%` with
+`plex_num_164`: LVGL rounded the 144×119 A4 glyph to a 144×128, 18,432-byte
+temporary buffer, its allocator returned NULL, and LVGL's default malloc
+assert entered `while(1)`. **Root cause:** the checked-in default had already
+moved the PSRAM-backed LVGL pool to 256 KiB, but the existing generated
+`sdkconfig` was still 96 KiB; defaults seed new configs and do not migrate old
+ones. The always-created v0.6 WiFi overlay made that stale budget fail.
+**The rule:** treat critical Kconfig values as build invariants, not defaults.
+**Guards:** root CMake now rejects LVGL pools below 256 KiB and
+`test_lvgl_memory_config.py` covers both sides. Verify the effective value in
+`build/config/sdkconfig.h`. **Watch for:** changing `sdkconfig.defaults`
+without regenerating or explicitly updating every existing build config.
+
 ## 2026-08-17 · The compiled-in IP address pointed at a network that no longer existed
 
 **What happened:** away from home, VibePulse showed dashes while

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,30 @@ point at the backlog item.
 
 ---
 
+## 2026-08-17 · The compiled-in IP address pointed at a network that no longer existed
+
+**What happened:** away from home, VibePulse showed dashes while
+Solelkollen on the same glass fetched happily. Hours of network
+debugging followed — IoT VLANs, client isolation, router admin — before
+the actual cause surfaced. **Root cause:** `TK_VIBEPULSE_BASE_URL` in
+`secrets.h` was a raw DHCP address (`http://192.168.1.50:8737`) from a
+network the Mac was no longer on. The runbook
+(`docs/agent-setup.md` step 1) had said to use the Bonjour name all
+along — "so the same binary works at home and on a phone hotspot" — but
+nothing *enforced* it, and an IP typed in once during setup worked for
+weeks before silently going stale. **The rule:** an address compiled
+into the firmware must be a *name*, never a number; a number is a
+snapshot of a DHCP lease. More generally: every compiled-in endpoint is
+the next travel failure — WiFi credentials were made data
+(`components/torget_wifi`), and the service address got a relay fallback
+(`net_source_policy`) for the reachability class no rename can fix.
+**Guards:** the runbook rule already existed; the relay fallback
+(`test_relay_boundary.py`) covers the cross-network case; no automated
+guard rejects a raw IP in `secrets.h` yet — a verify step in
+`docs/agent-setup.md` could `grep` for `http://[0-9]` and warn.
+**Watch for:** companion-app endpoints (`SG_GLANCE_URL` and friends)
+and any future `TK_*_URL` configured as an IP "just for now".
+
 ## 2026-08-17 · A global auth threshold refused every open network
 
 **What happened:** on the road the panel would never join a café or

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -39,9 +39,8 @@ the next travel failure — WiFi credentials were made data
 (`components/torget_wifi`), and the service address got a relay fallback
 (`net_source_policy`) for the reachability class no rename can fix.
 **Guards:** the runbook rule already existed; the relay fallback
-(`test_relay_boundary.py`) covers the cross-network case; no automated
-guard rejects a raw IP in `secrets.h` yet — a verify step in
-`docs/agent-setup.md` could `grep` for `http://[0-9]` and warn.
+(`test_relay_boundary.py`) covers the cross-network case; the verify step
+in `docs/agent-setup.md` step 1 now greps for `http://[0-9]` and warns.
 **Watch for:** companion-app endpoints (`SG_GLANCE_URL` and friends)
 and any future `TK_*_URL` configured as an IP "just for now".
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -39,21 +39,29 @@ command — `python3 tools/tokenserver/smoke.py` (exit 0 ok / 1 warnings /
 
 The only log the device has. ESP-IDF `ESP_LOGx` over the USB console —
 attach with `idf.py monitor -p /dev/cu.usbmodem101` (ESP-IDF env sourced).
-Five tags:
+Eleven tags:
 
 | Tag | Owner | Talks about |
 |-----|-------|-------------|
-| `torget` | `main/main.c` | boot, WiFi, SNTP, heap, brightness, MADCTL |
+| `torget` | `main/main.c` | boot, WiFi candidate hunt, SNTP, heap, brightness, MADCTL |
 | `rotation` | `main/rotation.c` | IMU reads, display rotation |
-| `torget-http` | `components/torget_net/torget_http.c` | every GET: error name, status, cap, URL |
+| `torget-http` | `components/torget_net/torget_http.c` | every GET: error name, status, cap, URL; `LAN svarade inte, provar reläet` when a fetch fails over to the relay |
 | `tokens` | `components/app_tokens/net.c` | /api/tokens + /api/max-tracker polls |
 | `agent-net` | `components/app_tokens/agent_net.c` | /api/agent-status poll (1 Hz, log rate-limited to 30 s) |
+| `github-net` | `components/app_tokens/github_net.c` | the optional /api/github poll |
+| `needs-you-net` | `components/app_tokens/needs_you_net.c` | signed verdict/panic POSTs (LAN only, never the relay) |
+| `boot-health` | `components/torget_ota/boot_health.c` | the 15 s boot-health gate: proofs landed, rollback verdicts |
+| `ota-service` | `components/torget_ota/ota_service.c` | maintenance window open/close, upload progress, image gates |
+| `wifi-setup` | `components/torget_wifi/wifi_setup.c` | setup window open/close, scan counts, received credentials (SSID only — passwords are never logged) |
+| `wifi-creds` | `components/torget_wifi/wifi_creds.c` | the remembered-network list in NVS: stores, rejects, corrupt-blob recovery |
 
 A healthy boot shows: the `boot:` banner (project name and git-describe
 version from the app descriptor, build date/time, IDF version, and the
 decoded reset reason — `strömpåslag` is normal; `PANIK`,
 `TASKVAKTHUND` or `BROWNOUT` mean the previous run died and this line is
-your only witness), the WiFi scan table (deliberately permanent — it is
+your only witness), `N ihågkomna nät i NVS` and `N nät i jaktlistan`
+(the remembered-network list and the candidate hunt — `docs/wifi.md`),
+the WiFi scan table (deliberately permanent — it is
 the ground truth for "which networks can the 2.4 GHz-only S3 actually
 see"), `WiFi uppe ("...")`, `tid synkad`, then steady-state `hämtning ok`
 lines every 30 s and a `heap:` line every 10 s.

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -41,8 +41,11 @@ Nothing can write firmware to the screen without three independent factors:
    *the window that can actually help*: **with an IP** it opens this OTA
    window, exactly as always; **without an IP** it opens the WiFi setup
    window instead, because an OTA window with no network can never
-   receive an upload. The consent model is unchanged — both windows
-   open only from the device.
+   receive an upload. A **second full 3 s hold** while this window is
+   open switches to the WiFi setup window (hold–hold: update window,
+   then network window); any release before three seconds still just
+   closes. The consent model is unchanged — both windows open only from
+   the device.
 2. **Knowledge** — the upload must carry `Authorization: Bearer <token>`,
    64 lowercase hex from `secrets.h` (`TG_OTA_TOKEN`), never committed.
 3. **Time** — the window closes itself after ten minutes; a short KEY3

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -36,6 +36,13 @@ Nothing can write firmware to the screen without three independent factors:
    compromised Mac cannot open it remotely. On the takeover, the UPDATE
    pill is the *only* yes — a tap anywhere else (including LATER)
    snoozes, so an accidental touch always lands on the safe side.
+
+   Since the WiFi setup window landed (`docs/wifi.md`), the hold opens
+   *the window that can actually help*: **with an IP** it opens this OTA
+   window, exactly as always; **without an IP** it opens the WiFi setup
+   window instead, because an OTA window with no network can never
+   receive an upload. The consent model is unchanged — both windows
+   open only from the device.
 2. **Knowledge** — the upload must carry `Authorization: Bearer <token>`,
    64 lowercase hex from `secrets.h` (`TG_OTA_TOKEN`), never committed.
 3. **Time** — the window closes itself after ten minutes; a short KEY3
@@ -76,6 +83,15 @@ compares against its own running version:
   calms down) until the update is installed.
 - **Match** → silence. The notice can never nag about nothing.
 - A busy device (open window, running transfer) is never taken over.
+
+Two windows, one port: the OTA window and the WiFi setup window both
+serve HTTP on port 80, so only one can exist at a time. If the setup
+window needs to open while an OTA window is standing open, it closes the
+OTA window first (an OTA window with no network could never receive an
+upload anyway) — the log says so. On the glass the OTA overlay always
+outranks the network screens: after an OTA reboot with no network, the
+re-armed READY ring owns the display and the network-search screen waits
+for the window to close.
 
 The nag rhythm lives in `components/torget_ota/notice_policy.c`, a pure
 host-tested module (`test/test_ota_notice_policy.c`).

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -1,0 +1,105 @@
+# The relay — numbers from anywhere, activity never
+
+The panel could only fetch from the tokenserver when both sat on the same
+LAN. One evening away from home proved how brittle that is: client
+isolation, an IoT VLAN and a drifted IP each blanked the glass while
+internet worked fine (`docs/lessons.md`, 2026-08-17 — three entries from
+the same evening). The relay removes the *same-LAN* requirement without
+touching what made the system trustworthy: no key ever leaves your
+machines, and nothing that names your work goes online.
+
+## The shape
+
+```
+ Mac (sleeps sometimes)  ──POST──►┐
+                                  ├──►  mailbox (Cloudflare Worker + KV,
+ PC (always on)          ──POST──►┘     your account, ~150 lines)
+                                              │
+                                              ▼  GET, any WiFi anywhere
+                                          the panel
+```
+
+Both machines run the same tokenserver with the same flag:
+
+```sh
+python3 tools/tokenserver/tokenserver.py --publish "https://.../u/<secret>"
+```
+
+The panel keeps its LAN URL as the primary source and falls back to the
+mailbox only when the LAN does not answer (`net_source_policy`, host-
+tested). At home nothing crosses the internet; the moment the LAN dies —
+travel, a sleeping Mac, a VLAN boundary — the numbers keep flowing.
+
+## The boundary: numbers, never activity
+
+Held from three directions — firmware (`test/test_relay_boundary.py`),
+service (`publisher.py` has no producers for the activity endpoints), and
+the Worker (it only accepts the three number paths):
+
+| Over the relay | LAN only, forever |
+|---|---|
+| `/api/tokens` — quota, burn rate | `/api/agent-status` — project names |
+| `/api/max-tracker` — history | Needs You — question text, commands |
+| `/api/github` — public repo stats | the device key's answer path |
+
+The reason is the mailbox's trust model: access control is a secret URL —
+the same level as a private share link. Right for percentages; wrong for
+anything that names what you are working on. And a signed verdict in
+public storage would be an instruction, not a number — so the panel can
+answer a prompt at home, never through a mailbox.
+
+## Multi-publisher: freshest wins per pool
+
+Every quota pool already carries its own observation stamp
+(`weekObservedAt`, `modelObservedAt`, … — built for the staleness logic).
+The mailbox merges on read using exactly those stamps: Claude numbers come
+from whichever machine asked Anthropic most recently; Codex from whichever
+machine ran Codex last. No primary machine, nothing to configure — run the
+publisher on both, the stamps sort it out (`tools/relay/test.mjs` holds
+the merge still).
+
+Honest limits:
+
+- **Codex follows the CLI.** The numbers are account-wide but they are
+  *written* only where Codex CLI runs. Mobile Codex use appears at the
+  next CLI run on a publishing machine.
+- **Max Tracker history is per machine** — the newest publisher's document
+  wins whole. Day-by-day merging across machines would invent data no
+  machine has seen.
+- **A dark LAN means a quiet agent row.** Agent status never crosses, so
+  away from home the panel is a numbers display. By design, not by gap.
+
+## Setup
+
+Deploy the Worker (once): [tools/relay/README.md](../tools/relay/README.md).
+Then:
+
+1. `--publish "https://.../u/<secret>"` on each machine that should feed
+   the mailbox. On Windows, register it to survive reboots:
+   `tools/tokenserver/install-windows-task.ps1 -PublishUrl "..."`
+   (closes issue #3's autostart gap).
+2. `TK_VIBEPULSE_RELAY_URL` in `secrets.h`, build, one OTA.
+
+## What the glass shows away from home
+
+| | |
+|---|---|
+| Claude quota + reset countdown | live — account-wide, any machine's probe sees everything |
+| Burn rate, value multiple, Max Tracker | live |
+| GitHub pulse | live |
+| Codex quota | live while a publishing machine runs Codex |
+| Agent row, NEEDS YOU | dark — activity never crosses the relay |
+
+## Decisions worth remembering
+
+- **The Anthropic probe's User-Agent is unchanged.** The publisher wears
+  an honest `vibepulse-publisher/1` toward the mailbox (test-enforced),
+  but the quota probe still presents itself as claude-cli. Changing that
+  risks the probe against an undocumented endpoint and needs a live test —
+  a deliberate, separate decision, not an oversight.
+- **Write economy is load-bearing.** Send-on-change + 5-minute heartbeat
+  keeps two publishers comfortably inside KV's 1 000 free writes/day.
+  A "simpler" always-send loop would exhaust it by mid-afternoon.
+- **The mailbox is disposable.** It holds only the latest few JSON bodies.
+  Delete the Worker and the panel falls back to LAN-only behaviour;
+  rotate the secret by redeploying and updating two places.

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -101,8 +101,17 @@ A 3 s hold opens **the window that can actually help**:
 - **Without an IP** → the WiFi setup window. An OTA window with no network
   could never receive an upload anyway.
 
-While either window owns the glass, *any* KEY3 release closes it — the same
-escape hatch the OTA window grew after 2026-08-16.
+**Hold again to switch windows.** A second full 3 s hold while the update
+window is open closes it and opens WIFI SETUP instead. That is how you
+teach a panel that already *has* a network a new one — pre-loading the
+phone hotspot at home before a trip, for instance — without waiting for it
+to be stranded first. The port-80 handover is owned by the setup guard, so
+the two HTTP servers never collide.
+
+While either window owns the glass, *any* KEY3 release before three
+seconds closes it — the same escape hatch the OTA window grew after
+2026-08-16. Only a deliberate, completed hold switches; you cannot fail
+to close by pressing.
 
 ## Where the credentials live
 

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -161,16 +161,25 @@ Per `spec/hardware.md`'s rule about claiming hardware truth:
 | Capability | Silicon | Board | Firmware | Verified on `torget-home-01` |
 |---|---|---|---|---|
 | 2.4 GHz station mode | yes | yes | yes | yes (2026-08-06) |
-| SoftAP / APSTA | yes | yes | **yes (new)** | **not yet** |
+| SoftAP / APSTA | yes | yes | yes | **first run WEDGED the panel (2026-08-17)** |
 | NVS read/write | yes | yes | yes | yes (boot-health probe) |
 
-SoftAP shares the radio and antenna that `radio.wifi-24` already lists as
-`unit_verified: yes`, and the registry has carried "SoftAP maintenance" as
-an opportunity for that capability since the recon. Running the access
-point on the physical unit — and measuring what it costs the internal DMA
-heap while it is up — is the open item. Watch the existing heap telemetry
-(`heap: internt ... DMA största ...`, every 10 s) with a window open before
-calling it done.
+The warning this table used to carry — that the access point's cost to the
+internal DMA heap was unmeasured — was borne out the first time the window
+opened on the physical unit: the panel wedged twice (both after a KEY3
+hold-hold during a post-OTA maintenance window) and was rolled back over
+USB. Suspected mechanism: the AP + second HTTP server + DNS task starved
+the flush's contiguous DMA block — the exact 2026-08-16 freeze anatomy —
+but the serial log from the incident is the judge, not this guess.
+
+Since then `window_open()` is bracketed by two host-tested DMA gates
+(`tg_wifi_setup_dma_ok_to_open` / `_continue`): it refuses to open unless
+the largest free DMA block clears 4x the flush, aborts and tears down if
+the post-APSTA measurement falls under 2x, and logs the largest block at
+every stage so the next incident names the hungry step. **The gates are
+defensive, not a verification** — the setup window remains unproven on
+hardware until a supervised run (serial monitor attached, USB recovery at
+hand) passes with the DMA telemetry healthy.
 
 ## Files
 

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -1,0 +1,169 @@
+# WiFi on the road — how the panel follows you
+
+The panel used to carry exactly two networks, both compiled into
+`secrets.h`. A new place meant editing a header, rebuilding, and flashing
+over USB — and OTA could not help, because OTA needs the network the panel
+cannot reach. This is the reference for what replaced that.
+
+## The short version
+
+```
+new place, panel finds nothing
+        │
+        ├─ 60 s ─► the glass says WHY (network hunted, radio's own reason)
+        │
+        ├─ 90 s ─► the panel raises VibePulse-setup and shows its password
+        │          (a 3 s KEY3 hold opens the same window immediately)
+        │
+        ├─ from the Mac:    tools/wifi-here.sh        ← nothing to type
+        └─ from a phone:    join the AP, portal opens ← type on a real keyboard
+                │
+                └─► remembered in NVS. Next time you are here, it just joins.
+```
+
+Six places are remembered. The one that worked most recently is tried
+first, and the least recently working one is evicted when a seventh
+arrives. The networks in `secrets.h` are appended underneath as an
+**immutable floor**: the setup window can add places, never remove your
+home network. That is what keeps a bad entry from turning into a USB
+rescue.
+
+## What actually changed on the road
+
+Four things about travel that the old firmware got wrong:
+
+| Before | Now |
+|---|---|
+| Two networks, compile-time | Six remembered in NVS + the compiled-in floor |
+| `threshold.authmode = WIFI_AUTH_WPA2_PSK` for every network — open café networks were refused in silence | The threshold follows each network: open where the password is blank |
+| No network → dashes forever, no reason anywhere | The glass names the network it is hunting and what the radio answered |
+| A new place meant rebuild + USB flash | One command on the Mac, or a phone and the panel's own portal |
+
+## The two ways in
+
+### From the Mac — `tools/wifi-here.sh`
+
+One command. It reads the Mac's current SSID, pulls that network's password
+out of the **system keychain** (macOS prompts you — that prompt is the
+consent), hops to the panel's access point, hands the credentials over, and
+releases the Mac's WiFi. The Mac is offline for roughly twenty seconds.
+
+The access point's password is **derived** from `TG_OTA_TOKEN` in
+`secrets.h` — `sha256("vibepulse-softap-v1" + token)`, first 12 hex
+characters — so the script computes it without reading anything off the
+glass. This grants nothing new: whoever holds that token can already write
+firmware to the panel. Without the token the password is random per window
+and lives only on the screen; pass it in explicitly:
+
+```sh
+TG_AP_PASS=<what the glass shows> tools/wifi-here.sh
+```
+
+`test/test_wifi_setup_wiring.py` asserts the domain string, the digest
+length and the AP name match between the firmware and the script. They
+cannot drift apart silently.
+
+### From a phone — the portal
+
+Join `VibePulse-setup` with the password shown on the glass. The panel runs
+a DNS responder that answers every query with its own address, so iOS and
+Android pop the captive portal by themselves; if yours does not, open
+`http://192.168.4.1/`. The page lists what the panel can see — **strongest
+first, and it is the panel's radio that decides**, which is the whole point
+when a phone shows five bars on a 5 GHz band the ESP32-S3 cannot hear.
+
+## The consent model
+
+The OTA window's three factors (physical presence, knowledge, time) are
+unchanged. The setup window inherits two of them and deliberately relaxes
+one:
+
+1. **Physical presence** — the access point's password is on the glass.
+   Whoever cannot see the screen (or hold `secrets.h` on their Mac) cannot
+   get in.
+2. **Time** — ten minutes, then it closes itself and hands back every byte
+   it cost. The AP, the HTTP server and the DNS task do not exist outside
+   an open window (the lazy-surface rule from the 2026-08-14 freeze).
+3. **The window may open itself** after 90 s without an IP. This weakens
+   nothing: with no network there is no remote that could have opened it,
+   and a panel in a hotel room should not require knowing a secret gesture
+   to become useful again.
+
+**The setup window can never write firmware.** It touches the network list
+in NVS and nothing else; OTA keeps its own gate and its own token. The
+wiring test asserts no OTA symbol ever appears in `wifi_setup.c`.
+
+### What KEY3 means now
+
+A 3 s hold opens **the window that can actually help**:
+
+- **With an IP** → the OTA maintenance window, exactly as before.
+- **Without an IP** → the WiFi setup window. An OTA window with no network
+  could never receive an upload anyway.
+
+While either window owns the glass, *any* KEY3 release closes it — the same
+escape hatch the OTA window grew after 2026-08-16.
+
+## Where the credentials live
+
+NVS, one blob, namespace `tgwifi`, key `slots`. One write, one commit — no
+half-written list if power drops mid-save. A blob of the wrong size is
+treated as empty rather than parsed at the wrong offsets, so an older or
+newer format degrades to "run on the `secrets.h` floor" instead of
+misreading.
+
+**NVS is not encrypted.** The passwords sit in flash in the clear. That is
+the same exposure `secrets.h` already had (the README says it plainly: a
+lost screen leaks your WiFi password) — not a new class of risk, but the
+reason a lost panel means rotating those networks. OTA never writes NVS, so
+the list survives every update.
+
+## What this does *not* fix
+
+Being honest about travel networks, because the failure modes are not
+firmware bugs:
+
+- **Captive portals.** The panel cannot click "I agree". Most hotel and
+  café networks stay out of reach no matter how easy joining them is.
+- **Client isolation.** Plenty of guest networks block device-to-device
+  traffic, so the panel associates fine and still cannot reach
+  `your-mac.local:8737`.
+- **WPA2-Enterprise.** Office and campus networks with a username are not
+  handled.
+- **5 GHz.** Still invisible to the ESP32-S3, forever. The setup portal's
+  list is the panel's own truth about what exists.
+
+**The network that always works on the road is the one you bring.** Turn on
+the phone hotspot (iPhone: *Maximize Compatibility*, or it broadcasts only
+5 GHz), put the Mac on it, and run `tools/wifi-here.sh` once. The panel
+remembers the hotspot from then on and rejoins it in every city.
+
+## Physical verification status
+
+Per `spec/hardware.md`'s rule about claiming hardware truth:
+
+| Capability | Silicon | Board | Firmware | Verified on `torget-home-01` |
+|---|---|---|---|---|
+| 2.4 GHz station mode | yes | yes | yes | yes (2026-08-06) |
+| SoftAP / APSTA | yes | yes | **yes (new)** | **not yet** |
+| NVS read/write | yes | yes | yes | yes (boot-health probe) |
+
+SoftAP shares the radio and antenna that `radio.wifi-24` already lists as
+`unit_verified: yes`, and the registry has carried "SoftAP maintenance" as
+an opportunity for that capability since the recon. Running the access
+point on the physical unit — and measuring what it costs the internal DMA
+heap while it is up — is the open item. Watch the existing heap telemetry
+(`heap: internt ... DMA största ...`, every 10 s) with a window open before
+calling it done.
+
+## Files
+
+| Path | What it owns |
+|---|---|
+| `components/torget_wifi/wifi_slots.c` | Pure policy: validation, eviction, candidate order, window timing. Host-tested. |
+| `components/torget_wifi/wifi_form.c` | Pure parsing: percent-decoding, form fields, HTML escaping. Host-tested. |
+| `components/torget_wifi/wifi_creds.c` | The NVS blob, and nothing else. |
+| `components/torget_wifi/wifi_setup.c` | The window: AP, portal, DNS responder, guard task. |
+| `components/torget_wifi/wifi_setup_ui.c` | The glass: the honest network screen and the setup screen. |
+| `main/main.c` | Still owns the radio. Builds the candidate list, routes KEY3. |
+| `tools/wifi-here.sh` | The Mac's one command. |

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -174,7 +174,7 @@ but the serial log from the incident is the judge, not this guess.
 
 Since then `window_open()` is bracketed by two host-tested DMA gates
 (`tg_wifi_setup_dma_ok_to_open` / `_continue`): it refuses to open unless
-the largest free DMA block clears 4x the flush, aborts and tears down if
+the largest free DMA block clears 3x the flush (calibrated against the measured healthy baseline of 40-47 kB on v0.5.0), aborts and tears down if
 the post-APSTA measurement falls under 2x, and logs the largest block at
 every stage so the next incident names the hungry step. **The gates are
 defensive, not a verification** — the setup window remains unproven on

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -138,6 +138,13 @@ the phone hotspot (iPhone: *Maximize Compatibility*, or it broadcasts only
 5 GHz), put the Mac on it, and run `tools/wifi-here.sh` once. The panel
 remembers the hotspot from then on and rejoins it in every city.
 
+For the reachability half of these failure modes — the panel is *online*
+but cannot reach the service across a network boundary — the relay
+fallback exists (`TK_VIBEPULSE_RELAY_URL` in `secrets.h.example`): number
+fetches fall back to a mailbox on the internet when the LAN service does
+not answer. Panel-side only so far; inert until the service's publisher
+ships.
+
 ## Physical verification status
 
 Per `spec/hardware.md`'s rule about claiming hardware truth:

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -6,7 +6,9 @@
 # utcheckade dras komponenten in och TORGET_HAVE_* grindar registerposten i
 # registry.c. En färsk klon utifrån bygger bara VibePulse.
 # torget_ota: bootens hälsogrind (boot_health.h) och KEY3:s underhållshåll.
-set(TORGET_MAIN_REQUIRES torget_app app_tokens torget_ota)
+# torget_wifi: nätverkslistan i NVS + setupfönstret som lägger till en ny
+# plats utan ombygge (docs/wifi.md).
+set(TORGET_MAIN_REQUIRES torget_app app_tokens torget_ota torget_wifi)
 # OBS $ENV{}: den här filen körs TVÅ gånger — en gång i ESP-IDF:s
 # early-expansion (då REQUIRES läses ut) och en gång i det riktiga bygget. I
 # expansionspasset syns INTE cache-/normalvariablerna som rot-CMakeLists.txt

--- a/main/main.c
+++ b/main/main.c
@@ -482,16 +482,28 @@ static void tick_cb(lv_timer_t *t) {
     if (key3_action == TG_BUTTON_NEXT_APP || key3_action == TG_BUTTON_PANIC)
       torget_wifi_setup_request_close();
   } else if (torget_ota_service_maintenance_open()) {
-    /* While the update window owns the glass, KEY3 has exactly one job: close
-     * it. ANY release does — a short tap or the panic-window hold — so the
-     * nödutgången never depends on out-tapping the panic threshold (a real
-     * trap found on hardware 2026-08-16: a ~2 s press panicked instead of
-     * closing, leaving the window stuck). Ten minutes without an escape once
-     * made a healthy device look hung. The 3 s hold that would open the
-     * window is a harmless no-op here — it is already open. No panic fires
-     * while the window is up. */
-    if (key3_action == TG_BUTTON_NEXT_APP || key3_action == TG_BUTTON_PANIC)
+    /* While the update window owns the glass, ANY release closes it — a
+     * short tap or the panic-window hold — so the nödutgången never depends
+     * on out-tapping the panic threshold (a real trap found on hardware
+     * 2026-08-16: a ~2 s press panicked instead of closing, leaving the
+     * window stuck). Ten minutes without an escape once made a healthy
+     * device look hung. No panic fires while the window is up.
+     *
+     * Ett NYTT fullt 3 s-håll byter fönster: OTA-fönstret stängs och
+     * setupfönstret öppnar. Det är vägen att nå WIFI SETUP på en panel som
+     * HAR nät (håll–håll: först uppdateringsfönstret, sen nätfönstret) —
+     * utan den kunde ett nytt nät bara läras ut när panelen redan var
+     * strandad. Nödutgången är intakt: varje släpp FÖRE tre sekunder
+     * stänger, bara ett medvetet fullbordat håll byter. */
+    if (key3_action == TG_BUTTON_NEXT_APP || key3_action == TG_BUTTON_PANIC) {
       torget_ota_service_close_maintenance();
+    } else if (key3_action == TG_BUTTON_OPEN_MAINTENANCE) {
+      /* Bara begäran härifrån: setupvaktens window_open äger överlämningen
+       * av port 80 (stänger OTA-fönstret och väntar ut dess httpd-stopp).
+       * Att stänga HÄR hade gjort portbytet till en kapplöpning mellan två
+       * vakter som pollar var 500:e ms. */
+      torget_wifi_setup_request_open();
+    }
   } else if (key3_action == TG_BUTTON_NEXT_APP) {
     torget_app_next();
   } else if (key3_action == TG_BUTTON_PANIC) {

--- a/main/main.c
+++ b/main/main.c
@@ -348,6 +348,9 @@ static void hook_ip_acquired(void) {
 }
 
 static const tg_wifi_setup_hooks s_setup_hooks = {
+  /* Flushens DMA-behov: golvet setupfönstrets grindar mäter mot —
+   * samma tal som heap-larmet i tick_cb vaktar. */
+  .flush_dma_bytes = (size_t)DISPLAY_FLUSH_ROWS * 480u * 2u,
   .have_ip = hook_have_ip,
   .ip_acquired = hook_ip_acquired,
   .sta_pause = hook_sta_pause,

--- a/main/main.c
+++ b/main/main.c
@@ -14,6 +14,7 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 
 #include "esp_app_desc.h"
@@ -45,6 +46,10 @@
 #include "rotation.h"
 #include "secrets.h"
 #include "torget.h"
+#include "wifi_creds.h"
+#include "wifi_setup.h"
+#include "wifi_setup_ui.h"
+#include "wifi_slots.h"
 
 static const char *TAG = "torget";
 
@@ -119,10 +124,10 @@ void torget_data_alive(void) { atomic_store(&s_data_alive, true); }
 /* Bootdiagnostik, medvetet permanent: skanna EN gång från nättasken (inte
  * event-loopen — dess stack sväljer varken blockering eller AP-listan)
  * innan första connect. S3:an är 2,4 GHz-only, så ett nät som saknas i
- * listan finns inte i dess värld oavsett vad telefonen ser. En hyllpryl
- * utan skärmtangentbord kan inte felsöka WiFi på annat sätt än att berätta
- * vad den ser; 2,5 s extra vid boot är priset. */
-static void scan_debug(void) {
+ * listan finns inte i dess värld oavsett vad telefonen ser. 2,5 s extra vid
+ * boot är priset; sedan setupfönstret finns (components/torget_wifi) står
+ * samma sanning också på glaset, inte bara i en logg ingen läser. */
+static void scan_debug(const char *target) {
   static wifi_ap_record_t ap[20]; /* 1,6 kB — på .bss, inte på stacken */
   ESP_LOGI(TAG, "skannar 2,4 GHz-banden...");
   if (esp_wifi_scan_start(NULL, true) != ESP_OK) {
@@ -134,7 +139,7 @@ static void scan_debug(void) {
     for (int i = 0; i < n; i++)
       ESP_LOGI(TAG, "  ser: \"%s\" kanal %d, %d dBm, auth %d",
                (const char *)ap[i].ssid, ap[i].primary, ap[i].rssi, ap[i].authmode);
-    ESP_LOGI(TAG, "  (%d nät totalt; vårt mål: \"%s\")", n, TG_WIFI_SSID);
+    ESP_LOGI(TAG, "  (%d nät totalt; vårt mål: \"%s\")", n, target);
   }
 }
 
@@ -147,52 +152,209 @@ static bool s_first_start = true;
 #define TG_WIFI2_PASS ""
 #endif
 
-static const char *const s_ssid[2] = { TG_WIFI_SSID, TG_WIFI2_SSID };
-static const char *const s_pass[2] = { TG_WIFI_PASS, TG_WIFI2_PASS };
-static int s_nat;         /* vilket av näten vi jagar just nu             */
-static int s_nat_missar;  /* missar i rad på DET nätet                    */
+/*
+ * Kandidatlistan: näten panelen minns (NVS, components/torget_wifi) först —
+ * det som senast fungerade överst — och secrets.h sist som en OFÖRÄNDERLIG
+ * botten. Botten är hela poängen: setupfönstret kan lägga till platser men
+ * aldrig ta bort hemnätet, så ingen felkonfiguration kan göra panelen
+ * ounderhållbar och kräva en USB-flashning för att komma tillbaka.
+ *
+ * Listan skrivs av setupvakten (efter nya uppgifter) och läses av
+ * event-loopen — därför ett kort mutexhåll runt varje åtkomst.
+ */
+static tg_wifi_slot s_cand[TG_WIFI_SLOTS + 2];
+static int s_cand_n;
+static int s_cand_i;      /* vilket nät vi jagar just nu */
+static int s_cand_misses; /* missar i rad på DET nätet   */
+static SemaphoreHandle_t s_cand_lock;
 
-/* 4 missar ≈ 10-15 s per nät innan vi provar det andra — snabbt nog för
- * bilen, trögt nog att inte fladdra när hemmanätet har en dålig stund. */
-#define NAT_MISSAR_INNAN_BYTE 4
+/* Medan setupfönstret äger radion (skanning + accesspunkt) ska
+ * event-handlern INTE ropa esp_wifi_connect: en connect mitt i en skanning
+ * ger bara ESP_ERR_WIFI_STATE och ett brus av misslyckanden i loggen. */
+static atomic_bool s_sta_paused;
 
-static void wifi_apply(int idx) {
+/* Senaste frånkopplingsorsaken i klartext, för den ärliga nätsidan. */
+static char s_reason_text[40];
+
+static void cand_lock(void)   { xSemaphoreTake(s_cand_lock, portMAX_DELAY); }
+static void cand_unlock(void) { xSemaphoreGive(s_cand_lock); }
+
+/* Bygger om listan ur NVS + secrets.h. prefer != NULL ställer jakten direkt
+ * på det nätet (setupfönstret har just fått dess lösenord). */
+static void wifi_reload_candidates(const char *prefer) {
+  static tg_wifi_slot remembered[TG_WIFI_SLOTS];
+  static tg_wifi_slot fixed[2];
+  const tg_wifi_slot *order[TG_WIFI_SLOTS + 2];
+
+  tg_wifi_creds_load(remembered);
+
+  memset(fixed, 0, sizeof fixed);
+  snprintf(fixed[0].ssid, sizeof fixed[0].ssid, "%s", TG_WIFI_SSID);
+  snprintf(fixed[0].pass, sizeof fixed[0].pass, "%s", TG_WIFI_PASS);
+  snprintf(fixed[1].ssid, sizeof fixed[1].ssid, "%s", TG_WIFI2_SSID);
+  snprintf(fixed[1].pass, sizeof fixed[1].pass, "%s", TG_WIFI2_PASS);
+
+  int n = tg_wifi_candidates(remembered, TG_WIFI_SLOTS, fixed, 2, order,
+                             TG_WIFI_SLOTS + 2);
+
+  cand_lock();
+  s_cand_n = n;
+  for (int i = 0; i < n; i++) s_cand[i] = *order[i];
+  s_cand_i = 0;
+  s_cand_misses = 0;
+  if (prefer) {
+    for (int i = 0; i < n; i++)
+      if (strcmp(s_cand[i].ssid, prefer) == 0) { s_cand_i = i; break; }
+  }
+  cand_unlock();
+
+  ESP_LOGI(TAG, "%d nät i jaktlistan (%d ihågkomna + secrets.h)", n,
+           tg_wifi_creds_count());
+}
+
+/* Nätet vi jagar just nu, kopierat till anroparens egen buffert så listan
+ * aldrig läses utan lås. */
+static void wifi_copy_current_ssid(char *out, size_t cap) {
+  if (!cap) return;
+  cand_lock();
+  if (s_cand_n > 0) snprintf(out, cap, "%s", s_cand[s_cand_i].ssid);
+  else out[0] = '\0';
+  cand_unlock();
+}
+
+/* Krokens variant. Bufferten är statisk och därför BARA för setupvakten —
+ * den är hookens enda anropare. Event-loopen och nättasken tar egna lokala
+ * buffertar; två taskar som skriver samma static hade kunnat rita ett
+ * hopblandat nätnamn på glaset just när någon felsöker sitt nät. */
+static const char *wifi_current_ssid(void) {
+  static char ssid[TG_WIFI_SSID_CAP];
+  wifi_copy_current_ssid(ssid, sizeof ssid);
+  return ssid;
+}
+
+static const char *wifi_last_reason(void) {
+  return s_reason_text[0] ? s_reason_text : NULL;
+}
+
+static void wifi_apply_current(void) {
   wifi_config_t cfg = { 0 };
-  strlcpy((char *)cfg.sta.ssid, s_ssid[idx], sizeof cfg.sta.ssid);
-  strlcpy((char *)cfg.sta.password, s_pass[idx], sizeof cfg.sta.password);
-  cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+  cand_lock();
+  if (s_cand_n > 0) {
+    strlcpy((char *)cfg.sta.ssid, s_cand[s_cand_i].ssid, sizeof cfg.sta.ssid);
+    strlcpy((char *)cfg.sta.password, s_cand[s_cand_i].pass,
+            sizeof cfg.sta.password);
+  }
+  cand_unlock();
+  /* Tröskeln följer nätet, inte en global gissning: ett öppet café-nät har
+   * ingen PSK och skulle avvisas tyst av en fast WPA2-tröskel — det var
+   * exakt vad den gamla koden gjorde på resa. */
+  cfg.sta.threshold.authmode =
+      cfg.sta.password[0] ? WIFI_AUTH_WPA2_PSK : WIFI_AUTH_OPEN;
   ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &cfg));
+}
+
+static void wifi_note_reason(int reason) {
+  /* Orsakskoden är diagnosen: 201 = nätet syns inte alls (fel namn, eller
+   * bara 5 GHz — S3:an hör enbart 2,4 GHz), 15/204 = fel lösenord. Samma
+   * sanning som loggen burit sedan 2026-08-06, nu också på glaset. */
+  switch (reason) {
+    case 201:
+      snprintf(s_reason_text, sizeof s_reason_text, "NOT SEEN - 2.4 GHZ ONLY");
+      break;
+    case 15:
+    case 204:
+      snprintf(s_reason_text, sizeof s_reason_text, "WRONG PASSWORD");
+      break;
+    default:
+      snprintf(s_reason_text, sizeof s_reason_text, "RADIO REASON %d", reason);
+      break;
+  }
 }
 
 static void wifi_event(void *arg, esp_event_base_t base, int32_t id, void *data) {
   (void)arg;
   if (base == WIFI_EVENT && id == WIFI_EVENT_STA_START) {
     if (s_first_start) { s_first_start = false; return; } /* nättasken sköter första */
-    esp_wifi_connect();
+    if (!atomic_load(&s_sta_paused)) esp_wifi_connect();
   } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
     xEventGroupClearBits(s_net_events, WIFI_GOT_IP);
-    /* Orsakskoden är diagnosen: 201 = nätet syns inte alls (fel namn, eller
-     * bara 5 GHz — S3:an hör enbart 2,4 GHz), 15/204 = fel lösenord. */
-    ESP_LOGW(TAG, "WiFi tappat (\"%s\", orsak %d), återansluter",
-             s_ssid[s_nat], ((wifi_event_sta_disconnected_t *)data)->reason);
-    /* Växelbruk hem/hotspot: efter NAT_MISSAR_INNAN_BYTE missar i rad provas
-     * det andra nätet (om ifyllt). Ingen prioritet — det som svarar vinner,
-     * och tappas det börjar jakten om. */
-    if (s_ssid[1][0] != '\0' && ++s_nat_missar >= NAT_MISSAR_INNAN_BYTE) {
-      s_nat = !s_nat;
-      s_nat_missar = 0;
-      ESP_LOGI(TAG, "provar \"%s\" i stället", s_ssid[s_nat]);
-      wifi_apply(s_nat);
+    int reason = ((wifi_event_sta_disconnected_t *)data)->reason;
+    wifi_note_reason(reason);
+    char ssid[TG_WIFI_SSID_CAP];
+    wifi_copy_current_ssid(ssid, sizeof ssid);
+    ESP_LOGW(TAG, "WiFi tappat (\"%s\", orsak %d), återansluter", ssid, reason);
+    /* Setupfönstret äger radion: ingen återanslutning förrän det släppt. */
+    if (atomic_load(&s_sta_paused)) return;
+    /* Växelbruk över hela listan: efter fyra missar i rad provas nästa
+     * kandidat. Ingen prioritet — det som svarar vinner, och tappas det
+     * börjar jakten om från samma plats i listan. */
+    bool switched = false;
+    cand_lock();
+    if (s_cand_n > 1 && tg_wifi_should_switch(++s_cand_misses)) {
+      s_cand_i = (s_cand_i + 1) % s_cand_n;
+      s_cand_misses = 0;
+      switched = true;
+    }
+    cand_unlock();
+    if (switched) {
+      wifi_copy_current_ssid(ssid, sizeof ssid);
+      ESP_LOGI(TAG, "provar \"%s\" i stället", ssid);
+      wifi_apply_current();
     }
     vTaskDelay(pdMS_TO_TICKS(2000));
-    esp_wifi_connect();
+    if (!atomic_load(&s_sta_paused)) esp_wifi_connect();
   } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
-    ESP_LOGI(TAG, "WiFi uppe (\"%s\")", s_ssid[s_nat]);
+    char ssid[TG_WIFI_SSID_CAP];
+    wifi_copy_current_ssid(ssid, sizeof ssid);
+    ESP_LOGI(TAG, "WiFi uppe (\"%s\")", ssid);
     torget_boot_screen_stage(TG_BOOT_WIFI_UP);
-    s_nat_missar = 0;
+    s_reason_text[0] = '\0';
+    cand_lock();
+    s_cand_misses = 0;
+    cand_unlock();
+    /* INGEN NVS här. Att flytta upp nätet i listan läser och skriver en
+     * blob på 600 byte — dels blockerar en flashskrivning event-loopen
+     * (cachen suspenderas), dels ryms arrayen illa på dess lilla stack.
+     * Nätvakten gör det i stället, på sin egen. */
     xEventGroupSetBits(s_net_events, WIFI_GOT_IP);
   }
 }
+
+/* Setupfönstrets krokar in i värdlagret. Fönstret äger aldrig radion
+ * själv — det ber om pausen och lämnar tillbaka den. */
+static bool hook_have_ip(void) {
+  return (xEventGroupGetBits(s_net_events) & WIFI_GOT_IP) != 0;
+}
+
+static void hook_sta_pause(bool paused) {
+  atomic_store(&s_sta_paused, paused);
+  if (!paused) esp_wifi_connect();
+}
+
+static void hook_creds_changed(const char *ssid) {
+  wifi_reload_candidates(ssid);
+  wifi_apply_current();
+  esp_wifi_connect();
+}
+
+/* Kallas av nätvakten när en uppkoppling just lyckats — den har stacken
+ * och friheten att röra flashen som event-loopen saknar. Nätet som gav IP
+ * flyter upp i listan så det provas först nästa gång. No-op för
+ * secrets.h-botten: den bor aldrig i NVS. */
+static void hook_ip_acquired(void) {
+  char ssid[TG_WIFI_SSID_CAP];
+  wifi_copy_current_ssid(ssid, sizeof ssid);
+  if (ssid[0]) tg_wifi_creds_mark_ok(ssid);
+}
+
+static const tg_wifi_setup_hooks s_setup_hooks = {
+  .have_ip = hook_have_ip,
+  .ip_acquired = hook_ip_acquired,
+  .sta_pause = hook_sta_pause,
+  .creds_changed = hook_creds_changed,
+  .current_ssid = wifi_current_ssid,
+  .last_reason = wifi_last_reason,
+};
 
 static void wifi_start(void) {
   ESP_ERROR_CHECK(esp_netif_init());
@@ -207,7 +369,8 @@ static void wifi_start(void) {
     IP_EVENT, IP_EVENT_STA_GOT_IP, wifi_event, NULL, NULL));
 
   ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-  wifi_apply(0);                  /* hemmanätet först; växelbruket tar över */
+  wifi_reload_candidates(NULL); /* NVS överst, secrets.h som botten */
+  wifi_apply_current();
   ESP_ERROR_CHECK(esp_wifi_start());
 }
 
@@ -228,7 +391,9 @@ static void time_sync(void) {
 static void net_task(void *arg) {
   (void)arg;
   vTaskDelay(pdMS_TO_TICKS(500)); /* låt STA-läget starta klart */
-  scan_debug();
+  char target[TG_WIFI_SSID_CAP];
+  wifi_copy_current_ssid(target, sizeof target);
+  scan_debug(target);
   esp_wifi_connect();
   xEventGroupWaitBits(s_net_events, WIFI_GOT_IP, pdFALSE, pdTRUE, portMAX_DELAY);
   time_sync();
@@ -309,7 +474,14 @@ static void tick_cb(lv_timer_t *t) {
   tg_button_action key3_action = tg_button_update(&key3, key3_down, now);
   if (key3_down)
     s_last_touch_us = now; /* knappkontakt är aktivitet, precis som touch */
-  if (torget_ota_service_maintenance_open()) {
+  if (torget_wifi_setup_is_open()) {
+    /* Samma nödutgång som OTA-fönstret: medan setupfönstret äger glaset
+     * stänger VILKET släpp som helst det. Ingen appväxling, ingen panik —
+     * ett fönster man inte kan stänga fick en frisk panel att se hängd ut
+     * (hårdvaruläxan 2026-08-16). */
+    if (key3_action == TG_BUTTON_NEXT_APP || key3_action == TG_BUTTON_PANIC)
+      torget_wifi_setup_request_close();
+  } else if (torget_ota_service_maintenance_open()) {
     /* While the update window owns the glass, KEY3 has exactly one job: close
      * it. ANY release does — a short tap or the panic-window hold — so the
      * nödutgången never depends on out-tapping the panic threshold (a real
@@ -328,7 +500,13 @@ static void tick_cb(lv_timer_t *t) {
      * svarskanal (ingen enhetsnyckel) gör det till en no-op. */
     tk_needs_you_send_panic();
   } else if (key3_action == TG_BUTTON_OPEN_MAINTENANCE) {
-    torget_ota_service_open_maintenance();
+    /* Ett håll betyder det ENDA som kan hjälpa just nu. Utan IP kan ett
+     * OTA-fönster aldrig ta emot en uppladdning — då är nätet problemet,
+     * och hållet öppnar setupfönstret i stället. Med IP är allt som förut.
+     * OTA:s samtyckesmodell är oförändrad: fönstret öppnas fortfarande
+     * bara från enheten, aldrig av ett skript. */
+    if (hook_have_ip()) torget_ota_service_open_maintenance();
+    else torget_wifi_setup_request_open();
   }
 
   int target = ((now - s_last_activity_us) > NIGHT_AFTER_US
@@ -506,6 +684,11 @@ void app_main(void) {
    * 2026-08-06). Ordningen är en del av kontraktet, inte en detalj. */
   s_net_events = xEventGroupCreate();
 
+  /* Kandidatlistans lås FÖRE wifi_start: event-handlern kan ta emot sitt
+   * första DISCONNECTED innan app_main hunnit längre. */
+  s_cand_lock = xSemaphoreCreateMutex();
+  ESP_ERROR_CHECK(s_cand_lock ? ESP_OK : ESP_ERR_NO_MEM);
+
   /* Panelen först, nätet sedan: initsekvensen tar ~1,2 s och skärmen ska
    * visa sina streck medan WiFi:t kopplar upp, inte stå svart i tio
    * sekunder. Egen start med små flushbitar — se display_start ovan. */
@@ -540,6 +723,11 @@ void app_main(void) {
   torget_ui_create(); /* bygger apparna via registret + launchern */
   /* UI-beviset: registret, apparnas create() och launchern överlevde. */
   torget_boot_health_mark(TG_HEALTH_UI);
+  /* Nätlagret EFTER apparna men FÖRE OTA-overlayn: båda bor på topplagret
+   * och hämtar sig längst fram i sin egen set(), så skapelseordningen
+   * avgör vem som vinner när båda vill synas. READY-ringen ska alltid
+   * vinna — den skapas därför sist. */
+  torget_wifi_ui_create();
   /* OTA-overlayn EFTER det delade UI:t, på topplagret, dold tills KEY3-
    * hållet öppnar underhållsfönstret — appträdet rörs aldrig. */
   torget_ota_ui_create();
@@ -562,4 +750,8 @@ void app_main(void) {
    * öppnat underhållsfönstret — en boot utan uppdatering ska ha samma
    * minnesprofil som en build helt utan OTA (frysläxan 2026-08-14). */
   torget_ota_service_start();
+  /* Nätvakten sist och lika lat: accesspunkten, http-servern och
+   * DNS-tasken existerar först när setupfönstret öppnats. En panel som
+   * hittar sitt nät betalar ingenting för att funktionen finns. */
+  torget_wifi_setup_start(&s_setup_hooks);
 }

--- a/secrets.h.example
+++ b/secrets.h.example
@@ -10,14 +10,26 @@
 #ifndef TORGET_SECRETS_H
 #define TORGET_SECRETS_H
 
-/* Plattformen: WiFi (2,4 GHz — S3:an hör inget annat). */
+/* Plattformen: WiFi (2,4 GHz — S3:an hör inget annat).
+ *
+ * De här två är panelens OFÖRÄNDERLIGA BOTTEN, inte hela nätlistan. Sedan
+ * setupfönstret finns (docs/wifi.md) minns panelen sex platser i NVS och
+ * lär sig nya på plats — utan ombygge, utan USB. Botten kan bara läggas
+ * till, aldrig tas bort, så en trasig nätpost kan aldrig göra skärmen
+ * ounderhållbar. Fyll i hemnätet här; resten sköts av tools/wifi-here.sh
+ * eller panelens egen accesspunkt. */
 #define TG_WIFI_SSID   ""
 #define TG_WIFI_PASS   ""
 
-/* Reservnät, t.ex. telefonens internetdelning — kortet växlar automatiskt
- * dit efter ~4 missar på hemmanätet (och tillbaka på samma vis). Tomt =
+/* Andra bottennätet, t.ex. telefonens internetdelning — kortet växlar
+ * automatiskt dit efter ~4 missar (och tillbaka på samma vis). Tomt =
  * funktionen är av. OBS iPhone: slå på "Maximera kompatibilitet" i
- * Internetdelning, annars sänder telefonen bara 5 GHz som S3:an inte hör. */
+ * Internetdelning, annars sänder telefonen bara 5 GHz som S3:an inte hör.
+ *
+ * Hotspoten är det enda nät som ALLTID fungerar på resa (hotellens
+ * captive portals och klientisolering stoppar panelen oavsett hur lätt
+ * den är att koppla upp). Den behöver inte stå här längre — panelen minns
+ * den lika bra via setupfönstret — men här överlever den en NVS-radering. */
 #define TG_WIFI2_SSID  ""
 #define TG_WIFI2_PASS  ""
 

--- a/secrets.h.example
+++ b/secrets.h.example
@@ -52,6 +52,29 @@
 #define TK_MAX_TRACKER_URL \
      TK_VIBEPULSE_BASE_URL "/api/max-tracker"
 
+/* Valfritt relä: en brevlåda på internet dit tjänsten LÄGGER sina färdiga
+ * siffror, så panelen kan hämta dem utan att dela nät med värden. Utan det
+ * här makrot beter sig allt exakt som förut — LAN eller ingenting.
+ *
+ * Varför: panelen kunde bara nå tjänsten på samma nät. Ett gästnät med
+ * klientisolering, ett IoT-VLAN eller en dator som bytt IP räckte för att
+ * glaset skulle stå tomt (2026-08-17: Solelkollen hämtade glatt över
+ * internet medan VibePulse visade streck). Med reläet behöver panelen bara
+ * INTERNET — vilket nät som helst, var som helst.
+ *
+ * Vad som går den vägen: kvot, burn rate, Max Tracker, GitHub. Alltså
+ * siffror. Agentstatus och Needs You gör det INTE — de bär projektnamn,
+ * frågetexter och kommandon, och lämnar aldrig LAN:et. Enhetsnyckelns
+ * svarsväg är LAN-only av samma skäl: panelen kan svara på en fråga hemma,
+ * aldrig via en brevlåda.
+ *
+ * Sökvägen ska bära minst 32 slumpade byte — den ÄR åtkomstkontrollen.
+ * Generera med:
+ *   python3 -c "import secrets; print(secrets.token_hex(32))"
+ * Tjänstens sida sätts på med tools/tokenserver --publish <samma URL>. */
+/* #define TK_VIBEPULSE_RELAY_URL \
+     "https://vibepulse-relay.exempel.workers.dev/u/replace-with-64-hex" */
+
 /* Optional public GitHub repository module. Configure the repository on the
  * Mac service with --github-repo owner/repository (or the
  * VIBEPULSE_GITHUB_REPO environment variable), then independently choose

--- a/test/run.sh
+++ b/test/run.sh
@@ -165,6 +165,13 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 /tmp/torget-boot-health-policy-test
 
 cc -std=c11 -Wall -Wextra -Werror -O1 \
+  ../components/torget_net/net_source_policy.c \
+  test_net_source_policy.c \
+  -lm \
+  -o /tmp/torget-net-source-test
+/tmp/torget-net-source-test
+
+cc -std=c11 -Wall -Wextra -Werror -O1 \
   ../components/torget_wifi/wifi_slots.c \
   test_wifi_slots.c \
   -lm \
@@ -192,6 +199,7 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_ota_reopen_wiring.py
 "$PYTHON_BIN" test_ota_sender_gates.py
 "$PYTHON_BIN" test_wifi_setup_wiring.py
+"$PYTHON_BIN" test_relay_boundary.py
 
 cd ..
 "$PYTHON_BIN" -m unittest tools.agent_assets.test_build_agent_images -v

--- a/test/run.sh
+++ b/test/run.sh
@@ -193,6 +193,7 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_target_tls_memory.py
 "$PYTHON_BIN" test_buddy_opt_in.py
 "$PYTHON_BIN" test_lvgl_layer_safety.py
+"$PYTHON_BIN" test_lvgl_memory_config.py
 "$PYTHON_BIN" test_vibepulse_layout_wiring.py
 "$PYTHON_BIN" test_preview_ui.py
 "$PYTHON_BIN" test_ota_partition.py

--- a/test/run.sh
+++ b/test/run.sh
@@ -164,6 +164,21 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
   -o /tmp/torget-boot-health-policy-test
 /tmp/torget-boot-health-policy-test
 
+cc -std=c11 -Wall -Wextra -Werror -O1 \
+  ../components/torget_wifi/wifi_slots.c \
+  test_wifi_slots.c \
+  -lm \
+  -o /tmp/torget-wifi-slots-test
+/tmp/torget-wifi-slots-test
+
+cc -std=c11 -Wall -Wextra -Werror -O1 \
+  ../components/torget_wifi/wifi_form.c \
+  ../components/torget_wifi/wifi_slots.c \
+  test_wifi_form.c \
+  -lm \
+  -o /tmp/torget-wifi-form-test
+/tmp/torget-wifi-form-test
+
 "$PYTHON_BIN" test_agent_demo_wiring.py
 "$PYTHON_BIN" test_agent_net_wiring.py
 "$PYTHON_BIN" test_github_wiring.py
@@ -176,6 +191,7 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_ota_partition.py
 "$PYTHON_BIN" test_ota_reopen_wiring.py
 "$PYTHON_BIN" test_ota_sender_gates.py
+"$PYTHON_BIN" test_wifi_setup_wiring.py
 
 cd ..
 "$PYTHON_BIN" -m unittest tools.agent_assets.test_build_agent_images -v

--- a/test/run.sh
+++ b/test/run.sh
@@ -223,4 +223,13 @@ cd ..
   tools.tokenserver.test_update_prices \
   tools.tokenserver.test_codex_usage \
   tools.tokenserver.test_interactions \
+  tools.tokenserver.test_publisher \
   tools.tokenserver.test_smoke -v
+
+# Brevlådans sammanslagning (tools/relay) är ren JS och hålls av node.
+# Saknas node hoppas den ÄRLIGT över med en rad — CI kör den alltid.
+if command -v node >/dev/null 2>&1; then
+  node --test tools/relay/test.mjs
+else
+  echo "OBS: node saknas — tools/relay/test.mjs hoppas över (CI kör den)"
+fi

--- a/test/test_lvgl_memory_config.py
+++ b/test/test_lvgl_memory_config.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Regression tests for Torget's configure-time LVGL pool floor."""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "cmake" / "torget_lvgl_memory_guard.cmake"
+ROOT_CMAKE = ROOT / "CMakeLists.txt"
+SDKCONFIG_DEFAULTS = ROOT / "sdkconfig.defaults"
+
+
+def run_guard(actual_kib: int) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "check.cmake"
+        script.write_text(
+            f'include("{GUARD.as_posix()}")\n'
+            f"torget_require_lvgl_pool({actual_kib})\n",
+            encoding="utf-8",
+        )
+        return subprocess.run(
+            ["cmake", "-P", str(script)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+
+class LvglMemoryConfigTests(unittest.TestCase):
+    def test_stale_96_kib_generated_config_is_rejected(self) -> None:
+        result = run_guard(96)
+        self.assertNotEqual(result.returncode, 0)
+        diagnostic = result.stdout + result.stderr
+        self.assertIn("LVGL pool is 96 KiB", diagnostic)
+        self.assertIn("at least 256 KiB", diagnostic)
+        self.assertIn("sdkconfig is stale", diagnostic)
+        self.assertIn("CONFIG_LV_MEM_SIZE_KILOBYTES=256", diagnostic)
+        self.assertIn("idf.py reconfigure && idf.py build", diagnostic)
+
+    def test_intended_256_kib_config_is_accepted(self) -> None:
+        result = run_guard(256)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_root_build_invokes_the_guard(self) -> None:
+        root_cmake = ROOT_CMAKE.read_text(encoding="utf-8")
+        self.assertIn(
+            'include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/'
+            'torget_lvgl_memory_guard.cmake")',
+            root_cmake,
+        )
+        self.assertIn(
+            'torget_require_lvgl_pool("${CONFIG_LV_MEM_SIZE_KILOBYTES}")',
+            root_cmake,
+        )
+
+    def test_checked_in_default_matches_the_guard_floor(self) -> None:
+        defaults = SDKCONFIG_DEFAULTS.read_text(encoding="utf-8").splitlines()
+        self.assertIn("CONFIG_LV_MEM_SIZE_KILOBYTES=256", defaults)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/test_net_source_policy.c
+++ b/test/test_net_source_policy.c
@@ -1,0 +1,110 @@
+#include <stdio.h>
+
+#include "../components/torget_net/net_source_policy.h"
+
+static int failures;
+
+static void check(const char *what, int condition) {
+  if (!condition) {
+    printf("FAIL %s\n", what);
+    failures++;
+  }
+}
+
+static const int64_t S = 1000000LL;
+
+static void test_home_uses_the_lan(void) {
+  tg_net_source_state st = {0};
+  check("a fresh panel asks the LAN first",
+        tg_net_source_first(&st, 10 * S) == TG_NET_SOURCE_LOCAL);
+  check("and gives it full patience",
+        tg_net_source_timeout_ms(&st, TG_NET_SOURCE_LOCAL) ==
+            TG_NET_LOCAL_TIMEOUT_MS);
+
+  tg_net_source_note(&st, TG_NET_SOURCE_LOCAL, true, 10 * S);
+  check("a working LAN keeps owning the fetches",
+        tg_net_source_first(&st, 40 * S) == TG_NET_SOURCE_LOCAL);
+  /* Hemma ska datan komma från hemmet — reläet får aldrig ta över så länge
+   * LAN svarar, hur bra reläet än fungerar. */
+  check("the relay never wins while the LAN answers", !st.relay_won);
+}
+
+static void test_away_falls_back_to_the_relay(void) {
+  tg_net_source_state st = {0};
+
+  /* Gästnät med klientisolering: LAN dör, reläet räddar hämtningen. */
+  check("the LAN may fall through to the relay",
+        tg_net_source_may_fall_back(TG_NET_SOURCE_LOCAL));
+  tg_net_source_note(&st, TG_NET_SOURCE_LOCAL, false, 10 * S);
+  tg_net_source_note(&st, TG_NET_SOURCE_RELAY, true, 10 * S);
+
+  check("the relay now leads", st.relay_won);
+  check("the next fetch skips the dead LAN",
+        tg_net_source_first(&st, 40 * S) == TG_NET_SOURCE_RELAY);
+  /* Poängen med att hoppa över: annars kostar varje hämtning en timeout på
+   * en adress vi vet är borta. */
+  check("and still skips it just before the reprobe window",
+        tg_net_source_first(&st, 10 * S + TG_NET_LOCAL_REPROBE_US - S) ==
+            TG_NET_SOURCE_RELAY);
+}
+
+static void test_a_dead_relay_does_not_loop_back(void) {
+  tg_net_source_state st = {0};
+  tg_net_source_note(&st, TG_NET_SOURCE_LOCAL, false, 10 * S);
+  tg_net_source_note(&st, TG_NET_SOURCE_RELAY, false, 10 * S);
+
+  /* Båda nere. Reläet får inte utses till vinnare, och det får inte falla
+   * vidare till LAN igen — annars snurrar en hämtning i ring mellan två
+   * döda adresser tills watchdogen tröttnar. */
+  check("a failed relay never becomes the leader", !st.relay_won);
+  check("the relay does not fall back onwards",
+        !tg_net_source_may_fall_back(TG_NET_SOURCE_RELAY));
+  check("the next fetch starts over at the LAN",
+        tg_net_source_first(&st, 40 * S) == TG_NET_SOURCE_LOCAL);
+}
+
+static void test_coming_home_is_noticed(void) {
+  tg_net_source_state st = {0};
+  tg_net_source_note(&st, TG_NET_SOURCE_LOCAL, false, 10 * S);
+  tg_net_source_note(&st, TG_NET_SOURCE_RELAY, true, 10 * S);
+
+  const int64_t due = 10 * S + TG_NET_LOCAL_REPROBE_US;
+  check("the LAN is retried once the window opens",
+        tg_net_source_first(&st, due) == TG_NET_SOURCE_LOCAL);
+  /* Återprovet får inte hålla upp en hämtning som annars landat. */
+  check("a reprobe is impatient",
+        tg_net_source_timeout_ms(&st, TG_NET_SOURCE_LOCAL) ==
+            TG_NET_REPROBE_TIMEOUT_MS);
+
+  /* Fortfarande borta: stämpeln flyttas fram så nästa återprov dröjer, i
+   * stället för att varje hämtning betalar timeouten på nytt. */
+  tg_net_source_note(&st, TG_NET_SOURCE_LOCAL, false, due);
+  check("a failed reprobe still counts as an attempt",
+        st.last_local_try_us == due);
+  check("so the relay keeps serving until the next window",
+        tg_net_source_first(&st, due + S) == TG_NET_SOURCE_RELAY);
+
+  /* Hemma igen: LAN svarar och tar tillbaka rodret direkt. */
+  const int64_t home = due + TG_NET_LOCAL_REPROBE_US;
+  check("the LAN is retried again",
+        tg_net_source_first(&st, home) == TG_NET_SOURCE_LOCAL);
+  tg_net_source_note(&st, TG_NET_SOURCE_LOCAL, true, home);
+  check("and a working LAN takes over immediately", !st.relay_won);
+  check("full patience is restored",
+        tg_net_source_timeout_ms(&st, TG_NET_SOURCE_LOCAL) ==
+            TG_NET_LOCAL_TIMEOUT_MS);
+}
+
+int main(void) {
+  test_home_uses_the_lan();
+  test_away_falls_back_to_the_relay();
+  test_a_dead_relay_does_not_loop_back();
+  test_coming_home_is_noticed();
+
+  if (failures == 0) {
+    printf("OK: all net-source failover policy tests pass\n");
+    return 0;
+  }
+  printf("%d tests failed\n", failures);
+  return 1;
+}

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The relay carries numbers, never activity.
+
+The relay is a mailbox on the internet, so whatever crosses it is readable
+by anyone who learns the URL.  Quota percentages and reset times are dull.
+Project names, question text and shell commands are not — and neither is the
+device key's answer path, which must never be reachable from outside the
+LAN.  Nothing in the compiler enforces that split, so it is asserted here.
+"""
+
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+read = lambda p: (root / p).read_text(encoding="utf-8")
+
+config = read("components/app_tokens/app_tokens_config.h")
+net = read("components/app_tokens/net.c")
+github = read("components/app_tokens/github_net.c")
+agent = read("components/app_tokens/agent_net.c")
+needs_you = read("components/app_tokens/needs_you_net.c")
+http = read("components/torget_net/torget_http.c")
+example = read("secrets.h.example")
+
+# --- What may cross: numbers -------------------------------------------
+for name in ("TK_TOKENS_RELAY_URL", "TK_MAX_TRACKER_RELAY_URL",
+             "TK_GITHUB_RELAY_URL"):
+    assert name in config, f"{name} must be derived in app_tokens_config.h"
+
+# Undefined base must compile to NULL, so a clone without the opt-in keeps
+# exactly today's behaviour instead of fetching a malformed URL.
+assert "#else" in config and "TK_TOKENS_RELAY_URL      NULL" in config, (
+    "without TK_VIBEPULSE_RELAY_URL every relay address must be NULL"
+)
+assert "torget_http_get_failover(TK_TOKENS_URL, TK_TOKENS_RELAY_URL" in net
+assert "torget_http_get_failover(TK_MAX_TRACKER_URL" in net
+assert "torget_http_get_failover(TK_GITHUB_URL" in github
+
+# --- What may not cross: anything that names your work ------------------
+for path, source in (("agent_net.c", agent), ("needs_you_net.c", needs_you)):
+    assert "RELAY" not in source.upper(), (
+        f"{path} must never reach the relay — it carries project names, "
+        "question text and commands"
+    )
+    assert "failover" not in source, (
+        f"{path} must not use the failover helper"
+    )
+
+# The device key answers only the LAN service.  A verdict posted into a
+# mailbox would be a signed instruction sitting in public storage.
+assert "TK_VIBEPULSE_BASE_URL" in needs_you, (
+    "the Needs You verdict must post to the LAN base URL"
+)
+
+# --- The failover helper itself -----------------------------------------
+# A missing relay must be a plain fetch, not a special case each caller
+# has to remember.
+assert "if (!relay_url || !relay_url[0])" in http, (
+    "a NULL/empty relay must degrade to a plain torget_http_get"
+)
+# Only the LAN attempt may fall onwards; a dead relay must not bounce back
+# or two dead addresses spin a fetch in circles.
+assert "tg_net_source_may_fall_back(source)" in http
+
+# --- The opt-in stays opt-in -------------------------------------------
+assert "/* #define TK_VIBEPULSE_RELAY_URL" in example, (
+    "the relay must ship commented out — a fresh clone stays LAN-only"
+)
+
+print("OK: the relay carries numbers, and activity stays on the LAN")

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -66,4 +66,17 @@ assert "/* #define TK_VIBEPULSE_RELAY_URL" in example, (
     "the relay must ship commented out — a fresh clone stays LAN-only"
 )
 
+# --- The same boundary, from the service side ---------------------------
+# The publisher must have no way to send the activity endpoints, and the
+# Worker must not accept them.  Three directions, one rule.
+publisher = read("tools/tokenserver/publisher.py")
+worker = read("tools/relay/worker.js")
+for source, name in ((publisher, "publisher.py"), (worker, "worker.js")):
+    assert "agent-status" not in source and "interaction" not in source, (
+        f"{name} must never touch the activity endpoints"
+    )
+assert '"/api/tokens", "/api/max-tracker", "/api/github"' in worker, (
+    "the Worker's endpoint allowlist must stay exactly the three number paths"
+)
+
 print("OK: the relay carries numbers, and activity stays on the LAN")

--- a/test/test_wifi_form.c
+++ b/test/test_wifi_form.c
@@ -1,0 +1,126 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../components/torget_wifi/wifi_form.h"
+#include "../components/torget_wifi/wifi_slots.h"
+
+static int failures;
+
+static void check(const char *what, int condition) {
+  if (!condition) {
+    printf("FAIL %s\n", what);
+    failures++;
+  }
+}
+
+static void test_url_decode(void) {
+  char plus[] = "Hotell+Gast";
+  check("plus decodes to space",
+        tg_wifi_url_decode(plus) && strcmp(plus, "Hotell Gast") == 0);
+
+  char pct[] = "caf%C3%A9%20wifi";
+  check("percent pairs decode",
+        tg_wifi_url_decode(pct) && strcmp(pct, "caf\xC3\xA9 wifi") == 0);
+
+  char upper[] = "a%2Fb";
+  check("uppercase hex decodes",
+        tg_wifi_url_decode(upper) && strcmp(upper, "a/b") == 0);
+
+  /* Trasig indata ger nej, inte en gissning. */
+  char truncated[] = "abc%4";
+  check("a truncated escape is rejected", !tg_wifi_url_decode(truncated));
+  char dangling[] = "abc%";
+  check("a dangling percent is rejected", !tg_wifi_url_decode(dangling));
+  char nonhex[] = "abc%zz";
+  check("a non-hex escape is rejected", !tg_wifi_url_decode(nonhex));
+
+  /* %00 skulle klippa strängen mitt itu och göra resten osynlig för varje
+   * längdkontroll efteråt — samma trunkeringsfälla som 2026-08-13. */
+  char embedded_nul[] = "hem%00extra";
+  check("an embedded NUL is rejected, not silently truncated",
+        !tg_wifi_url_decode(embedded_nul));
+}
+
+static void test_form_field(void) {
+  char out[TG_WIFI_PASS_CAP];
+
+  check("first field is found",
+        tg_wifi_form_field("ssid=hem&pass=hemligt1", "ssid", out, sizeof out) &&
+            strcmp(out, "hem") == 0);
+  check("last field is found",
+        tg_wifi_form_field("ssid=hem&pass=hemligt1", "pass", out, sizeof out) &&
+            strcmp(out, "hemligt1") == 0);
+  check("a missing field says so",
+        !tg_wifi_form_field("ssid=hem", "pass", out, sizeof out));
+
+  /* Prefixet får inte räcka: "ssid" ska inte matcha "ssid2". */
+  check("a key prefix does not match a longer key",
+        !tg_wifi_form_field("ssid2=x", "ssid", out, sizeof out));
+
+  /* Ett tomt värde är ett giltigt svar — det är ett öppet nät. */
+  check("an empty value is a valid answer",
+        tg_wifi_form_field("ssid=hem&pass=", "pass", out, sizeof out) &&
+            out[0] == '\0');
+
+  check("an encoded value decodes",
+        tg_wifi_form_field("ssid=Hotell+G%C3%A5rd&pass=x", "ssid", out,
+                           sizeof out) &&
+            strcmp(out, "Hotell G\xC3\xA5rd") == 0);
+
+  /* Längden mäts EFTER avkodningen: ett 32-tecken SSID fullt av mellanslag
+   * blir 96 tecken kodat och skulle annars nekas fast det får plats. */
+  char ssid_out[TG_WIFI_SSID_CAP];
+  char body[256] = "ssid=";
+  for (int i = 0; i < 32; i++) strcat(body, "%20");
+  check("a full-length ssid survives its own encoding",
+        tg_wifi_form_field(body, "ssid", ssid_out, sizeof ssid_out) &&
+            strlen(ssid_out) == 32);
+
+  /* Ett tecken för långt ska nekas, inte tyst klippas. */
+  char one_too_long[256] = "ssid=";
+  for (int i = 0; i < 33; i++) strcat(one_too_long, "a");
+  check("one byte past the cap is rejected, not truncated",
+        !tg_wifi_form_field(one_too_long, "ssid", ssid_out, sizeof ssid_out));
+
+  /* Skräp mitt i kroppen får inte dölja fältet som kommer efter. */
+  check("a malformed pair does not hide later fields",
+        tg_wifi_form_field("junk&ssid=hem", "ssid", out, sizeof out) &&
+            strcmp(out, "hem") == 0);
+}
+
+static void test_html_escape(void) {
+  char out[128];
+
+  tg_wifi_html_escape("hem", out, sizeof out);
+  check("plain text passes through", strcmp(out, "hem") == 0);
+
+  /* Ett SSID i luften är någon annans sträng och hamnar i portalens HTML. */
+  tg_wifi_html_escape("</option><script>x</script>", out, sizeof out);
+  check("markup cannot break out of the option list",
+        strstr(out, "<script>") == NULL && strstr(out, "&lt;") != NULL);
+
+  tg_wifi_html_escape("a&b\"c", out, sizeof out);
+  check("ampersand and quote are escaped", strcmp(out, "a&amp;b&quot;c") == 0);
+
+  /* Trunkering hellre än spill, och alltid NUL-terminerat. */
+  char tiny[6];
+  tg_wifi_html_escape("aaaaaaaaaa", tiny, sizeof tiny);
+  check("truncation stays inside the buffer", strlen(tiny) < sizeof tiny);
+  char no_room[4];
+  tg_wifi_html_escape("&&&&", no_room, sizeof no_room);
+  check("an entity that does not fit is dropped whole",
+        no_room[0] == '\0');
+}
+
+int main(void) {
+  test_url_decode();
+  test_form_field();
+  test_html_escape();
+
+  if (failures == 0) {
+    printf("OK: all WiFi setup-form parsing tests pass\n");
+    return 0;
+  }
+  printf("%d tests failed\n", failures);
+  return 1;
+}

--- a/test/test_wifi_setup_wiring.py
+++ b/test/test_wifi_setup_wiring.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""The contracts the WiFi setup window shares across three languages.
+
+The firmware, the Mac script and the consent model each hold one half of an
+agreement.  Nothing catches these at compile time, so they are asserted
+here — the drift they prevent is silent and only shows up on a hotel room
+floor with a panel that will not join anything.
+"""
+
+import hashlib
+import re
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+setup_c = (root / "components/torget_wifi/wifi_setup.c").read_text(encoding="utf-8")
+main_c = (root / "main/main.c").read_text(encoding="utf-8")
+script = (root / "tools/wifi-here.sh").read_text(encoding="utf-8")
+slots_h = (root / "components/torget_wifi/wifi_slots.h").read_text(encoding="utf-8")
+
+# --- The access point's identity must match on both sides ------------------
+# The script joins by name; a rename on one side alone strands the panel.
+ap_ssid = re.search(r'#define AP_SSID\s+"([^"]+)"', setup_c).group(1)
+assert f"AP_SSID={ap_ssid}" in script, (
+    f"tools/wifi-here.sh joins a different SSID than the firmware raises ({ap_ssid})"
+)
+
+ap_host = re.search(r'#define AP_ADDRESS\s+"([^"]+)"', setup_c).group(1)
+assert f"AP_HOST={ap_host}" in script, (
+    "the script posts to a different address than the firmware serves"
+)
+
+# --- The derived access-point password ------------------------------------
+# Firmware: sha256(domain || TG_OTA_TOKEN), first 6 bytes as 12 hex chars.
+# Script:   the same digest, cut to 12 characters.  Both are asserted against
+# a worked example so neither the domain string nor the length can drift.
+domain_c = re.search(r'static const char domain\[\] = "([^"]+)"', setup_c).group(1)
+domain_sh = re.search(r"^DOMAIN=(\S+)", script, re.M).group(1)
+assert domain_c == domain_sh, (
+    f"domain separation string differs: firmware {domain_c!r}, script {domain_sh!r}"
+)
+
+# The firmware writes 6 bytes as "%02x" pairs; the script cuts 12 characters.
+assert re.search(r"for \(int i = 0; i < 6; i\+\+\)\s*\n\s*snprintf\(s_ap_pass \+ i \* 2, 3, \"%02x\"", setup_c), (
+    "the firmware no longer writes exactly 6 bytes of the digest as hex"
+)
+assert "cut -c1-12" in script, "the script no longer cuts the digest to 12 characters"
+
+token = "a" * 64
+expected = hashlib.sha256((domain_c + token).encode()).hexdigest()[:12]
+assert len(expected) == 12 and expected.isalnum()
+# WPA2 refuses anything shorter than 8 characters — a 12-char PSK has margin.
+assert len(expected) >= 8, "a derived AP password below 8 chars cannot be a WPA2 PSK"
+
+# --- The consent model ------------------------------------------------------
+# docs/ota.md promises the OTA maintenance window opens ONLY from the device.
+# Routing KEY3 by network state must never hand a script that power.
+assert "torget_wifi_setup_request_open()" in main_c
+assert re.search(
+    r"if \(hook_have_ip\(\)\) torget_ota_service_open_maintenance\(\);\s*\n\s*else torget_wifi_setup_request_open\(\);",
+    main_c,
+), "KEY3 must open the OTA window only when there is an IP, setup otherwise"
+
+# The setup window may never become a firmware path.
+assert "esp_ota" not in setup_c and "ota_ops" not in setup_c, (
+    "the WiFi setup window must never gain a firmware-writing surface"
+)
+
+# --- The immutable floor ----------------------------------------------------
+# secrets.h is what makes a bad network entry recoverable without USB.  The
+# candidate list must always be built with the compiled-in networks appended.
+assert "tg_wifi_candidates(remembered, TG_WIFI_SLOTS, fixed, 2" in main_c, (
+    "the compiled-in secrets.h networks must stay as the candidate floor"
+)
+assert "TG_WIFI_SSID" in main_c and "TG_WIFI2_SSID" in main_c
+
+# --- The lazy surface -------------------------------------------------------
+# The 2026-08-14 freeze lesson: a boot that never opens the window must not
+# pay for it.  The AP, the HTTP server and the DNS task all live in
+# window_open(), never in the start path.
+start_fn = setup_c.split("void torget_wifi_setup_start(")[1]
+for forbidden in ("httpd_start", "esp_netif_create_default_wifi_ap", "dns_task"):
+    assert forbidden not in start_fn, (
+        f"{forbidden} must not run at boot — the setup surface is lazy"
+    )
+
+# --- Password handling ------------------------------------------------------
+# A password must never reach the log; the SSID may, because it is the only
+# way to debug a network from a serial console.
+for line in setup_c.splitlines():
+    if "ESP_LOG" in line:
+        assert "s_ap_pass" not in line and "pass" not in line.split("ESP_LOG")[1], (
+            f"a password must never be logged: {line.strip()}"
+        )
+
+# --- Window timing ----------------------------------------------------------
+# The window must close itself; an open AP left up overnight is a surface.
+assert "TG_WIFI_SETUP_WINDOW_US   (600LL" in slots_h, (
+    "the setup window must stay bounded at ten minutes"
+)
+
+print("OK: WiFi setup window, Mac script and consent model agree")

--- a/test/test_wifi_setup_wiring.py
+++ b/test/test_wifi_setup_wiring.py
@@ -60,6 +60,24 @@ assert re.search(
     main_c,
 ), "KEY3 must open the OTA window only when there is an IP, setup otherwise"
 
+# The double hold: a second full hold while the OTA window is open must
+# REQUEST the setup window, never close-and-open from the LVGL task — the
+# port-80 handover belongs to the setup guard's window_open().  Two request
+# sites total: the no-IP route and the switch route.
+assert main_c.count("torget_wifi_setup_request_open();") == 2, (
+    "expected exactly the no-IP route and the hold-again switch route"
+)
+maintenance_branch = main_c.split("torget_ota_service_maintenance_open()) {")[1]
+# Skär vid nästa YTTRE gren (appväxlaren) — den inre else-if-kedjan för
+# knapphändelserna hör till branchen och får inte klippa bort växlingsvägen.
+maintenance_branch = maintenance_branch.split("torget_app_next()")[0]
+assert "torget_wifi_setup_request_open();" in maintenance_branch, (
+    "the hold-again switch must live inside the maintenance-open branch"
+)
+assert "torget_ota_service_close_maintenance();\n      torget_wifi_setup_request_open" not in main_c, (
+    "the LVGL task must not close the OTA window itself when switching"
+)
+
 # The setup window may never become a firmware path.
 assert "esp_ota" not in setup_c and "ota_ops" not in setup_c, (
     "the WiFi setup window must never gain a firmware-writing surface"

--- a/test/test_wifi_setup_wiring.py
+++ b/test/test_wifi_setup_wiring.py
@@ -91,6 +91,25 @@ assert "tg_wifi_candidates(remembered, TG_WIFI_SLOTS, fixed, 2" in main_c, (
 )
 assert "TG_WIFI_SSID" in main_c and "TG_WIFI2_SSID" in main_c
 
+# --- The DMA gates ----------------------------------------------------------
+# The access point was the one surface whose memory cost had never been
+# measured on hardware, and its first physical run wedged the panel
+# (2026-08-17).  The gates must bracket the expensive step: refuse before
+# anything happens, abort after the APSTA switch, both against the flush's
+# contiguous-DMA floor.  A wedge-proof window is one that would rather stay
+# closed than freeze the glass.
+open_gate = setup_c.find("tg_wifi_setup_dma_ok_to_open")
+apsta = setup_c.find("esp_wifi_set_mode(WIFI_MODE_APSTA)")
+cont_gate = setup_c.find("tg_wifi_setup_dma_ok_to_continue")
+httpd_start_at = setup_c.find("server_start();")
+assert 0 < open_gate < apsta < cont_gate < httpd_start_at, (
+    "window_open must gate on DMA before the APSTA switch and again before "
+    "the HTTP server"
+)
+assert "flush_dma_bytes" in main_c, (
+    "main.c must hand the flush's DMA floor to the setup hooks"
+)
+
 # --- The lazy surface -------------------------------------------------------
 # The 2026-08-14 freeze lesson: a boot that never opens the window must not
 # pay for it.  The AP, the HTTP server and the DNS task all live in

--- a/test/test_wifi_slots.c
+++ b/test/test_wifi_slots.c
@@ -1,0 +1,201 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../components/torget_wifi/wifi_slots.h"
+
+static int failures;
+
+static void check(const char *what, int condition) {
+  if (!condition) {
+    printf("FAIL %s\n", what);
+    failures++;
+  }
+}
+
+static void put(tg_wifi_slot *slot, const char *ssid, const char *pass,
+                uint32_t seq) {
+  memset(slot, 0, sizeof *slot);
+  snprintf(slot->ssid, sizeof slot->ssid, "%s", ssid);
+  snprintf(slot->pass, sizeof slot->pass, "%s", pass);
+  slot->seq = seq;
+}
+
+static void test_validation(void) {
+  check("empty ssid rejected", !tg_wifi_ssid_valid(""));
+  check("NULL ssid rejected", !tg_wifi_ssid_valid(NULL));
+  check("normal ssid accepted", tg_wifi_ssid_valid("Hotell Gast"));
+  char too_long[TG_WIFI_SSID_CAP + 4];
+  memset(too_long, 'a', sizeof too_long - 1);
+  too_long[sizeof too_long - 1] = '\0';
+  check("33-byte ssid rejected", !tg_wifi_ssid_valid(too_long));
+  /* Ett SSID med radbrytning i hamnar i loggen och i AP-listans HTML —
+   * upstream är fientlig (läxan 2026-08-13, NUL-trunkeringen). */
+  check("ssid with newline rejected", !tg_wifi_ssid_valid("hem\nAP"));
+
+  check("empty password is a valid open network", tg_wifi_pass_valid(""));
+  check("7-char psk rejected", !tg_wifi_pass_valid("1234567"));
+  check("8-char psk accepted", tg_wifi_pass_valid("12345678"));
+  check("64-char psk rejected", !tg_wifi_pass_valid(
+      "0123456789012345678901234567890123456789012345678901234567890123"));
+  check("psk with control char rejected", tg_wifi_pass_valid("abc\tdefg") == 0);
+}
+
+static void test_write_slot_updates_before_it_evicts(void) {
+  tg_wifi_slot slots[TG_WIFI_SLOTS];
+  memset(slots, 0, sizeof slots);
+  put(&slots[0], "hem", "hemligt1", 5);
+  put(&slots[1], "kontor", "kontoret", 9);
+
+  check("known ssid updates its own slot",
+        tg_wifi_slot_for_write(slots, TG_WIFI_SLOTS, "hem") == 0);
+  check("new ssid takes the first empty slot",
+        tg_wifi_slot_for_write(slots, TG_WIFI_SLOTS, "hotell") == 2);
+
+  /* Fullt: den med lägst seq vräks, inte den första bästa. */
+  for (int i = 0; i < TG_WIFI_SLOTS; i++) {
+    char name[16];
+    snprintf(name, sizeof name, "plats%d", i);
+    put(&slots[i], name, "losenord", (uint32_t)(10 + i));
+  }
+  put(&slots[3], "aldrig-igen", "losenord", 2); /* lägst seq */
+  check("a full list evicts the least recently working network",
+        tg_wifi_slot_for_write(slots, TG_WIFI_SLOTS, "ny-plats") == 3);
+  check("a full list still prefers updating a known network",
+        tg_wifi_slot_for_write(slots, TG_WIFI_SLOTS, "plats5") == 5);
+}
+
+static void test_seq_next_saturates(void) {
+  tg_wifi_slot slots[2];
+  memset(slots, 0, sizeof slots);
+  check("empty list starts at 1", tg_wifi_seq_next(slots, 2) == 1);
+  put(&slots[0], "a", "losenord", 7);
+  check("next is one past the highest", tg_wifi_seq_next(slots, 2) == 8);
+  put(&slots[1], "b", "losenord", UINT32_MAX);
+  check("saturates instead of wrapping to zero",
+        tg_wifi_seq_next(slots, 2) == UINT32_MAX);
+}
+
+static void test_candidate_order(void) {
+  tg_wifi_slot remembered[TG_WIFI_SLOTS];
+  memset(remembered, 0, sizeof remembered);
+  put(&remembered[0], "hotell", "hotellet", 3);
+  put(&remembered[1], "hem", "hemligt1", 9);   /* senast lyckad */
+  put(&remembered[2], "kontor", "kontoret", 6);
+
+  tg_wifi_slot fixed[2];
+  memset(fixed, 0, sizeof fixed);
+  put(&fixed[0], "hem", "hemligt1", 0);        /* samma som NVS-posten */
+  put(&fixed[1], "iPhone", "hotspot1", 0);
+
+  const tg_wifi_slot *out[TG_WIFI_SLOTS + 2];
+  int n = tg_wifi_candidates(remembered, TG_WIFI_SLOTS, fixed, 2, out,
+                             TG_WIFI_SLOTS + 2);
+  check("every non-empty network appears once", n == 4);
+  check("most recently working network is tried first",
+        strcmp(out[0]->ssid, "hem") == 0);
+  check("then the next most recent", strcmp(out[1]->ssid, "kontor") == 0);
+  check("then the oldest remembered", strcmp(out[2]->ssid, "hotell") == 0);
+  /* Botten ur secrets.h ligger sist och dubbleras inte: "hem" fanns redan
+   * i NVS, så bara hotspoten är kvar att lägga till. */
+  check("the compiled-in floor comes last",
+        strcmp(out[3]->ssid, "iPhone") == 0);
+}
+
+static void test_candidates_survive_an_empty_store(void) {
+  tg_wifi_slot remembered[TG_WIFI_SLOTS];
+  memset(remembered, 0, sizeof remembered);
+  tg_wifi_slot fixed[2];
+  memset(fixed, 0, sizeof fixed);
+  put(&fixed[0], "hem", "hemligt1", 0);
+  /* fixed[1] lämnas tom — en secrets.h utan reservnät. */
+
+  const tg_wifi_slot *out[TG_WIFI_SLOTS + 2];
+  int n = tg_wifi_candidates(remembered, TG_WIFI_SLOTS, fixed, 2, out,
+                             TG_WIFI_SLOTS + 2);
+  /* Det här ÄR en färsk panel: tom NVS får aldrig betyda noll kandidater,
+   * för då slutar hemnätet fungera efter en uppdatering. */
+  check("a fresh panel still has its compiled-in home network", n == 1);
+  check("and it is the home network", strcmp(out[0]->ssid, "hem") == 0);
+
+  int none = tg_wifi_candidates(remembered, TG_WIFI_SLOTS, NULL, 0, out,
+                                TG_WIFI_SLOTS + 2);
+  check("no networks at all is zero, not a crash", none == 0);
+}
+
+static void test_switching(void) {
+  check("three misses stay on the same network", !tg_wifi_should_switch(3));
+  check("four misses switch", tg_wifi_should_switch(4));
+}
+
+static void test_setup_window_opens_only_when_it_can_help(void) {
+  const int64_t s = 1000000LL;
+
+  check("a panel with an IP never opens the setup window",
+        !tg_wifi_setup_should_open(true, 500 * s, 0, 0));
+  check("a short outage does not open it",
+        !tg_wifi_setup_should_open(false, 60 * s, 30 * s, 0));
+  check("ninety seconds without an IP opens it",
+        tg_wifi_setup_should_open(false, 200 * s, 100 * s, 0));
+  /* Kylperioden: en stängd panel som fortfarande saknar nät får inte
+   * öppna ett nytt fönster i samma andetag. */
+  check("a window that just closed holds the next one back",
+        !tg_wifi_setup_should_open(false, 300 * s, 100 * s, 290 * s));
+  check("after the cooldown it may open again",
+        tg_wifi_setup_should_open(false, 500 * s, 100 * s, 290 * s));
+  /* Har vi aldrig varit utan IP finns ingen startpunkt att mäta från. */
+  check("an unknown outage start never opens the window",
+        !tg_wifi_setup_should_open(false, 900 * s, 0, 0));
+}
+
+static void test_search_screen_lets_the_boot_screen_finish(void) {
+  const int64_t s = 1000000LL;
+
+  /* Bootskärmen äger de första 45 sekunderna och ger upp där. Tog nätsidan
+   * glaset direkt vid boot skulle två lager slåss om samma pixlar. */
+  check("the network screen stays away during boot",
+        !tg_wifi_search_ui_visible(false, 10 * s, 1 * s));
+  check("and while the boot screen is still up at 45 s",
+        !tg_wifi_search_ui_visible(false, 44 * s, 1 * s));
+  check("after a minute without an IP it explains itself",
+        tg_wifi_search_ui_visible(false, 61 * s, 1 * s));
+  /* En router som startar om ska inte svartna hela skärmen. */
+  check("a short outage never takes the glass",
+        !tg_wifi_search_ui_visible(false, 500 * s, 470 * s));
+  check("a panel with an IP never shows it",
+        !tg_wifi_search_ui_visible(true, 500 * s, 0));
+}
+
+static void test_setup_window_closes(void) {
+  const int64_t s = 1000000LL;
+
+  check("a window that was never opened cannot close",
+        !tg_wifi_setup_should_close(100 * s, 0, 0));
+  check("an open window with no join stays open",
+        !tg_wifi_setup_should_close(400 * s, 100 * s, 0));
+  check("ten minutes closes it",
+        tg_wifi_setup_should_close(701 * s, 100 * s, 0));
+  /* Klienten ska hinna läsa svaret innan AP:n rycks undan. */
+  check("a fresh join keeps the AP up for the linger",
+        !tg_wifi_setup_should_close(302 * s, 100 * s, 300 * s));
+  check("after the linger a joined window closes",
+        tg_wifi_setup_should_close(306 * s, 100 * s, 300 * s));
+}
+
+int main(void) {
+  test_validation();
+  test_write_slot_updates_before_it_evicts();
+  test_seq_next_saturates();
+  test_candidate_order();
+  test_candidates_survive_an_empty_store();
+  test_switching();
+  test_setup_window_opens_only_when_it_can_help();
+  test_search_screen_lets_the_boot_screen_finish();
+  test_setup_window_closes();
+
+  if (failures == 0) {
+    printf("OK: all WiFi slot/window policy tests pass\n");
+    return 0;
+  }
+  printf("%d tests failed\n", failures);
+  return 1;
+}

--- a/test/test_wifi_slots.c
+++ b/test/test_wifi_slots.c
@@ -181,7 +181,34 @@ static void test_setup_window_closes(void) {
         tg_wifi_setup_should_close(306 * s, 100 * s, 300 * s));
 }
 
+static void test_dma_gates_protect_the_flush(void) {
+  const size_t flush = 12 * 480 * 2; /* 11 520 — panelflushens block */
+
+  /* Öppningen kräver x4: accesspunkten, httpd:n och DNS-tasken ska rymmas
+   * utan att närma sig flushens tak. Ett vägrat fönster är en loggrad;
+   * en fryst panel är en USB-räddning (kilningen 2026-08-17). */
+  check("plenty of DMA opens", tg_wifi_setup_dma_ok_to_open(200000, flush));
+  check("exactly 4x opens", tg_wifi_setup_dma_ok_to_open(4 * flush, flush));
+  check("below 4x refuses to open",
+        !tg_wifi_setup_dma_ok_to_open(4 * flush - 1, flush));
+
+  /* Fortsättningsgrinden efter APSTA-bytet: under x2 rivs fönstret hellre
+   * än att httpd + DNS staplas ovanpå ett block som redan är i farozonen. */
+  check("above 2x continues",
+        tg_wifi_setup_dma_ok_to_continue(2 * flush, flush));
+  check("below 2x aborts",
+        !tg_wifi_setup_dma_ok_to_continue(2 * flush - 1, flush));
+
+  /* Ett okonfigurerat flushvärde får aldrig göra grinden till en
+   * papperstiger — "vet inte" betyder nej. */
+  check("an unset flush size refuses to open",
+        !tg_wifi_setup_dma_ok_to_open(200000, 0));
+  check("an unset flush size refuses to continue",
+        !tg_wifi_setup_dma_ok_to_continue(200000, 0));
+}
+
 int main(void) {
+  test_dma_gates_protect_the_flush();
   test_validation();
   test_write_slot_updates_before_it_evicts();
   test_seq_next_saturates();

--- a/test/test_wifi_slots.c
+++ b/test/test_wifi_slots.c
@@ -183,14 +183,21 @@ static void test_setup_window_closes(void) {
 
 static void test_dma_gates_protect_the_flush(void) {
   const size_t flush = 12 * 480 * 2; /* 11 520 — panelflushens block */
+  const size_t open_floor = TG_WIFI_SETUP_DMA_OPEN_FACTOR * flush;
 
-  /* Öppningen kräver x4: accesspunkten, httpd:n och DNS-tasken ska rymmas
-   * utan att närma sig flushens tak. Ett vägrat fönster är en loggrad;
-   * en fryst panel är en USB-räddning (kilningen 2026-08-17). */
   check("plenty of DMA opens", tg_wifi_setup_dma_ok_to_open(200000, flush));
-  check("exactly 4x opens", tg_wifi_setup_dma_ok_to_open(4 * flush, flush));
-  check("below 4x refuses to open",
-        !tg_wifi_setup_dma_ok_to_open(4 * flush - 1, flush));
+  check("exactly the open floor opens",
+        tg_wifi_setup_dma_ok_to_open(open_floor, flush));
+  check("below the open floor refuses",
+        !tg_wifi_setup_dma_ok_to_open(open_floor - flush, flush));
+
+  /* Kalibreringen mot verkligheten: v0.5.0:s friska baslinje på
+   * torget-home-01 var 40960 byte (serielogg 2026-08-18). En grind som
+   * vägrar en frisk panel dödar funktionen den skyddar — faktorn valdes
+   * så att baslinjen passerar. Faller det här testet har någon höjt
+   * faktorn över uppmätt verklighet. */
+  check("the measured healthy baseline passes the open gate",
+        tg_wifi_setup_dma_ok_to_open(40960, flush));
 
   /* Fortsättningsgrinden efter APSTA-bytet: under x2 rivs fönstret hellre
    * än att httpd + DNS staplas ovanpå ett block som redan är i farozonen. */

--- a/tools/relay/README.md
+++ b/tools/relay/README.md
@@ -1,0 +1,69 @@
+# The relay mailbox
+
+A ~150-line Cloudflare Worker that lets the panel fetch its numbers from
+anywhere, instead of only from the same LAN as the service. Full design
+rationale and what may/may not cross it: [docs/relay.md](../../docs/relay.md).
+
+## Deploy (once, ~10 minutes)
+
+Requires a free Cloudflare account and `wrangler` (`npm i -g wrangler`).
+
+```sh
+cd tools/relay
+wrangler kv namespace create VIBEPULSE      # note the id it prints
+
+cat > wrangler.toml <<EOF
+name = "vibepulse-relay"
+main = "worker.js"
+compatibility_date = "2026-08-01"
+
+[[kv_namespaces]]
+binding = "VIBEPULSE"
+id = "<the id from above>"
+EOF
+
+python3 -c "import secrets; print(secrets.token_hex(32))"   # the secret
+wrangler secret put RELAY_SECRET            # paste the secret
+wrangler deploy                             # prints the workers.dev URL
+```
+
+Your mailbox address is then:
+
+```
+https://vibepulse-relay.<your-subdomain>.workers.dev/u/<the secret>
+```
+
+The secret never lives in code or in this repo — it exists in the Worker's
+secret store, in your `secrets.h`, and in the service's start command.
+
+## Wire it up
+
+**Service side** (each machine that should publish — one or several):
+
+```sh
+python3 tools/tokenserver/tokenserver.py --publish "https://.../u/<secret>"
+```
+
+**Panel side** (`secrets.h`, then build + OTA once):
+
+```c
+#define TK_VIBEPULSE_RELAY_URL "https://.../u/<secret>"
+```
+
+## Verify
+
+```sh
+curl -s https://.../u/<secret>/api/tokens | head -c 200   # JSON within 30 s
+```
+
+`wrangler tail` shows requests live. The `test.mjs` suite
+(`node --test tools/relay/test.mjs`) holds the merge logic still without
+any Cloudflare involvement.
+
+## Free-tier arithmetic
+
+The publisher sends only on change plus a 5-minute heartbeat
+(`tools/tokenserver/publisher.py`), which lands at a few hundred KV writes
+per day against the free tier's 1 000. The panel's reads (2 880/day at a
+30 s cadence) sit far under the 100 000-read allowance. Two publishers
+double the writes; still comfortable.

--- a/tools/relay/test.mjs
+++ b/tools/relay/test.mjs
@@ -1,0 +1,71 @@
+/*
+ * Brevlådans sammanslagning, hållen stilla med node --test (ingen
+ * Cloudflare behövs): färskast vinner PER POOL för /api/tokens, nyast
+ * dokument för resten, och döda/korrupta dokument tystar aldrig de andra.
+ *
+ * Körs av test/run.sh när node finns; CI:s tokenserver-jobb kör den via
+ * "node --test tools/relay/".
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mergeTokens, newestBody } from "./worker.js";
+
+test("en ensam avsändare passerar orörd", () => {
+  const doc = { receivedAt: 100, publisher: "mac",
+                body: { v: 2, weekPct: 73, weekObservedAt: 90 } };
+  assert.deepEqual(mergeTokens([doc]), doc.body);
+});
+
+test("varje pool tas från den maskin som såg den senast", () => {
+  const mac = { receivedAt: 200, publisher: "mac", body: {
+    v: 2,
+    weekPct: 70, weekObservedAt: 150,        // äldre Claude-observation
+    codexWeekPct: 41, codexWeekObservedAt: 190,  // färsk Codex (Macen kör Codex)
+  } };
+  const pc = { receivedAt: 210, publisher: "pc", body: {
+    v: 2,
+    weekPct: 73, weekObservedAt: 205,        // färsk Claude (PC:n frågade nyss)
+    codexWeekPct: 39, codexWeekObservedAt: 100,  // gammal Codex
+  } };
+  const merged = mergeTokens([mac, pc]);
+  assert.equal(merged.weekPct, 73, "Claude ska komma från PC:n");
+  assert.equal(merged.codexWeekPct, 41, "Codex ska komma från Macen");
+  assert.equal(merged.codexWeekObservedAt, 190,
+               "stämpeln ska följa sin pools vinnare");
+});
+
+test("en pool bara den ena maskinen känner överlever", () => {
+  const utan = { receivedAt: 300, publisher: "pc",
+                 body: { v: 2, weekPct: 73, weekObservedAt: 295 } };
+  const med = { receivedAt: 250, publisher: "mac",
+                body: { v: 2, weekPct: 60, weekObservedAt: 200,
+                        codexWeekPct: 41, codexWeekObservedAt: 240 } };
+  const merged = mergeTokens([utan, med]);
+  assert.equal(merged.codexWeekPct, 41,
+               "att PC:n aldrig sett Codex får inte radera Codex-siffran");
+  assert.equal(merged.weekPct, 73);
+});
+
+test("ostämplade fält följer det nyast mottagna dokumentet", () => {
+  const gammal = { receivedAt: 100, publisher: "mac",
+                   body: { v: 2, daySessions: 4 } };
+  const ny = { receivedAt: 200, publisher: "pc",
+               body: { v: 2, daySessions: 9 } };
+  assert.equal(mergeTokens([gammal, ny]).daySessions, 9);
+});
+
+test("döda och korrupta dokument tystar inte de andra", () => {
+  const frisk = { receivedAt: 100, publisher: "mac",
+                  body: { v: 2, weekPct: 73 } };
+  assert.equal(mergeTokens([null, { receivedAt: 1, body: null },
+                            frisk]).weekPct, 73);
+  assert.equal(mergeTokens([]), null);
+  assert.equal(mergeTokens([null]), null);
+});
+
+test("newestBody är nyast mottagna, inget annat", () => {
+  const a = { receivedAt: 100, publisher: "mac", body: { streak: 3 } };
+  const b = { receivedAt: 200, publisher: "pc", body: { streak: 1 } };
+  assert.equal(newestBody([a, b]).streak, 1);
+  assert.equal(newestBody([]), null);
+});

--- a/tools/relay/worker.js
+++ b/tools/relay/worker.js
@@ -1,0 +1,156 @@
+/*
+ * VibePulse-brevlådan: en Cloudflare Worker + KV som håller tjänstens
+ * senaste siffror så panelen kan hämta dem från vilket nät som helst.
+ *
+ * Rollen är medvetet dum: den kan ingenting, vet ingenting och har inga
+ * nycklar. Tjänsten (tools/tokenserver --publish) POSTar färdiga JSON-
+ * kroppar hit; panelen GETtar dem när LAN:et inte svarar. Det som ligger
+ * här är SIFFROR — kvot, burn rate, Max Tracker, GitHub. Agentstatus och
+ * Needs You publiceras aldrig (firmwarens test/test_relay_boundary.py och
+ * tjänstens publisher.py håller den gränsen från var sitt håll).
+ *
+ * Åtkomstkontrollen ÄR sökvägen: /u/<hemlighet>/api/... där hemligheten
+ * är minst 32 slumpade byte ur secrets.h (TK_VIBEPULSE_RELAY_URL). Samma
+ * skyddsnivå som en privat delningslänk — rätt nivå för procentsiffror,
+ * och skälet till att inget känsligare än siffror får bo här.
+ *
+ * Flera avsändare (en Mac som sover, en alltid-på-PC) publicerar till
+ * samma brevlåda under eget namn. Läsningen slår ihop dem:
+ *
+ *   /api/tokens      — färskast VINNER PER POOL: varje kvotpool bär redan
+ *                      sin egen observationsstämpel (weekObservedAt,
+ *                      modelObservedAt, ... — byggda för stalenesslogiken),
+ *                      så Codex-siffran kan komma från Macen som körde
+ *                      Codex senast medan Claude-siffran kommer från PC:n
+ *                      som frågade Anthropic för tio sekunder sedan.
+ *   /api/max-tracker — nyast mottagna dokument vinner helt. Historiken är
+ *                      per maskin; en dag-för-dag-sammanslagning vore att
+ *                      hitta på data ingen maskin har sett. Ärlig gräns:
+ *                      kör du Max Tracker-historik från två maskiner är
+ *                      det den senast publicerande som syns.
+ *   /api/github      — nyast vinner. Båda frågar samma publika API.
+ *
+ * Deploy: se README.md i den här katalogen. KV-bindningen heter VIBEPULSE.
+ */
+
+const ENDPOINTS = ["/api/tokens", "/api/max-tracker", "/api/github"];
+const MAX_BODY_BYTES = 64 * 1024; // largest honest payload is ~8 kB
+const MAX_PUBLISHERS = 8;
+
+/*
+ * Sammanslagningen för /api/tokens, som ren funktion så testerna kan hålla
+ * den stilla (node --test i test.mjs — ingen Cloudflare behövs).
+ *
+ * Regeln: basen är det nyast MOTTAGNA dokumentet (fält utan stämpel följer
+ * det). Sedan får varje observationsstämplad fältgrupp — prefixet framför
+ * "ObservedAt", t.ex. week/model/codexWeek — sina fält från det dokument
+ * vars stämpel för JUST den gruppen är färskast. En grupp ett dokument
+ * saknar lämnas orörd: att en maskin aldrig sett Codex betyder inte att
+ * Codex-siffran ska försvinna.
+ */
+export function mergeTokens(docs) {
+  const alive = docs.filter((d) => d && typeof d.body === "object" &&
+                                   d.body !== null);
+  if (alive.length === 0) return null;
+  alive.sort((a, b) => (b.receivedAt || 0) - (a.receivedAt || 0));
+  const merged = { ...alive[0].body };
+
+  const groups = new Set();
+  for (const doc of alive)
+    for (const key of Object.keys(doc.body))
+      if (key.endsWith("ObservedAt")) groups.add(key.slice(0, -10));
+
+  for (const group of groups) {
+    const stamp = group + "ObservedAt";
+    let winner = null;
+    for (const doc of alive) {
+      const at = doc.body[stamp];
+      if (typeof at !== "number") continue;
+      if (winner === null || at > winner.body[stamp]) winner = doc;
+    }
+    if (winner === null) continue;
+    for (const key of Object.keys(winner.body))
+      if (key === stamp || (key.startsWith(group) &&
+                            !key.endsWith("ObservedAt")))
+        merged[key] = winner.body[key];
+  }
+  return merged;
+}
+
+/* Nyast mottagna dokument, för endpoints utan sammanslagning. */
+export function newestBody(docs) {
+  const alive = docs.filter((d) => d && typeof d.body === "object" &&
+                                   d.body !== null);
+  if (alive.length === 0) return null;
+  alive.sort((a, b) => (b.receivedAt || 0) - (a.receivedAt || 0));
+  return alive[0].body;
+}
+
+function parsePath(url, secret) {
+  const prefix = `/u/${secret}`;
+  const path = new URL(url).pathname;
+  if (!path.startsWith(prefix + "/")) return null;
+  const endpoint = path.slice(prefix.length);
+  return ENDPOINTS.includes(endpoint) ? endpoint : null;
+}
+
+async function readDocs(env, endpoint) {
+  const listed = await env.VIBEPULSE.list({ prefix: `${endpoint}:` });
+  const docs = [];
+  for (const key of listed.keys.slice(0, MAX_PUBLISHERS)) {
+    const raw = await env.VIBEPULSE.get(key.name);
+    if (!raw) continue;
+    try {
+      docs.push(JSON.parse(raw));
+    } catch {
+      /* ett korrupt dokument tystar inte de andra */
+    }
+  }
+  return docs;
+}
+
+export default {
+  async fetch(request, env) {
+    // Hemligheten är en Worker-secret (wrangler secret put RELAY_SECRET),
+    // aldrig kod. Utan den svarar brevlådan ingenting alls.
+    const secret = env.RELAY_SECRET;
+    if (!secret || secret.length < 32)
+      return new Response("relay not configured", { status: 503 });
+
+    const endpoint = parsePath(request.url, secret);
+    if (endpoint === null) return new Response("not found", { status: 404 });
+
+    if (request.method === "POST" || request.method === "PUT") {
+      const publisher =
+          (request.headers.get("X-VibePulse-Publisher") || "unnamed")
+              .slice(0, 64).replace(/[^A-Za-z0-9._-]/g, "_");
+      const raw = await request.text();
+      if (raw.length > MAX_BODY_BYTES)
+        return new Response("too large", { status: 413 });
+      let body;
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        return new Response("not json", { status: 400 });
+      }
+      const doc = JSON.stringify({ receivedAt: Date.now() / 1000,
+                                   publisher, body });
+      await env.VIBEPULSE.put(`${endpoint}:${publisher}`, doc);
+      return new Response("ok", { status: 200 });
+    }
+
+    if (request.method === "GET") {
+      const docs = await readDocs(env, endpoint);
+      const merged = endpoint === "/api/tokens" ? mergeTokens(docs)
+                                                : newestBody(docs);
+      if (merged === null)
+        return new Response(JSON.stringify({ error: "no data yet" }),
+                            { status: 404,
+                              headers: { "Content-Type": "application/json" } });
+      return new Response(JSON.stringify(merged),
+                          { headers: { "Content-Type": "application/json" } });
+    }
+
+    return new Response("method not allowed", { status: 405 });
+  },
+};

--- a/tools/tokenserver/install-windows-task.ps1
+++ b/tools/tokenserver/install-windows-task.ps1
@@ -1,0 +1,80 @@
+<#
+Registrera tokenservern som en schemalagd uppgift på Windows, så den
+överlever utloggning och omstart — luckan i issue #3: tjänsten fanns men
+dog med terminalfönstret.
+
+Körs i PowerShell från repots rot:
+
+  powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 `
+      -PublishUrl "https://<din-brevlåda>/u/<hemlighet>"
+
+  # utan relä (bara LAN-servering):
+  powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1
+
+  # avinstallera:
+  powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -Uninstall
+
+Designval, i linje med resten av repot:
+
+- Uppgiften kör som DEN INLOGGADE ANVÄNDAREN, inte SYSTEM. Tokenservern
+  läser %USERPROFILE%\.claude\.credentials.json — en SYSTEM-tjänst hade
+  läst fel profil och dessutom gett processen mer rättigheter än den
+  behöver.
+- pythonw.exe (inget konsolfönster). Loggarna hamnar där de redan bor:
+  %LOCALAPPDATA%\VibePulse\ (tjänstens egen självroterande logg).
+- Ingen hemlighet i den registrerade kommandoraden utom relä-URL:en, som
+  användaren själv valt att ge — samma exponeringsnivå som secrets.h.
+- Starta om vid fel, var 5:e minut, utan tak — en hyllservice ska resa
+  sig själv, precis som launchd-plisten gör på macOS.
+#>
+param(
+    [string]$PublishUrl = "",
+    [string]$PublishName = "",
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+$TaskName = "VibePulse tokenserver"
+
+if ($Uninstall) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "Uppgiften '$TaskName' borttagen. Processen som redan kör påverkas inte;"
+    Write-Host "stoppa den via porten:  Get-NetTCPConnection -LocalPort 8737 -State Listen |"
+    Write-Host "  Select -Expand OwningProcess | ForEach-Object { Stop-Process -Id `$_ }"
+    exit 0
+}
+
+# Repots rot är två steg upp från det här skriptet — uppgiften ska
+# överleva att den registreras från vilken katalog som helst.
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$Server = Join-Path $RepoRoot "tools\tokenserver\tokenserver.py"
+if (-not (Test-Path $Server)) { throw "hittar inte $Server" }
+
+# pythonw = ingen konsol. Faller tillbaka till python.exe om pythonw
+# saknas (minimala installationer) — då syns ett fönster, men tjänsten kör.
+$Python = (Get-Command pythonw.exe -ErrorAction SilentlyContinue).Source
+if (-not $Python) { $Python = (Get-Command python.exe).Source }
+
+$ServerArgs = "`"$Server`""
+if ($PublishUrl) {
+    $ServerArgs += " --publish `"$PublishUrl`""
+    if ($PublishName) { $ServerArgs += " --publish-name `"$PublishName`"" }
+}
+
+$Action = New-ScheduledTaskAction -Execute $Python -Argument $ServerArgs `
+    -WorkingDirectory $RepoRoot
+$Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$Settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+    -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 5) `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0)
+
+Register-ScheduledTask -TaskName $TaskName -Action $Action `
+    -Trigger $Trigger -Settings $Settings -Force | Out-Null
+Start-ScheduledTask -TaskName $TaskName
+
+Write-Host "Uppgiften '$TaskName' registrerad och startad."
+Write-Host "  server:  $Server"
+if ($PublishUrl) { Write-Host "  relä:    $PublishUrl" }
+Write-Host "  loggar:  $env:LOCALAPPDATA\VibePulse\"
+Write-Host "Verifiera:  curl http://localhost:8737/  (claudeProbe ska visa ok)"

--- a/tools/tokenserver/publisher.py
+++ b/tools/tokenserver/publisher.py
@@ -1,0 +1,161 @@
+"""Push the served numbers to a relay mailbox on the internet.
+
+The panel could only fetch from this service when both sat on the same
+LAN.  A guest network's client isolation, an IoT VLAN, or a host that
+changed IP was enough to blank the glass while internet worked fine
+(2026-08-17, the whole evening).  The relay is the answer's second half:
+the panel-side failover landed in ``components/torget_net``; this module
+is the service side, POSTing the same three payloads the LAN endpoints
+serve to a mailbox the panel can always reach.
+
+What crosses, and what never does, mirrors the firmware's tested boundary
+(``test/test_relay_boundary.py``): numbers only.  ``/api/tokens``,
+``/api/max-tracker`` and ``/api/github``.  Agent status and Needs You
+carry project names, question text and commands — they are not published,
+and there is deliberately no way to add them here without also changing
+the firmware's boundary test.
+
+Several machines may publish to the same mailbox (a Mac that sleeps, an
+always-on PC).  Each send names its publisher so the mailbox can merge
+freshest-per-source; this module only needs to be honest about who it is.
+
+Write economy is a design constraint, not an optimization: the free tier
+of the intended mailbox (Cloudflare KV) allows 1 000 writes/day, and a
+30-second cadence would burn 2 880.  So a payload is sent only when its
+content actually changed, plus a heartbeat so the mailbox's staleness is
+bounded even when nothing changes.  Both rules live in pure functions the
+tests can hold still.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+
+log = logging.getLogger("tokenserver")
+
+# Publish cadence: check for changes at the same rhythm the panel polls,
+# heartbeat every five minutes.  ~300 heartbeat writes/day for three
+# endpoints plus real changes -- comfortably inside 1 000.
+CHECK_EVERY_S = 30.0
+HEARTBEAT_EVERY_S = 300.0
+
+# An honest User-Agent.  The relay is our own mailbox; there is nobody to
+# imitate and no reason to.
+USER_AGENT = "vibepulse-publisher/1"
+
+
+def payload_fingerprint(payload) -> str:
+    """A stable content hash for change detection.
+
+    sort_keys makes dict ordering irrelevant; the serialized form is also
+    exactly what gets sent, so "fingerprint unchanged" always means "the
+    mailbox already holds these bytes".
+    """
+    body = json.dumps(payload, sort_keys=True).encode()
+    return hashlib.sha256(body).hexdigest()
+
+
+def should_send(last_fingerprint, last_sent_at, fingerprint, now) -> bool:
+    """The write-economy rule: send on change, or on heartbeat, never else.
+
+    ``last_fingerprint is None`` means never sent (fresh start): send.
+    A failed send must NOT update the caller's state, so the next tick
+    retries by construction rather than by a retry mechanism.
+    """
+    if last_fingerprint is None:
+        return True
+    if fingerprint != last_fingerprint:
+        return True
+    return (now - last_sent_at) >= HEARTBEAT_EVERY_S
+
+
+class Publisher:
+    """Owns the publish loop for a set of payload producers.
+
+    ``producers`` maps endpoint path -> zero-arg callable returning the
+    payload (the same callables the HTTP handlers use, so the mailbox can
+    never diverge from what the LAN serves).  ``post`` is injectable for
+    tests; the default does a real HTTP POST.
+    """
+
+    def __init__(self, relay_url: str, machine: str, producers: dict,
+                 post=None, clock=time.time):
+        self.relay_url = relay_url.rstrip("/")
+        self.machine = machine
+        self.producers = producers
+        self.post = post if post is not None else self._http_post
+        self.clock = clock
+        # per path: (fingerprint, sent_at)
+        self._state = {}
+        self._stop = threading.Event()
+        self._thread = None
+
+    # ------------------------------------------------------------------ http
+
+    def _http_post(self, url: str, body: bytes) -> bool:
+        request = urllib.request.Request(
+            url, data=body, method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": USER_AGENT,
+                "X-VibePulse-Publisher": self.machine,
+            })
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                return 200 <= response.status < 300
+        except (urllib.error.URLError, OSError, TimeoutError):
+            return False
+
+    # ------------------------------------------------------------------ loop
+
+    def publish_once(self) -> int:
+        """One pass over every producer.  Returns the number of sends.
+
+        A producer that raises is logged and skipped -- one broken payload
+        must never stop the others from publishing (the same isolation the
+        HTTP handlers give each endpoint).
+        """
+        sends = 0
+        for path, produce in self.producers.items():
+            try:
+                payload = produce()
+            except Exception:
+                log.exception("publicering: %s-producenten föll", path)
+                continue
+            fingerprint = payload_fingerprint(payload)
+            last_fingerprint, sent_at = self._state.get(path, (None, 0.0))
+            now = self.clock()
+            if not should_send(last_fingerprint, sent_at, fingerprint, now):
+                continue
+            body = json.dumps(payload, sort_keys=True).encode()
+            if self.post(self.relay_url + path, body):
+                self._state[path] = (fingerprint, now)
+                sends += 1
+            else:
+                # State untouched: next tick retries.  Log once per failure
+                # tick is acceptable at this cadence; the panel keeps its
+                # last good values either way.
+                log.warning("publicering: %s nådde inte reläet", path)
+        return sends
+
+    def start(self):
+        def run():
+            while not self._stop.wait(CHECK_EVERY_S):
+                self.publish_once()
+        # First pass immediately: the mailbox should be warm within one
+        # cadence of service start, not one heartbeat.
+        self.publish_once()
+        self._thread = threading.Thread(target=run, name="relay-publisher",
+                                        daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)

--- a/tools/tokenserver/test_publisher.py
+++ b/tools/tokenserver/test_publisher.py
@@ -1,0 +1,117 @@
+"""The relay publisher's two contracts: write economy, and honesty.
+
+Write economy because the mailbox's free tier allows 1 000 writes/day and
+a naive 30-second cadence would burn 2 880.  Honesty because every send
+must name its publisher (the mailbox merges freshest-per-source) and wear
+the project's own User-Agent, not somebody else's.
+"""
+
+import unittest
+
+try:
+    from .publisher import (Publisher, HEARTBEAT_EVERY_S,
+                            payload_fingerprint, should_send, USER_AGENT)
+except ImportError:
+    from publisher import (Publisher, HEARTBEAT_EVERY_S,
+                           payload_fingerprint, should_send, USER_AGENT)
+
+
+class FingerprintTests(unittest.TestCase):
+    def test_key_order_is_irrelevant(self):
+        a = payload_fingerprint({"x": 1, "y": [1, 2]})
+        b = payload_fingerprint({"y": [1, 2], "x": 1})
+        self.assertEqual(a, b)
+
+    def test_value_changes_are_visible(self):
+        self.assertNotEqual(payload_fingerprint({"pct": 73.0}),
+                            payload_fingerprint({"pct": 73.1}))
+
+
+class ShouldSendTests(unittest.TestCase):
+    def test_a_fresh_start_sends(self):
+        self.assertTrue(should_send(None, 0.0, "abc", 1000.0))
+
+    def test_unchanged_content_waits(self):
+        self.assertFalse(should_send("abc", 1000.0, "abc", 1010.0))
+
+    def test_changed_content_sends_immediately(self):
+        self.assertTrue(should_send("abc", 1000.0, "def", 1001.0))
+
+    def test_the_heartbeat_bounds_staleness(self):
+        just_before = 1000.0 + HEARTBEAT_EVERY_S - 1
+        at = 1000.0 + HEARTBEAT_EVERY_S
+        self.assertFalse(should_send("abc", 1000.0, "abc", just_before))
+        self.assertTrue(should_send("abc", 1000.0, "abc", at))
+
+
+class PublisherTests(unittest.TestCase):
+    def _publisher(self, producers, results=None):
+        sent = []
+        outcomes = list(results) if results is not None else None
+
+        def post(url, body):
+            sent.append((url, body))
+            return True if outcomes is None else outcomes.pop(0)
+
+        clock = {"now": 1000.0}
+        p = Publisher("https://relay.example/u/s3cret/", "test-machine",
+                      producers, post=post, clock=lambda: clock["now"])
+        return p, sent, clock
+
+    def test_publishes_each_endpoint_to_its_path(self):
+        p, sent, _ = self._publisher({
+            "/api/tokens": lambda: {"weekPct": 73.0},
+            "/api/github": lambda: {"stars": 5},
+        })
+        self.assertEqual(p.publish_once(), 2)
+        urls = sorted(url for url, _ in sent)
+        # Trailing slash on the configured URL must not double up.
+        self.assertEqual(urls, ["https://relay.example/u/s3cret/api/github",
+                                "https://relay.example/u/s3cret/api/tokens"])
+
+    def test_unchanged_payloads_are_not_resent(self):
+        p, sent, clock = self._publisher({"/api/tokens": lambda: {"pct": 73}})
+        p.publish_once()
+        clock["now"] += 30
+        p.publish_once()
+        self.assertEqual(len(sent), 1, "an unchanged payload was resent")
+
+    def test_change_and_heartbeat_both_send(self):
+        value = {"pct": 73}
+        p, sent, clock = self._publisher({"/api/tokens": lambda: dict(value)})
+        p.publish_once()
+        value["pct"] = 74
+        clock["now"] += 30
+        p.publish_once()
+        self.assertEqual(len(sent), 2, "a changed payload must send")
+        clock["now"] += HEARTBEAT_EVERY_S
+        p.publish_once()
+        self.assertEqual(len(sent), 3, "the heartbeat must send")
+
+    def test_a_failed_send_retries_next_tick(self):
+        p, sent, clock = self._publisher({"/api/tokens": lambda: {"a": 1}},
+                                         results=[False, True])
+        self.assertEqual(p.publish_once(), 0)
+        clock["now"] += 30
+        self.assertEqual(p.publish_once(), 1)
+        self.assertEqual(len(sent), 2)
+
+    def test_a_broken_producer_does_not_stop_the_others(self):
+        def broken():
+            raise RuntimeError("boom")
+
+        p, sent, _ = self._publisher({"/api/tokens": broken,
+                                      "/api/github": lambda: {"ok": 1}})
+        self.assertEqual(p.publish_once(), 1)
+        self.assertEqual(len(sent), 1)
+
+    def test_the_user_agent_is_our_own(self):
+        # The Anthropic probe imitating claude-cli is a separate, deliberate
+        # decision — but OUR mailbox gets OUR name.  If someone changes the
+        # constant to imitate anything, this fails.
+        self.assertTrue(USER_AGENT.startswith("vibepulse-publisher/"),
+                        USER_AGENT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -70,6 +70,7 @@ if __package__:
     from .github_monitor import GitHubMonitor, disabled_snapshot, normalize_repo
     from .interactions import InteractionStore
     from .max_tracker import MaxTrackerStore
+    from .publisher import Publisher
     from .quota_cache import CachedQuota, QuotaCache
     from .usage_history import Forecast, UsageHistory
     from . import codex_usage, interactions, value_meter
@@ -79,6 +80,7 @@ else:  # direktkörning: python3 tools/tokenserver/tokenserver.py
     from github_monitor import GitHubMonitor, disabled_snapshot, normalize_repo
     from interactions import InteractionStore
     from max_tracker import MaxTrackerStore
+    from publisher import Publisher
     from quota_cache import CachedQuota, QuotaCache
     from usage_history import Forecast, UsageHistory
     import codex_usage
@@ -2290,6 +2292,19 @@ def _build_arg_parser():
         help="Frivilligt publikt GitHub-repo som owner/repository. "
              "Kan också sättas med VIBEPULSE_GITHUB_REPO.")
     ap.add_argument(
+        "--publish", metavar="RELAY_URL", default=None,
+        help="also POST the numbers endpoints (/api/tokens, /api/max-tracker,"
+             " /api/github) to a relay mailbox on the internet, so a panel"
+             " that cannot reach this LAN still gets them (docs/relay.md)."
+             " The URL is the mailbox address INCLUDING its secret path."
+             " Agent status and Needs You are never published -- the relay"
+             " carries numbers, not activity")
+    ap.add_argument(
+        "--publish-name", default=None,
+        help="publisher name sent with every relay POST (default: this"
+             " machine's hostname). Several machines may publish to the same"
+             " mailbox; the mailbox merges freshest-per-source by name")
+    ap.add_argument(
         "--interactions", action="store_true",
         help="accept Claude Code hooks on loopback and let a paired device "
              "answer them ('Needs You'). Off by default. Needs a device key "
@@ -2489,6 +2504,42 @@ def main():
                         "TK_VIBEPULSE_DEVICE_KEY i secrets.h (samma värde "
                         "som skärmen bygger med) för att kunna svara.")
 
+    relay_publisher = None
+    if args.publish:
+        # Producenterna ÄR handlarnas: reläet kan aldrig glida ifrån det
+        # LAN-endpointsen serverar. Agentstatus och Needs You publiceras
+        # medvetet inte — reläet bär siffror, aldrig aktivitet (samma gräns
+        # som firmwarens test/test_relay_boundary.py håller).
+        def _tokens_payload():
+            return get_snapshot(Handler.projects_dir,
+                                max_tracker_store=Handler.max_tracker_store)
+
+        def _tracker_payload():
+            quota_snapshot = get_snapshot(
+                Handler.projects_dir,
+                max_tracker_store=Handler.max_tracker_store)
+            today = datetime.now().astimezone().date().isoformat()
+            payload = Handler.max_tracker_store.snapshot(today, Handler.plans)
+            payload["stale"] = bool(
+                quota_snapshot.get("claudeWeekStale") or
+                quota_snapshot.get("codexWeekStale"))
+            return payload
+
+        def _github_payload():
+            return (github_monitor.snapshot() if github_monitor is not None
+                    else disabled_snapshot())
+
+        machine = args.publish_name or socket.gethostname().split(".")[0]
+        relay_publisher = Publisher(args.publish, machine, {
+            "/api/tokens": _tokens_payload,
+            "/api/max-tracker": _tracker_payload,
+            "/api/github": _github_payload,
+        })
+        relay_publisher.start()
+        log.info("publicerar siffror till reläet som \"%s\" (ändringar + "
+                 "hjärtslag var 5:e minut; agentstatus och Needs You "
+                 "publiceras ALDRIG)", machine)
+
     backfill_stop = threading.Event()
     backfill_thread = threading.Thread(
         target=_run_max_tracker_backfill,
@@ -2508,6 +2559,8 @@ def main():
     except KeyboardInterrupt:
         pass
     finally:
+        if relay_publisher is not None:
+            relay_publisher.stop()
         if github_monitor is not None:
             github_monitor.stop()
         backfill_stop.set()

--- a/tools/wifi-here.sh
+++ b/tools/wifi-here.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# "Panelen, följ med dit jag är." Ett kommando på Macen som ger VibePulse
+# nätet Macen redan sitter på — ingen ombyggnad, ingen USB-kabel, ingenting
+# att skriva av från glaset.
+#
+#   1. Panelen reser sin egen accesspunkt (VibePulse-setup). Den gör det
+#      själv efter 90 s utan nät, eller direkt om du håller KEY3 ~3 s.
+#   2. tools/wifi-here.sh
+#
+# Skriptet läser Macens nuvarande SSID, hämtar lösenordet ur nyckelringen
+# (macOS frågar dig — det är samtycket), hoppar över till panelens
+# accesspunkt, lämnar över uppgifterna och släpper tillbaka WiFi:t. Macen är
+# offline i ungefär tjugo sekunder.
+#
+# Panelen MINNS nätet. Nästa gång du är på samma plats ansluter den själv,
+# och du kör aldrig det här kommandot igen för just den platsen.
+#
+# Accesspunktens lösenord härleds ur TG_OTA_TOKEN i secrets.h, samma
+# hemlighet som redan får skriva firmware — därför behöver skriptet inget
+# som står på skärmen. Saknas token är lösenordet slumpat per fönster och
+# står bara på glaset; kör då med:  TG_AP_PASS=<det på skärmen> tools/wifi-here.sh
+set -eu
+cd "$(dirname "$0")/.."
+
+AP_SSID=VibePulse-setup
+AP_HOST=192.168.4.1
+DOMAIN=vibepulse-softap-v1
+
+case "$(uname -s)" in
+  Darwin) ;;
+  *) echo "wifi-here.sh är macOS-specifikt (networksetup + nyckelringen)." >&2
+     echo "På annan plattform: anslut till $AP_SSID och öppna http://$AP_HOST/" >&2
+     exit 1 ;;
+esac
+
+# WiFi-gränssnittet heter inte alltid en0 (Ethernet-dongel, extra portar).
+IFACE=$(networksetup -listallhardwareports \
+        | awk '/Hardware Port: Wi-Fi/{getline; print $2; exit}')
+[ -n "$IFACE" ] || { echo "hittar inget Wi-Fi-gränssnitt" >&2; exit 1; }
+
+# Macens nuvarande nät. networksetup skriver "You are not associated..." när
+# WiFi är av — då finns inget nät att ge vidare.
+SSID=$(networksetup -getairportnetwork "$IFACE" | sed -n 's/^Current Wi-Fi Network: //p')
+[ -n "$SSID" ] || {
+  echo "Macen sitter inte på något Wi-Fi-nät — det är nätet vi skulle ge vidare." >&2
+  exit 1
+}
+echo "Macen är på \"$SSID\" ($IFACE)."
+
+# Lösenordet ur systemnyckelringen. Det här är prompten som gör dig till den
+# som godkänner överlämningen; skriptet ser aldrig något du inte släppt fram.
+# Ett öppet nät har ingen post — tomt lösenord är ett giltigt svar.
+PSK=$(security find-generic-password -ga "$SSID" -w \
+      /Library/Keychains/System.keychain 2>/dev/null || true)
+
+# Accesspunktens lösenord: härlett ur token, eller övertaget ur miljön.
+if [ -n "${TG_AP_PASS:-}" ]; then
+  AP_PASS=$TG_AP_PASS
+else
+  TOKEN=$(sed -n 's/.*TG_OTA_TOKEN[^"]*"\([0-9a-f]\{64\}\)".*/\1/p' secrets.h | head -1)
+  [ -n "$TOKEN" ] || {
+    echo "inget TG_OTA_TOKEN i secrets.h — läs av lösenordet på glaset och kör:" >&2
+    echo "  TG_AP_PASS=<lösenordet> tools/wifi-here.sh" >&2
+    exit 1
+  }
+  AP_PASS=$(printf '%s%s' "$DOMAIN" "$TOKEN" | shasum -a 256 | cut -c1-12)
+fi
+
+echo "hoppar över till $AP_SSID (Macen är offline en stund)..."
+if ! networksetup -setairportnetwork "$IFACE" "$AP_SSID" "$AP_PASS" >/dev/null 2>&1; then
+  echo "kom inte in på $AP_SSID." >&2
+  echo "Står WIFI SETUP på glaset? Fönstret är öppet i tio minuter — håll" >&2
+  echo "KEY3 ~3 s för att öppna ett nytt." >&2
+  exit 1
+fi
+
+# Tillbaka till Macens eget nät oavsett hur det går härnäst: att lämna
+# någon strandad på en panels accesspunkt vore ett uselt slut.
+restore() {
+  echo "släpper tillbaka Macens WiFi..."
+  networksetup -setairportpower "$IFACE" off >/dev/null 2>&1 || true
+  sleep 2
+  networksetup -setairportpower "$IFACE" on >/dev/null 2>&1 || true
+}
+trap restore EXIT
+
+# Vänta in DHCP från panelen innan POST:en — direkt efter associationen har
+# gränssnittet ännu ingen adress och curl faller på "no route to host".
+i=0
+while [ "$i" -lt 15 ]; do
+  curl -s --max-time 2 "http://$AP_HOST/" >/dev/null 2>&1 && break
+  i=$((i + 1))
+  sleep 1
+done
+[ "$i" -lt 15 ] || { echo "panelen svarar inte på http://$AP_HOST/" >&2; exit 1; }
+
+echo "lämnar över \"$SSID\"..."
+CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+       -X POST "http://$AP_HOST/join" \
+       --data-urlencode "ssid=$SSID" \
+       --data-urlencode "pass=$PSK")
+
+if [ "$CODE" != "200" ]; then
+  echo "panelen avvisade uppgifterna (HTTP $CODE)." >&2
+  [ -n "$PSK" ] || echo "Nyckelringen gav inget lösenord — är nätet öppet?" >&2
+  exit 1
+fi
+
+echo "klart. Panelen ansluter till \"$SSID\" och minns det härnäst."


### PR DESCRIPTION
## Summary

- Enforce an effective LVGL memory pool of at least 256 KiB during ESP-IDF configuration.
- Add four regression checks covering rejection at 96 KiB, acceptance at 256 KiB, root build wiring, and alignment with `sdkconfig.defaults`.
- Record the hardware-confirmed root cause and recovery procedure.

## Root cause

The generated `sdkconfig` still configured a 96 KiB LVGL pool even though `sdkconfig.defaults` specified 256 KiB, because defaults do not migrate an already-generated configuration. Rendering the `%` glyph in `plex_num_164` required an 18 KiB temporary buffer. Under v0.6's added pressure from the always-created WiFi overlay, that allocation failed and `LV_ASSERT_MALLOC` spun in `while(1)` while holding the LVGL lock, wedging the renderer.

## Validation

- `idf.py reconfigure && idf.py build`
- `PATH=.venv/bin:$PATH ./test/run.sh` — 565 Python tests and 6 TAP tests passed
- Physical `ota_1` panel: rotation, repeated token/max-tracker renders, and maintenance takeover open/close all remained responsive; post-stress JTAG inspection showed healthy LVGL and idle tasks
- `ota_0` was not written or modified

## Scope

This PR excludes the simulator debug probes and all ignored/local configuration files.
