### PR TITLE
Fix interaction parser stack overflow on panel

### DIFF
--- a/components/app_tokens/agent_net.c
+++ b/components/app_tokens/agent_net.c
@@ -18,6 +18,12 @@ static const char *TAG = "agent-net";
 
 #define AGENT_POLL_MS 1000
 #define AGENT_LOG_EVERY_MS 30000
+/* A v2 Needs You item adds a 2 KiB snapshot plus the bounded 1 KiB
+ * canonical-view buffer and SHA/cJSON call frames to the poll path. The old
+ * 6 KiB budget overflowed on the ESP32-S3 as soon as the first real Codex
+ * approval arrived. Keep explicit headroom for the strict parser: this task
+ * may die while owning UI work immediately after a successful parse. */
+#define AGENT_TASK_STACK_BYTES (10 * 1024)
 
 #ifdef TK_AGENT_STATUS_URL
 
@@ -138,7 +144,10 @@ static void agent_net_task(void *arg) {
 }
 
 void tokens_agent_net_start(void) {
-  xTaskCreate(agent_net_task, "agent-status", 6144, NULL, 5, NULL);
+  if (xTaskCreate(agent_net_task, "agent-status", AGENT_TASK_STACK_BYTES,
+                  NULL, 5, NULL) != pdPASS) {
+    ESP_LOGE(TAG, "agentstatus-tasken kunde inte starta");
+  }
 }
 
 #else

--- a/test/test_agent_net_wiring.py
+++ b/test/test_agent_net_wiring.py
@@ -75,6 +75,18 @@ assert re.search(r"static\s+tk_agent_http_response\s+response\s*;", source), (
     "the 1536-byte response state must live in static .bss"
 )
 assert re.search(
+    r'#define\s+AGENT_TASK_STACK_BYTES\s+\(10\s*\*\s*1024\)', source
+), (
+    "agent-status needs 10 KiB: strict v2 pending-view canonicalization "
+    "overflowed the original 6 KiB stack on the panel"
+)
+assert re.search(
+    r'xTaskCreate\(agent_net_task,\s*"agent-status",\s*'
+    r'AGENT_TASK_STACK_BYTES,\s*NULL,\s*5,\s*NULL\)',
+    source,
+    re.DOTALL,
+), "agent-status must use the guarded v2 interaction stack budget"
+assert re.search(
     r"torget_ui_lock\(\);\s*tokens_apply_agent_status\(&snapshot\);\s*"
     r"torget_ui_unlock\(\);",
     source,


### PR DESCRIPTION
## What changed
- raise the `agent-status` task stack from the legacy 6 KiB budget to 10 KiB
- add a source-level regression so strict v2 pending-view parsing cannot silently return to the unsafe budget
- report task creation failure instead of ignoring it

## Root cause
A real Codex approval exercises two 2,084-byte snapshots plus the bounded 1 KiB canonical public-view buffer and normal SHA/cJSON call frames. The original 6 KiB task stack overflowed on the ESP32-S3 and rebooted the panel as soon as the interaction arrived.

## Verification
- focused agent-network and interaction-relay guards pass
- full local runner: 737 tests plus all host C/UI gates pass
- ESP-IDF 5.5.2 target links successfully with 63% of the app slot free
- live RED reproduced on the panel before the fix; live GREEN will be repeated after CI and USB installation to ota_1

`ota_0` is untouched.