### PR TITLE
CI runs the full host gate, one shared tokenserver list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@
 # same ./test/run.sh a maintainer runs at the bench — C binaries, wiring
 # tests, the Mbed TLS crypto vectors (against the exact IDF-pinned sources)
 # and the SDL landmark captures under xvfb (OBS-24). Only the JS suites are
-# skipped inside run.sh (--skip-js): the interaction-relay and tokenserver
-# jobs run those with npm caching instead.
+# skipped inside run.sh (--skip-js): the npm-cached interaction-relay job
+# runs the Worker suite, and the tokenserver job runs the relay mailbox one.
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
-# CI: the headless lanes that are rock solid on hosted runners.
-# Lane 3 (the full host gate incl. SDL landmark captures) needs display
-# plumbing on CI and is tracked as a follow-up issue.
+# CI: the whole repository gate, not a subset. The host-gate job runs the
+# same ./test/run.sh a maintainer runs at the bench — C binaries, wiring
+# tests, the Mbed TLS crypto vectors (against the exact IDF-pinned sources)
+# and the SDL landmark captures under xvfb (OBS-24). Only the JS suites are
+# skipped inside run.sh (--skip-js): the interaction-relay and tokenserver
+# jobs run those with npm caching instead.
 name: CI
 
 on:
@@ -18,7 +21,47 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # One version for the firmware build AND the Mbed TLS sources the host
+  # gate's C crypto vectors compile against — bump them together, or the
+  # vectors stop guarding the bytes the panel actually ships.
+  IDF_VERSION: v5.5.2
+
 jobs:
+  host-gate:
+    name: Host gate (./test/run.sh)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install the pinned host-gate Python dependencies
+        run: >
+          python -m pip install -r requirements-dev.txt
+          -r requirements-interaction-relay.txt
+      - name: Install SDL2, Ninja and xvfb for the simulator landmarks
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install -y --no-install-recommends
+          libsdl2-dev ninja-build xvfb
+      # The vectors test compiles the panel's AES-GCM/HKDF boundary against
+      # ESP-IDF's bundled Mbed TLS. Only those sources are needed — no
+      # xtensa toolchain — so a sparse clone (~70 MB, seconds) suffices.
+      - name: Fetch ESP-IDF's pinned Mbed TLS for the C crypto vectors
+        run: |
+          git clone --depth 1 --branch "$IDF_VERSION" --filter=blob:none \
+            --sparse https://github.com/espressif/esp-idf.git \
+            "$RUNNER_TEMP/esp-idf-mbedtls"
+          git -C "$RUNNER_TEMP/esp-idf-mbedtls" sparse-checkout set \
+            components/mbedtls
+          git -C "$RUNNER_TEMP/esp-idf-mbedtls" submodule update --init \
+            --depth 1 components/mbedtls/mbedtls
+      - name: Run the full host gate under a virtual display
+        env:
+          IDF_PATH: ${{ runner.temp }}/esp-idf-mbedtls
+        run: xvfb-run -a ./test/run.sh --skip-js
+
   interaction-relay:
     name: Encrypted interaction Worker
     runs-on: ubuntu-latest
@@ -51,27 +94,12 @@ jobs:
       - name: Run tokenserver unit tests
         shell: bash
         run: |
-          # Same seventeen modules as test/run.sh, same order. The lists
-          # drifting apart is how a green CI hid a runtime NameError in
-          # PR #11 (test_interactions was missing) — keep them in sync.
+          # The module list lives in test/tokenserver-suite.txt, shared with
+          # test/run.sh. Two lists drifting apart is how a green CI hid a
+          # runtime NameError in PR #11 (test_interactions was missing) —
+          # now one list exists and run.sh guards its completeness.
           python -m unittest \
