### PR TITLE
[codex] Fix Wi-Fi icon and relay write budget

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -367,3 +367,18 @@ direct LAN wins for five seconds, authenticated relay rows expire, and an old
 relay-owned activity view clears once instead of pretending to be live.
 **Watch for:** adding another screen to a shared “connected” indicator without
 testing the exact transport and stale boundary that feed actually uses.
+
+## 2026-08-21 · Change detection is not a cloud write budget
+
+**What happened:** the numbers Worker began returning error 1101 and every
+cross-network feed stayed stale even though its code and KV binding were
+healthy. **Root cause:** the publisher sent on every payload change; the
+quota body includes a current-time field and minute countdowns, so it wrote
+about every 30 seconds until Cloudflare KV's account-wide 1,000-write daily
+free allowance was exhausted. The old arithmetic counted only five-minute
+heartbeats and ignored real changes. **The rule:** a metered sink needs an
+absolute rate ceiling, not only change detection. **Guards:** quotas are
+capped at one write per five minutes and Max Tracker/GitHub at one per thirty
+minutes; a regression simulates two continuously changing publishers for a
+full day and requires at most 768 writes. **Watch for:** adding an endpoint or
+shortening a ceiling without recomputing the account-wide two-publisher bound.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -102,9 +102,12 @@ Then:
   but the quota probe still presents itself as claude-cli. Changing that
   risks the probe against an undocumented endpoint and needs a live test —
   a deliberate, separate decision, not an oversight.
-- **Write economy is load-bearing.** Send-on-change + 5-minute heartbeat
-  keeps two publishers comfortably inside KV's 1 000 free writes/day.
-  A "simpler" always-send loop would exhaust it by mid-afternoon.
+- **Write economy is load-bearing.** Local change detection is backed by an
+  absolute cloud ceiling: quotas at most every 5 minutes, Max Tracker and
+  GitHub at most every 30 minutes. Even if every payload changes continuously,
+  two publishers make at most 768 writes/day against KV's 1,000-write free
+  allowance. Change detection alone once exhausted the allowance because
+  current-time and reset-countdown fields legitimately change every minute.
 - **The mailbox is disposable.** It holds only the latest few JSON bodies.
   Delete the Worker and the panel falls back to LAN-only behaviour;
   rotate the secret by redeploying and updating two places.

