### PR TITLE
Fix panel relay HKDF build wiring

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -10,6 +10,7 @@ menu "VibePulse optional network features"
 config TK_VIBEPULSE_INTERACTION_RELAY
     bool "Encrypted Needs You relay (works across unrelated Wi-Fi)"
     default n
+    select MBEDTLS_HKDF_C
     help
         Poll a separately deployed Cloudflare mailbox for end-to-end
         encrypted Claude/Codex Needs You views and return signed encrypted

--- a/test/test_interaction_relay_build.py
+++ b/test/test_interaction_relay_build.py
@@ -27,6 +27,16 @@ class InteractionRelayBuildTests(unittest.TestCase):
         self.assertRegex(match.group("body"), r"(?m)^\s*bool\b")
         self.assertRegex(match.group("body"), r"(?m)^\s*default n\s*$")
 
+    def test_enabled_relay_selects_its_hkdf_dependency(self) -> None:
+        source = read("main/Kconfig.projbuild")
+        match = re.search(
+            r"config TK_VIBEPULSE_INTERACTION_RELAY\n(?P<body>.*?)(?=\nconfig |\nendmenu|\Z)",
+            source,
+            re.S,
+        )
+        self.assertIsNotNone(match)
+        self.assertRegex(match.group("body"), r"(?m)^\s*select MBEDTLS_HKDF_C\s*$")
+
     def test_component_is_absent_from_default_build(self) -> None:
         source = read("components/app_tokens/CMakeLists.txt")
         self.assertIn("if(CONFIG_TK_VIBEPULSE_INTERACTION_RELAY)", source)

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -3338,6 +3338,13 @@ class InteractionRelayConfigTests(unittest.TestCase):
             self.stopped = True
 
     def setUp(self):
+        self.test_home = tempfile.TemporaryDirectory(
+            prefix="vibepulse-relay-config-test-")
+        self.addCleanup(self.test_home.cleanup)
+        home_patch = mock.patch.object(
+            tokenserver.Path, "home", return_value=Path(self.test_home.name))
+        home_patch.start()
+        self.addCleanup(home_patch.stop)
         self.saved = (
             tokenserver.Handler.interaction_store,
             getattr(tokenserver.Handler, "interaction_relay_status", "off"),


### PR DESCRIPTION
## Summary

- select ESP-IDF HKDF support whenever the encrypted interaction relay is enabled
- pin the target-build dependency with a regression test
- isolate relay configuration tests from an installed private Mac token

## Root cause

The panel relay called `mbedtls_hkdf`, but its Kconfig switch did not select `MBEDTLS_HKDF_C`. Host vectors defined that option themselves, so only the real ESP32-S3 link exposed the missing symbol.

## Verification

- full `test/run.sh`: 737 Python tests plus all host/C/UI gates passed
- relay C/Python crypto vectors passed
- full ESP-IDF 5.5.2 target linked successfully
- clean firmware: `v0.6.0-82-gcbd3ecf`, 1,952,208 bytes, 63% app-partition headroom

`ota_0` was not touched and no device flash was performed.