-            tools.tokenserver.test_github_monitor \
-            tools.tokenserver.test_tokenserver \
-            tools.tokenserver.test_agent_status \
-            tools.tokenserver.test_usage_history \
-            tools.tokenserver.test_quota_cache \
-            tools.tokenserver.test_max_tracker \
-            tools.tokenserver.test_value_meter \
-            tools.tokenserver.test_update_prices \
-            tools.tokenserver.test_codex_usage \
-            tools.tokenserver.test_vibepulse_config \
-            tools.tokenserver.test_codex_interactions \
-            tools.tokenserver.test_interactions \
-            tools.tokenserver.test_interaction_relay \
-            tools.tokenserver.test_interaction_relay_integration \
-            tools.tokenserver.test_interaction_relay_crypto \
-            tools.tokenserver.test_publisher \
-            tools.tokenserver.test_smoke -v
+            $(tr -d '\r' < test/tokenserver-suite.txt | grep -v '^#') -v
       - name: Run relay mailbox merge tests
         shell: bash
         run: node --test tools/relay/test.mjs
@@ -92,6 +120,6 @@ jobs:
       - name: Build with ESP-IDF 5.5
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.5.2
+          esp_idf_version: ${{ env.IDF_VERSION }}
           target: esp32s3
           command: idf.py build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   test binaries, wiring and capacity tests, the Mbed TLS crypto vectors
   (against a sparse clone of the IDF-pinned sources) and the SDL landmark
   captures under `xvfb-run`. Only the JS suites are skipped (`--skip-js`);