--- a/docs/superpowers/plans/2026-08-21-vibepulse-wifi-icon-clarity.md
+++ b/docs/superpowers/plans/2026-08-21-vibepulse-wifi-icon-clarity.md
@@ -101,3 +101,43 @@ git add platform/torget_ui.c design/vibepulse/studio-design.json \
   test/test_vibepulse_visual_landmarks.py test/test_wifi_onboarding_design.py
 git commit -m "fix: clarify weak WiFi signal icon"
 ```
+
+### Task 3: Close the physical fan-geometry gap
+
+The contrast change passed simulator pixel counts, but the first physical
+AMOLED review showed a second defect: all three arcs shared the centre of the
+box while the dot sat eleven empty rows below them.  The result looked like a
+small blob plus a stray dot rather than one familiar Wi-Fi symbol.
+
+**Files:**
+- Modify: `test/test_vibepulse_visual_landmarks.py`
+- Modify: `platform/torget_ui.c`
+
+- [ ] **Step 1: Pin the physical regression before renderer changes**
+
+Require the full-strength icon's arc-to-dot silhouette to have no vertical ink
+gap longer than two pixels, and require its first ink row to leave at least five
+pixels of top breathing room inside the existing `(418,38)..(446,66)` box.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+```sh
+PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python \
+  test/test_vibepulse_visual_landmarks.py \
+  -k global_wifi_icon_is_one_connected_fan -v
+```
+
+Expected: the old geometry fails with an eleven-row gap.
+
+- [ ] **Step 3: Give all arcs one lower fan origin**
+
+Keep the 28 px global lane, colors, states, slash, and 3 px strokes.  Change
+only the three arc y offsets so their centres share the same lower origin next
+to the dot.  The dot remains inside the same group and above the header rule.
+
+- [ ] **Step 4: Rebuild, verify, and inspect at 1:1**
+
+Run the focused test, the complete raster matrix, layer safety, design checks,
+and live preview.  Inspect all four signal strengths on Claude, Codex, GitHub,
+launcher, value, Needs You, OTA, and any installed companion surface before a
+new physical flash is proposed.

--- a/platform/torget_ui.c
+++ b/platform/torget_ui.c
@@ -50,11 +50,11 @@ static lv_obj_t *bare(lv_obj_t *parent) {
 
 /* ------------------------------------------------------- delad Wi-Fi-status */
 
-static lv_obj_t *wifi_arc_create(int size, int offset) {
+static lv_obj_t *wifi_arc_create(int size, int x_offset, int y_offset) {
   lv_obj_t *arc = lv_arc_create(tg.wifi_group);
   lv_obj_remove_style_all(arc);
   lv_obj_set_size(arc, size, size);
-  lv_obj_set_pos(arc, offset, offset);
+  lv_obj_set_pos(arc, x_offset, y_offset);
   lv_arc_set_rotation(arc, 225);
   lv_arc_set_bg_angles(arc, 0, 90);
   lv_obj_set_style_arc_width(arc, 3, LV_PART_MAIN);
@@ -105,12 +105,15 @@ static void wifi_status_create(void) {
   tg.wifi_group = bare(lv_layer_top());
   lv_obj_set_pos(tg.wifi_group, 418, 38);
   lv_obj_set_size(tg.wifi_group, 28, 28);
-  tg.wifi_arc[0] = wifi_arc_create(28, 0);
-  tg.wifi_arc[1] = wifi_arc_create(20, 4);
-  tg.wifi_arc[2] = wifi_arc_create(12, 8);
+  /* Every arc radiates from local (14,22), directly above the dot.  Keeping
+   * one lower origin makes the 28 px mark read as a single familiar Wi-Fi
+   * fan on the physical AMOLED instead of three arcs floating over a dot. */
+  tg.wifi_arc[0] = wifi_arc_create(28, 0, 8);
+  tg.wifi_arc[1] = wifi_arc_create(20, 4, 12);
+  tg.wifi_arc[2] = wifi_arc_create(12, 8, 16);
 
   tg.wifi_dot = bare(tg.wifi_group);
-  lv_obj_set_pos(tg.wifi_dot, 12, 22);
+  lv_obj_set_pos(tg.wifi_dot, 12, 20);
   lv_obj_set_size(tg.wifi_dot, 4, 4);
   lv_obj_set_style_radius(tg.wifi_dot, LV_RADIUS_CIRCLE, 0);
   lv_obj_set_style_bg_opa(tg.wifi_dot, LV_OPA_COVER, 0);

--- a/test/test_vibepulse_visual_landmarks.py
+++ b/test/test_vibepulse_visual_landmarks.py
@@ -1253,6 +1253,34 @@ class VibePulseVisualLandmarkTests(unittest.TestCase):
         for signature in signatures[1:]:
             self.assertGreater(signature[0], 0)
 
+    def test_global_wifi_icon_is_one_connected_fan_not_a_floating_dot(self):
+        """Physical AMOLED review found the old concentric arcs at y=38..49
+        and the dot at y=61..62.  Pixel-count tests called that a Wi-Fi icon,
+        but the eleven empty rows made it read as two unrelated marks on the
+        panel.  A familiar Wi-Fi fan must keep every horizontal ink band close
+        enough to the next one to form a single silhouette."""
+        image = self.image("torget-wifi-global-claude-3.bmp")
+        ink_rows = []
+        for y in range(38, 66):
+            ink_rows.append(any(
+                image.getpixel((x, y)) in (self.NY_WHITE, self.NY_MUTED)
+                for x in range(418, 446)
+            ))
+
+        first = ink_rows.index(True)
+        last = len(ink_rows) - 1 - ink_rows[::-1].index(True)
+        longest_gap = self._longest_run([
+            not row for row in ink_rows[first:last + 1]
+        ])
+        self.assertLessEqual(
+            longest_gap, 2,
+            "the Wi-Fi dot must visually belong to the three signal arcs",
+        )
+        self.assertGreaterEqual(
+            first + 38, 43,
+            "the fan must radiate from the lower dot, not hug the box top",
+        )
+
     def test_wifi_status_is_hidden_on_boot_and_foreground_on_overlays(self):
         box = (418, 38, 446, 66)
         for name in ("boot-cold", "boot-wifi", "boot-time"):

--- a/tools/relay/README.md
+++ b/tools/relay/README.md
@@ -62,8 +62,11 @@ any Cloudflare involvement.
 
 ## Free-tier arithmetic
 
-The publisher sends only on change plus a 5-minute heartbeat
-(`tools/tokenserver/publisher.py`), which lands at a few hundred KV writes
-per day against the free tier's 1 000. The panel's reads (2 880/day at a
-30 s cadence) sit far under the 100 000-read allowance. Two publishers
-double the writes; still comfortable.
+The publisher checks locally every 30 seconds, but it has a hard cloud-write
+ceiling: quotas at most every 5 minutes, Max Tracker and GitHub at most every
+30 minutes (tools/tokenserver/publisher.py). That is at most 384 KV writes per
+day for one continuously changing publisher, or 768 for two, below the free
+account's 1,000-write allowance. The ceiling is necessary because presentation
+fields such as the current time and reset countdowns legitimately change on
+almost every local check. The panel's reads (2,880/day at a 30 s cadence) stay
+below the 100,000-read allowance.

--- a/tools/tokenserver/publisher.py
+++ b/tools/tokenserver/publisher.py
@@ -21,10 +21,11 @@ freshest-per-source; this module only needs to be honest about who it is.
 
 Write economy is a design constraint, not an optimization: the free tier
 of the intended mailbox (Cloudflare KV) allows 1 000 writes/day, and a
-30-second cadence would burn 2 880.  So a payload is sent only when its
-content actually changed, plus a heartbeat so the mailbox's staleness is
-bounded even when nothing changes.  Both rules live in pure functions the
-tests can hold still.
+30-second cadence would burn 2 880 for just one endpoint.  Content hashes
+alone are insufficient because honest presentation fields such as ``at`` and
+reset countdowns change continuously.  Every endpoint therefore has a hard
+minimum send interval as well as change detection.  The ceilings keep two
+continuously changing publishers below the account-wide free allowance.
 """
 
 from __future__ import annotations
@@ -39,11 +40,21 @@ import urllib.request
 
 log = logging.getLogger("tokenserver")
 
-# Publish cadence: check for changes at the same rhythm the panel polls,
-# heartbeat every five minutes.  ~300 heartbeat writes/day for three
-# endpoints plus real changes -- comfortably inside 1 000.
+# Check locally at the same rhythm the panel polls.  Cloud sends have the
+# per-endpoint ceilings below; the base heartbeat remains five minutes.
 CHECK_EVERY_S = 30.0
 HEARTBEAT_EVERY_S = 300.0
+
+# KV's free allowance is account-wide: 1,000 writes/day.  At these absolute
+# ceilings one publisher can make at most 384 writes/day (288 quota updates,
+# 48 Max Tracker updates and 48 GitHub updates); two make at most 768.
+# The local 30-second check remains responsive without being allowed to turn
+# volatile presentation timestamps into cloud writes.
+MIN_SEND_INTERVAL_S = {
+    "/api/tokens": 300.0,
+    "/api/max-tracker": 1800.0,
+    "/api/github": 1800.0,
+}
 
 # An honest User-Agent.  The relay is our own mailbox; there is nobody to
 # imitate and no reason to.
@@ -61,7 +72,8 @@ def payload_fingerprint(payload) -> str:
     return hashlib.sha256(body).hexdigest()
 
 
-def should_send(last_fingerprint, last_sent_at, fingerprint, now) -> bool:
+def should_send(last_fingerprint, last_sent_at, fingerprint, now,
+                min_interval_s=0.0) -> bool:
     """The write-economy rule: send on change, or on heartbeat, never else.
 
     ``last_fingerprint is None`` means never sent (fresh start): send.
@@ -70,9 +82,12 @@ def should_send(last_fingerprint, last_sent_at, fingerprint, now) -> bool:
     """
     if last_fingerprint is None:
         return True
+    elapsed = now - last_sent_at
+    if elapsed < min_interval_s:
+        return False
     if fingerprint != last_fingerprint:
         return True
-    return (now - last_sent_at) >= HEARTBEAT_EVERY_S
+    return elapsed >= max(HEARTBEAT_EVERY_S, min_interval_s)
 
 
 class Publisher:
@@ -131,7 +146,9 @@ class Publisher:
             fingerprint = payload_fingerprint(payload)
             last_fingerprint, sent_at = self._state.get(path, (None, 0.0))
             now = self.clock()
-            if not should_send(last_fingerprint, sent_at, fingerprint, now):
+            min_interval = MIN_SEND_INTERVAL_S.get(path, HEARTBEAT_EVERY_S)
+            if not should_send(last_fingerprint, sent_at, fingerprint, now,
+                               min_interval):
                 continue
             body = json.dumps(payload, sort_keys=True).encode()
             if self.post(self.relay_url + path, body):

--- a/tools/tokenserver/test_publisher.py
+++ b/tools/tokenserver/test_publisher.py
@@ -10,10 +10,12 @@ import unittest
 
 try:
     from .publisher import (Publisher, HEARTBEAT_EVERY_S,
-                            payload_fingerprint, should_send, USER_AGENT)
+                            MIN_SEND_INTERVAL_S, payload_fingerprint,
+                            should_send, USER_AGENT)
 except ImportError:
     from publisher import (Publisher, HEARTBEAT_EVERY_S,
-                           payload_fingerprint, should_send, USER_AGENT)
+                           MIN_SEND_INTERVAL_S, payload_fingerprint,
+                           should_send, USER_AGENT)
 
 
 class FingerprintTests(unittest.TestCase):
@@ -76,17 +78,20 @@ class PublisherTests(unittest.TestCase):
         p.publish_once()
         self.assertEqual(len(sent), 1, "an unchanged payload was resent")
 
-    def test_change_and_heartbeat_both_send(self):
+    def test_change_waits_for_the_endpoint_ceiling_then_sends(self):
         value = {"pct": 73}
         p, sent, clock = self._publisher({"/api/tokens": lambda: dict(value)})
         p.publish_once()
         value["pct"] = 74
         clock["now"] += 30
         p.publish_once()
-        self.assertEqual(len(sent), 2, "a changed payload must send")
-        clock["now"] += HEARTBEAT_EVERY_S
+        self.assertEqual(len(sent), 1, "a change must respect the write cap")
+        clock["now"] += MIN_SEND_INTERVAL_S["/api/tokens"] - 30
         p.publish_once()
-        self.assertEqual(len(sent), 3, "the heartbeat must send")
+        self.assertEqual(len(sent), 2, "the bounded change must send")
+        clock["now"] += MIN_SEND_INTERVAL_S["/api/tokens"]
+        p.publish_once()
+        self.assertEqual(len(sent), 3, "the heartbeat must still send")
 
     def test_a_failed_send_retries_next_tick(self):
         p, sent, clock = self._publisher({"/api/tokens": lambda: {"a": 1}},
@@ -111,6 +116,26 @@ class PublisherTests(unittest.TestCase):
         # constant to imitate anything, this fails.
         self.assertTrue(USER_AGENT.startswith("vibepulse-publisher/"),
                         USER_AGENT)
+
+    def test_two_publishers_fit_the_free_daily_write_budget(self):
+        """Even continuously changing payloads remain below 1,000/day."""
+        total_sends = 0
+        for _publisher_number in range(2):
+            generation = {"value": 0}
+            p, _sent, clock = self._publisher({
+                "/api/tokens": lambda g=generation: {"value": g["value"]},
+                "/api/max-tracker": lambda g=generation: {
+                    "value": g["value"],
+                },
+                "/api/github": lambda g=generation: {"value": g["value"]},
+            })
+            for _tick in range(int(24 * 60 * 60 / 30)):
+                generation["value"] += 1
+                total_sends += p.publish_once()
+                clock["now"] += 30
+
+        self.assertLessEqual(total_sends, 768)
+        self.assertLess(total_sends, 1000)
 
 
 if __name__ == "__main__":

--- a/tools/tokenserver/test_publisher.py
+++ b/tools/tokenserver/test_publisher.py
@@ -101,6 +101,20 @@ class PublisherTests(unittest.TestCase):
         self.assertEqual(p.publish_once(), 1)
         self.assertEqual(len(sent), 2)
 
+    def test_failed_throttled_update_does_not_restart_the_ceiling(self):
+        value = {"a": 1}
+        p, sent, clock = self._publisher(
+            {"/api/tokens": lambda: dict(value)},
+            results=[True, False, True],
+        )
+        self.assertEqual(p.publish_once(), 1)
+        value["a"] = 2
+        clock["now"] += MIN_SEND_INTERVAL_S["/api/tokens"]
+        self.assertEqual(p.publish_once(), 0)
+        clock["now"] += 30
+        self.assertEqual(p.publish_once(), 1)
+        self.assertEqual(len(sent), 3)
+
     def test_a_broken_producer_does_not_stop_the_others(self):
         def broken():
             raise RuntimeError("boom")

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -3184,9 +3184,10 @@ def main():
             "/api/github": _github_payload,
         })
         relay_publisher.start()
-        log.info("publicerar siffror till reläet som \"%s\" (ändringar + "
-                 "hjärtslag var 5:e minut; agentstatus och Needs You "
-                 "publiceras ALDRIG)", machine)
+        log.info("publicerar siffror till reläet som \"%s\" (högst var "
+                 "5:e minut för kvoter och var 30:e minut för GitHub/Max "
+                 "Tracker; agentstatus och Needs You publiceras ALDRIG)",
+                 machine)
 
     backfill_stop = threading.Event()
     backfill_thread = threading.Thread(


### PR DESCRIPTION
## What changed

- Rebuilds the 28 px top-right Wi-Fi mark around one lower fan origin, so the
  signal arcs and dot read as one familiar icon on the physical AMOLED.
- Adds a raster regression for arc-to-dot continuity and preserves the existing
  lane, four signal states, colors, disconnect slash, and global overlay.
- Caps numbers-relay writes to at most every 5 minutes for quota data and every
  30 minutes for Max Tracker/GitHub.
- Corrects the operator docs and startup diagnostic, and records the incident
  in the lessons log.

## Root cause and impact

The old icon used concentric arcs near the top of its box with the dot eleven
empty rows below, so it looked like a blob plus a stray dot on the panel.

The numbers publisher also relied on content changes alone. /api/tokens
contains a current-time field and reset countdowns, so it wrote roughly every
30 seconds and exhausted Cloudflare KV's account-wide 1,000-write free daily
allowance. With the new absolute ceilings, one continuously changing publisher
uses at most 384 writes/day and two use at most 768. The privacy boundary is
unchanged: this mailbox still carries numbers only.

## Verification

- Full repository runner: 757 tests passed.
- Worker relay suite: 6 tests passed.
- ESP-IDF 5.5 build: complete ESP32-S3 firmware linked; torget.bin uses 38%
  of the smallest OTA slot.
- 49 exact 480x480 visual landmark tests and the live preview export passed.
- Independent code review: READY, no remaining findings.

## Physical follow-up

The simulator output has been inspected at 1:1. Physical acceptance remains
pending a separately authorized flash and review on the AMOLED panel.