-  their own npm-cached jobs still run them. The tokenserver module list
+  their own jobs still run them — the Worker suite npm-cached in the
+  interaction-relay job, the relay mailbox test in the tokenserver job.
+  The tokenserver module list
   moved to `test/tokenserver-suite.txt` — one list shared by `run.sh` and
   CI, with a completeness guard so a new test module cannot silently stay
   outside the gate (the PR #11 lesson, made structural). Two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,22 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   reason codes were already in the serial log; a shelf gadget nobody has a
   cable to could not show them.
 
+### Changed
+
+- **CI now runs the whole host gate**, not a subset (OBS-24). A `host-gate`
+  job executes the same `./test/run.sh` as the bench on every push — the C
+  test binaries, wiring and capacity tests, the Mbed TLS crypto vectors
+  (against a sparse clone of the IDF-pinned sources) and the SDL landmark
+  captures under `xvfb-run`. Only the JS suites are skipped (`--skip-js`);
+  their own npm-cached jobs still run them. The tokenserver module list
+  moved to `test/tokenserver-suite.txt` — one list shared by `run.sh` and
+  CI, with a completeness guard so a new test module cannot silently stay
+  outside the gate (the PR #11 lesson, made structural). Two
+  `test_vibepulse_codex_plugin.py` cases learned Linux along the way: the
+  doctor-probe expectation now resolves `/bin/sh` (a dash symlink on
+  Debian-family runners), and the descendant-kill assertion accepts a
+  SIGKILLed orphan that pid 1 has not reaped yet.
+
 ### Fixed
 
 - Open networks were refused in silence. Every network was applied with

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -348,8 +348,9 @@ claim; mention the monitor command + power caveat.
 wiring/capacity tests, the Mbed TLS crypto vectors (compiled against a
 sparse clone of the IDF-pinned sources, same `IDF_VERSION` as the
 firmware job), and the SDL landmark captures under `xvfb-run`. The JS
-suites stay in their own npm-cached jobs — that skip is the gate's only
-CI difference. The tokenserver module list moved to
+suites stay in their own jobs (the Worker suite in the npm-cached
+interaction-relay job, the relay mailbox one in the tokenserver job) —
+that skip is the gate's only CI difference. The tokenserver module list moved to
 `test/tokenserver-suite.txt`, shared by `run.sh` and CI, with a
 completeness guard in `run.sh` (every `tools/tokenserver/test_*.py` must
 be listed). The false "tracked as a follow-up issue" claim is gone from

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -343,16 +343,23 @@ pointing at [observability.md](observability.md); correct the README
 claim; mention the monitor command + power caveat.
 
 ### OBS-24 · CI runs a fraction of the local gate
-`ci · M · open`
+`ci · M · done (2026-08-21)` — a `host-gate` CI job now runs
+`./test/run.sh --skip-js` on every push: all the C test binaries, the
+wiring/capacity tests, the Mbed TLS crypto vectors (compiled against a
+sparse clone of the IDF-pinned sources, same `IDF_VERSION` as the
+firmware job), and the SDL landmark captures under `xvfb-run`. The JS
+suites stay in their own npm-cached jobs — that skip is the gate's only
+CI difference. The tokenserver module list moved to
+`test/tokenserver-suite.txt`, shared by `run.sh` and CI, with a
+completeness guard in `run.sh` (every `tools/tokenserver/test_*.py` must
+be listed). The false "tracked as a follow-up issue" claim is gone from
+the `ci.yml` header. Original problem, for the record:
 CI = five tokenserver unittest modules + an ESP-IDF build. The 11 C test
 binaries, visual landmarks, hardware-registry checks, and skill-contract
 tests in `./test/run.sh` never run in CI — every parser-regression class
 from the lessons log is guarded only on the maintainer's Mac. The
 `ci.yml` header says the full gate "is tracked as a follow-up issue";
 **no such issue exists**.
-**Fix:** run `./test/run.sh` in CI minus the SDL-dependent captures
-(or with `xvfb`), and actually file the lane-3 issue so the claim in
-`ci.yml` is true.
 
 ### OBS-25 · No linting anywhere
 `hygiene · S · open`

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -424,7 +424,24 @@ underlying fallthrough is not.
 dated suffix dropped) and keep the map for exceptions only — then a new
 model is styled on arrival instead of on the next hand edit.
 
-### OBS-28 · Pin logging config on purpose
+### OBS-31 · A codex wire test is RST-flaky on Windows CI
+`test · S · open`
+`test_every_json_post_route_rejects_text_plain_before_parsing`
+(`test_codex_interactions.py`, subtest `/api/codex/permission`) failed
+once on the `windows-latest` tokenserver job with `None != 415` — the
+client read **no HTTP status at all** — then passed on the same commit
+in the re-run (run 32452343376, attempts 1→2; the run before, with
+identical tokenserver code, was green too). The shape is the classic
+WinSock race: a server that rejects early and closes without draining
+the request body can trigger a connection reset before the client reads
+the response — Linux and macOS deliver the buffered response anyway,
+Windows drops it. One occurrence in the suite's first two Windows runs
+of the full host-gate era; worth a signature here before it becomes a
+"CI is unreliable" impression.
+**Fix:** make the rejection path drain (or the test client tolerate one
+retry of) the unread body on early 4xx, and reproduce under load on a
+Windows box before trusting either — a wire test asserting a security
+boundary must not be loosened blindly.
 `firmware · S · open`
 `sdkconfig.defaults` deliberately pins flash, PSRAM, LVGL, and mbedTLS
 with reasoned comments — but nothing about logging: default level,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -196,8 +196,10 @@ succeeding, their pages keep reading as live (OBS-09). Until fixed, a
 GitHub Actions, four jobs: a `host-gate` job that runs the same
 `./test/run.sh` as the bench (C test binaries, visual landmarks under
 xvfb, crypto vectors, hardware registries, skill contracts, the
-tokenserver suite), the two npm-cached JS jobs it skips via `--skip-js`,
-and an ESP-IDF firmware build. Since OBS-24 closed (2026-08-21), red
+tokenserver suite), the jobs covering the JS suites it skips via
+`--skip-js` (the npm-cached interaction-relay job runs the Worker suite;
+the tokenserver matrix job runs the relay mailbox one), and an ESP-IDF
+firmware build. Since OBS-24 closed (2026-08-21), red
 `./test/run.sh` means red CI too — the remaining gap is only
 platform-shaped (CI is Linux; macOS-only quirks still need the bench).
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -193,11 +193,13 @@ succeeding, their pages keep reading as live (OBS-09). Until fixed, a
 
 ### 6. CI logs
 
-GitHub Actions, two lanes: the six tokenserver unittest modules, and an
-ESP-IDF firmware build. **The local gate `./test/run.sh` is much bigger**
-(11 C test binaries, visual landmarks, hardware registries, skill
-contracts) and none of that extra coverage runs in CI (OBS-24). Green CI
-+ red `./test/run.sh` is possible; the local gate is the authority.
+GitHub Actions, four jobs: a `host-gate` job that runs the same
+`./test/run.sh` as the bench (C test binaries, visual landmarks under
+xvfb, crypto vectors, hardware registries, skill contracts, the
+tokenserver suite), the two npm-cached JS jobs it skips via `--skip-js`,
+and an ESP-IDF firmware build. Since OBS-24 closed (2026-08-21), red
+`./test/run.sh` means red CI too — the remaining gap is only
+platform-shaped (CI is Linux; macOS-only quirks still need the bench).
 
 ## Known bad signatures
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -4,8 +4,8 @@
 #
 # Flaggor:
 #   --skip-js  hoppa över Node-lanen (relay + interaction-relay). Enbart för
-#              CI:s host-gate-jobb, som kör dem i egna jobb med npm-cache.
-#              Lokalt körs hela grinden flagglöst: ./test/run.sh
+#              CI:s host-gate-jobb — CI kör dem i egna jobb (Worker-sviten
+#              npm-cachad). Lokalt körs hela grinden flagglöst: ./test/run.sh
 set -e
 cd "$(dirname "$0")"
 
@@ -296,7 +296,7 @@ done
 # Båda molntjänsterna hålls av Node. CI måste ha Node 22; en lokal
 # firmwareutvecklare utan Node får ett ärligt hopp i stället för falskt grönt.
 if [ "$SKIP_JS" = 1 ]; then
-  echo "OBS: --skip-js — relayernas JS-tester körs i CI:s egna jobb med npm-cache"
+  echo "OBS: --skip-js — relayernas JS-tester körs i CI:s egna jobb"
 elif command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
   node --test tools/relay/test.mjs
   (cd tools/interaction-relay && npm ci && npm test && npm run typecheck)

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,8 +1,21 @@
 #!/bin/sh
-# Hosttesterna för Torgets rena kärnor. Kräver clang (Xcode CLT) samt
-# Python 3.11+ med PyYAML 6.0.3 och Pillow 12.3.0.
+# Hosttesterna för Torgets rena kärnor. Kräver en C-kompilator (clang via
+# Xcode CLT, eller gcc) samt Python 3.11+ med PyYAML 6.0.3 och Pillow 12.3.0.
+#
+# Flaggor:
+#   --skip-js  hoppa över Node-lanen (relay + interaction-relay). Enbart för
+#              CI:s host-gate-jobb, som kör dem i egna jobb med npm-cache.
+#              Lokalt körs hela grinden flagglöst: ./test/run.sh
 set -e
 cd "$(dirname "$0")"
+
+SKIP_JS=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-js) SKIP_JS=1 ;;
+    *) echo "Okänd flagga: $arg (känd: --skip-js)" >&2; exit 2 ;;
+  esac
+done
 
 PYTHON_BIN=${PYTHON_BIN:-python3}
 if ! "$PYTHON_BIN" -c \
@@ -266,28 +279,25 @@ cd ..
 "$PYTHON_BIN" test/test_token_body_capacity.py
 "$PYTHON_BIN" test/test_agent_status_body_capacity.py
 "$PYTHON_BIN" -m unittest tools.test_hardware_registry -v
+# Tokenservermodulerna listas i test/tokenserver-suite.txt — EN lista,
+# delad med CI:s tokenserverjobb (PR #11-läxan: två listor gled isär och
+# grön CI dolde en NameError). Vakten: varje test_*.py i tools/tokenserver/
+# måste stå i listan, så en ny modul inte tyst kan hamna utanför grinden.
+for suite_file in tools/tokenserver/test_*.py; do
+  suite_module="tools.tokenserver.$(basename "$suite_file" .py)"
+  if ! grep -qxF "$suite_module" test/tokenserver-suite.txt; then
+    echo "ERROR: $suite_module saknas i test/tokenserver-suite.txt" >&2
+    exit 1
+  fi
+done
 "$PYTHON_BIN" -m unittest \
-  tools.tokenserver.test_github_monitor \
-  tools.tokenserver.test_tokenserver \
-  tools.tokenserver.test_agent_status \
-  tools.tokenserver.test_usage_history \
-  tools.tokenserver.test_quota_cache \
-  tools.tokenserver.test_max_tracker \
-  tools.tokenserver.test_value_meter \
-  tools.tokenserver.test_update_prices \
-  tools.tokenserver.test_codex_usage \
-  tools.tokenserver.test_vibepulse_config \
-  tools.tokenserver.test_codex_interactions \
-  tools.tokenserver.test_interactions \
-  tools.tokenserver.test_interaction_relay \
-  tools.tokenserver.test_interaction_relay_integration \
-  tools.tokenserver.test_interaction_relay_crypto \
-  tools.tokenserver.test_publisher \
-  tools.tokenserver.test_smoke -v
+  $(tr -d '\r' < test/tokenserver-suite.txt | grep -v '^#') -v
 
 # Båda molntjänsterna hålls av Node. CI måste ha Node 22; en lokal
 # firmwareutvecklare utan Node får ett ärligt hopp i stället för falskt grönt.
-if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+if [ "$SKIP_JS" = 1 ]; then
+  echo "OBS: --skip-js — relayernas JS-tester körs i CI:s egna jobb med npm-cache"
+elif command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
   node --test tools/relay/test.mjs
   (cd tools/interaction-relay && npm ci && npm test && npm run typecheck)
 elif [ -n "${CI:-}" ]; then

--- a/test/test_github_wiring.py
+++ b/test/test_github_wiring.py
@@ -101,7 +101,10 @@ class GitHubWiringTests(unittest.TestCase):
         self.assertIn("TK_GITHUB_SCREEN_ENABLED 1", workflow)
         self.assertIn("TK_GITHUB_NOTIFICATIONS_ENABLED 1", workflow)
         self.assertIn("TK_GITHUB_SOUND_ENABLED 1", workflow)
-        self.assertIn("tools.tokenserver.test_github_monitor", workflow)
+        # CI's tokenserver module list lives in the shared suite file.
+        self.assertIn("test/tokenserver-suite.txt", workflow)
+        self.assertIn("tools.tokenserver.test_github_monitor",
+                      read("test/tokenserver-suite.txt"))
 
 
 if __name__ == "__main__":

--- a/test/test_interaction_relay_docs.py
+++ b/test/test_interaction_relay_docs.py
@@ -101,12 +101,18 @@ assert "tools/interaction-relay" in workflow
 assert "requirements-interaction-relay.txt" in workflow
 for runner in ("ubuntu-latest", "macos-latest", "windows-latest"):
     assert runner in workflow, f"tokenserver CI is missing {runner}"
+# The module list CI runs lives in test/tokenserver-suite.txt, shared with
+# test/run.sh — assert the modules there, and that CI consumes the list.
+assert "test/tokenserver-suite.txt" in workflow, (
+    "tokenserver CI must consume the shared suite list"
+)
+suite = read("test/tokenserver-suite.txt")
 for module in (
     "test_vibepulse_config", "test_codex_interactions",
     "test_interaction_relay", "test_interaction_relay_integration",
     "test_interaction_relay_crypto",
 ):
-    assert f"tools.tokenserver.{module}" in workflow, (
+    assert f"tools.tokenserver.{module}" in suite, (
         f"tokenserver CI is missing {module} from the host contract"
     )
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -2130,7 +2130,11 @@ class RelaySetupTests(unittest.TestCase):
                 urlopen=lambda *_args, **_kwargs:
                     BytesResponse(healthy_diagnostics()),
                 stdout=output), 1)
-            self.assertEqual(runner.calls[0][0][0:2], ["/bin/sh", "-c"])
+            # The doctor probes the interpreter through Path.resolve(), so
+            # the expectation must resolve too: /bin/sh is itself on macOS
+            # but a symlink to dash on Debian-family CI runners.
+            self.assertEqual(runner.calls[0][0][0:2],
+                             [str(Path("/bin/sh").resolve()), "-c"])
             self.assertEqual(runner.calls[1][0], ["/codex", "--version"])
             self.assertTrue(all(call[1]["timeout"] <= 15
                                 and call[1]["shell"] is False
@@ -2925,6 +2929,28 @@ class RelaySetupTests(unittest.TestCase):
             self.assertEqual(setup.load_config(path), original)
             self.assertNotIn("PASS", output.getvalue())
 
+    def assert_process_tree_killed(self, pid):
+        # SIGKILL lands immediately, but reaping belongs to the reaper: on
+        # Linux an orphan killed via killpg stays a kill-proof zombie until
+        # pid 1 (or the nearest subreaper) collects it, and os.kill(pid, 0)
+        # succeeds on zombies. Killed therefore means: gone, or a zombie
+        # that can never run again — never a schedulable process.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            try:
+                stat = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+                state = stat.rsplit(")", 1)[1].split()[0]
+            except (OSError, IndexError):
+                state = ""
+            if state == "Z":
+                return
+            time.sleep(0.05)
+        self.fail(f"descendant {pid} still schedulable after tree kill")
+
     @unittest.skipUnless(os.name == "posix", "POSIX process-group behavior")
     def test_timeout_kills_descendant_that_inherits_output_pipes(self):
         setup = load_setup()
@@ -2944,8 +2970,7 @@ class RelaySetupTests(unittest.TestCase):
                 elapsed = time.monotonic() - started
             self.assertLess(elapsed, 2.0)
             descendant_pid = int(pid_path.read_text(encoding="utf-8"))
-            with self.assertRaises(ProcessLookupError):
-                os.kill(descendant_pid, 0)
+            self.assert_process_tree_killed(descendant_pid)
             recovered = setup._invoke(
                 [sys.executable, "-c", "print('after-tree-kill')"],
                 setup._AUTO)

--- a/test/tokenserver-suite.txt
+++ b/test/tokenserver-suite.txt
@@ -1,0 +1,22 @@
+# Tokenservermodulerna för python -m unittest — EN lista, läst av både
+# test/run.sh och .github/workflows/ci.yml. Två listor som gled isär var
+# så en grön CI dolde en NameError i PR #11 (test_interactions saknades);
+# därför bor listan här och ingen annanstans. Rader som börjar med # är
+# kommentarer; konsumenterna kör tr -d '\r' | grep -v '^#' före bruk.
+tools.tokenserver.test_github_monitor
+tools.tokenserver.test_tokenserver
+tools.tokenserver.test_agent_status
+tools.tokenserver.test_usage_history
+tools.tokenserver.test_quota_cache
+tools.tokenserver.test_max_tracker
+tools.tokenserver.test_value_meter
+tools.tokenserver.test_update_prices
+tools.tokenserver.test_codex_usage
+tools.tokenserver.test_vibepulse_config
+tools.tokenserver.test_codex_interactions
+tools.tokenserver.test_interactions
+tools.tokenserver.test_interaction_relay
+tools.tokenserver.test_interaction_relay_integration
+tools.tokenserver.test_interaction_relay_crypto
+tools.tokenserver.test_publisher
+tools.tokenserver.test_smoke

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -3307,17 +3307,22 @@ class ArgumentParsingTests(unittest.TestCase):
 
 class RepositoryRunnerTests(unittest.TestCase):
     def test_default_runner_includes_config_and_codex_route_suites_once(self):
-        runner = (Path(__file__).resolve().parents[2] / "test" / "run.sh")
-        contents = runner.read_text(encoding="utf-8")
+        # The module list lives in test/tokenserver-suite.txt (one line per
+        # module), shared by test/run.sh and CI so the two can never drift.
+        root = Path(__file__).resolve().parents[2]
+        suite = (root / "test" / "tokenserver-suite.txt").read_text(
+            encoding="utf-8")
+        modules = [line.strip() for line in suite.splitlines()
+                   if line.strip() and not line.startswith("#")]
 
-        self.assertEqual(
-            contents.count("tools.tokenserver.test_vibepulse_config"), 1)
-        self.assertEqual(
-            contents.count("tools.tokenserver.test_codex_interactions"), 1)
-        self.assertEqual(
-            contents.count("tools.tokenserver.test_interaction_relay "), 1)
-        self.assertEqual(contents.count(
-            "tools.tokenserver.test_interaction_relay_integration"), 1)
+        for module in ("tools.tokenserver.test_vibepulse_config",
+                       "tools.tokenserver.test_codex_interactions",
+                       "tools.tokenserver.test_interaction_relay",
+                       "tools.tokenserver.test_interaction_relay_integration"):
+            self.assertEqual(modules.count(module), 1, module)
+
+        runner = (root / "test" / "run.sh").read_text(encoding="utf-8")
+        self.assertIn("test/tokenserver-suite.txt", runner)
 
 
 class InteractionRelayConfigTests(unittest.TestCase):


### PR DESCRIPTION
Closes OBS-24: CI ran a fraction of the local gate — the C test binaries, wiring tests, crypto vectors and SDL landmark captures only ever ran on the maintainer's Mac, and the `ci.yml` header pointed at a follow-up issue that never existed.

## What changes

- **A `host-gate` job runs the same `./test/run.sh` as the bench on every push.** The SDL landmark captures run under `xvfb-run` (libsdl2-dev + Ninja from apt), and the Mbed TLS crypto vectors compile against a sparse clone of ESP-IDF's bundled sources (~70 MB, seconds, no xtensa toolchain) pinned by the same `IDF_VERSION` the firmware job builds with. Only the JS suites are skipped (new `--skip-js` flag); their own jobs still run them — the Worker suite npm-cached in the interaction-relay job, the relay mailbox test in the tokenserver job.
- **The tokenserver module list moved to `test/tokenserver-suite.txt`**, consumed by both `run.sh` and `ci.yml`, with a completeness guard in `run.sh` (every `tools/tokenserver/test_*.py` must be listed). The PR #11 drift class — a green CI hiding a runtime NameError because one list lost a module — becomes structurally impossible.
- **Two `test_vibepulse_codex_plugin.py` cases learned Linux**: the doctor-probe expectation resolves `/bin/sh` (a dash symlink on Debian-family runners), and the descendant-kill assertion accepts a SIGKILLed orphan that pid 1 has not reaped yet (`os.kill(pid, 0)` succeeds on zombies).
- **Docs match reality**: OBS-24 closed, `observability.md` §6 no longer says green CI + red gate is possible, CHANGELOG entry added, and a Windows wire-test flake observed during the rollout is recorded as OBS-31 with its signature.

## Validation

- Full CI recipe validated end to end on headless Linux before pushing: `xvfb-run -a ./test/run.sh --skip-js` with `IDF_PATH` at the sparse clone exits 0 (46/46 landmarks, 737 tokenserver tests via the shared list, codex plugin 102/102).
- All three commits are green on CI, including two full runs of the new host-gate job (6m42s and 3m17s). The single red job in between was the OBS-31 Windows flake, green on one re-run of the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU3qynEwPdV5DRfu2ozJs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU3qynEwPdV5DRfu2ozJs8)_