### PR TITLE
Make Wi-Fi status clearly connected or offline

### DIFF
--- a/design/vibepulse/wifi-onboarding-design.json
+++ b/design/vibepulse/wifi-onboarding-design.json
@@ -12,7 +12,7 @@
     "height": 18,
     "scope": "page-drift-shell",
     "color": "#9298A2",
-    "states": ["offline", "weak", "medium", "strong"],
+    "states": ["offline", "connected"],
     "hiddenDuringBoot": true
   },
   "open": {

--- a/platform/torget.h
+++ b/platform/torget.h
@@ -42,10 +42,11 @@ uint8_t torget_wifi_signal_bars(void);
 
 /* One neutral Wi-Fi status mark shared by every ordinary app page. It lives
  * in the translated page shell; opaque setup/OTA takeovers cover it instead
- * of letting it float above them. NORMAL follows real 0..3 association
- * strength, SETUP selects the complete mark for the phone flow, and HIDDEN is
- * reserved for the one-time boot screen. These UI calls require the caller
- * to hold the LVGL lock, matching the rest of the platform UI API. */
+ * of letting it float above them. NORMAL renders 0 as the slashed offline fan
+ * and any nonzero association strength as the complete connected fan. SETUP
+ * selects the connected mark for the phone flow, and HIDDEN is reserved for
+ * the one-time boot screen. These UI calls require the caller to hold the
+ * LVGL lock, matching the rest of the platform UI API. */
 typedef enum {
   TG_WIFI_STATUS_NORMAL = 0,
   TG_WIFI_STATUS_SETUP,

--- a/platform/torget_ui.c
+++ b/platform/torget_ui.c
@@ -29,7 +29,7 @@ static struct {
   lv_obj_t *wifi_image;
   tg_wifi_status_mode wifi_mode;
   tg_wifi_status_mode wifi_rendered_mode;
-  uint8_t wifi_rendered_bars;
+  bool wifi_rendered_connected;
   bool wifi_rendered_valid;
 } tg;
 
@@ -49,29 +49,27 @@ static lv_obj_t *bare(lv_obj_t *parent) {
 
 static void wifi_status_render(void) {
   if (!tg.wifi_group) return;
-  uint8_t bars = tg.wifi_mode == TG_WIFI_STATUS_SETUP
-                     ? 3 : torget_wifi_signal_bars();
-  if (bars > 3) bars = 3;
+  bool connected = tg.wifi_mode == TG_WIFI_STATUS_SETUP ||
+                   torget_wifi_signal_bars() > 0;
   if (tg.wifi_rendered_valid && tg.wifi_rendered_mode == tg.wifi_mode &&
-      tg.wifi_rendered_bars == bars)
+      tg.wifi_rendered_connected == connected)
     return;
 
   tg.wifi_rendered_valid = true;
   tg.wifi_rendered_mode = tg.wifi_mode;
-  tg.wifi_rendered_bars = bars;
+  tg.wifi_rendered_connected = connected;
   if (tg.wifi_mode == TG_WIFI_STATUS_HIDDEN) {
     lv_obj_add_flag(tg.wifi_group, LV_OBJ_FLAG_HIDDEN);
     return;
   }
 
   lv_obj_remove_flag(tg.wifi_group, LV_OBJ_FLAG_HIDDEN);
-  static const lv_image_dsc_t *states[4] = {
-      &tg_img_wifi_offline,
-      &tg_img_wifi_weak,
-      &tg_img_wifi_medium,
-      &tg_img_wifi_strong,
-  };
-  lv_image_set_src(tg.wifi_image, states[bars]);
+  /* On the 2.16-inch AMOLED the weak/medium silhouettes read as a broken or
+   * undersized icon.  Signal strength remains available to networking, but
+   * the header has one familiar full fan for connected and one equally large
+   * slashed fan for offline. */
+  lv_image_set_src(tg.wifi_image,
+                   connected ? &tg_img_wifi_strong : &tg_img_wifi_offline);
 }
 
 static void wifi_status_timer(lv_timer_t *timer) {

--- a/test/test_lvgl_layer_safety.py
+++ b/test/test_lvgl_layer_safety.py
@@ -90,6 +90,9 @@ assert "wifi_active_clip" not in platform_ui
 assert "lv_arc_create" not in platform_ui
 assert "lv_obj_set_style_transform" not in platform_ui
 assert "lv_line_create(tg.wifi_group)" not in platform_ui
+assert "connected ? &tg_img_wifi_strong : &tg_img_wifi_offline" in platform_ui
+assert "&tg_img_wifi_weak" not in platform_ui
+assert "&tg_img_wifi_medium" not in platform_ui
 assert "TG_WIFI_STATUS_NORMAL" in platform_header
 assert "TG_WIFI_STATUS_SETUP" in platform_header
 assert "TG_WIFI_STATUS_HIDDEN" in platform_header
@@ -98,7 +101,7 @@ assert "void torget_wifi_status_foreground(void);" in platform_header
 assert "uint8_t torget_wifi_signal_bars(void);" in platform_header
 assert "Never implies relay health" in platform_header
 
-# Setup can still force the strong state while it owns the glass, but because
+# Setup can still force the connected state while it owns the glass, but because
 # both setup and OTA are opaque top-layer overlays there is no reparenting or
 # duplicate Wi-Fi object.  Boot keeps the ordinary page mark hidden until the
 # one-time handoff.

--- a/test/test_vibepulse_visual_landmarks.py
+++ b/test/test_vibepulse_visual_landmarks.py
@@ -1226,7 +1226,7 @@ class VibePulseVisualLandmarkTests(unittest.TestCase):
         self.assertGreater(
             self._count(image, (24, 358, 232, 452), self.NY_RED), 0)
 
-    def test_global_wifi_icon_is_neutral_consistent_and_distinct(self):
+    def test_global_wifi_icon_is_neutral_consistent_and_two_state(self):
         box = (426, 28, 446, 46)
         signatures = []
         for bars in range(4):
@@ -1253,7 +1253,14 @@ class VibePulseVisualLandmarkTests(unittest.TestCase):
                     crops.append(crop.tobytes())
             self.assertTrue(all(crop == crops[0] for crop in crops))
             signatures.append(crops[0])
-        self.assertEqual(len(set(signatures)), 4)
+        self.assertNotEqual(
+            signatures[0], signatures[3],
+            "offline must be visibly different from connected",
+        )
+        self.assertEqual(
+            signatures[1:], [signatures[3]] * 3,
+            "every connected signal level must use the same full-size fan",
+        )
 
     def test_global_wifi_icon_is_one_connected_fan_not_a_floating_dot(self):
         """Physical AMOLED review found the old concentric arcs at y=38..49

--- a/test/test_wifi_onboarding_design.py
+++ b/test/test_wifi_onboarding_design.py
@@ -37,7 +37,7 @@ class WifiOnboardingDesignTests(unittest.TestCase):
                 "height": 18,
                 "scope": "page-drift-shell",
                 "color": "#9298A2",
-                "states": ["offline", "weak", "medium", "strong"],
+                "states": ["offline", "connected"],
                 "hiddenDuringBoot": True,
             },
         )
@@ -124,6 +124,12 @@ class WifiOnboardingDesignTests(unittest.TestCase):
         self.assertIn("lv_image_create(tg.wifi_group)", platform)
         self.assertNotIn("LV_SYMBOL_WIFI", platform)
         self.assertIn("TG_WIFI_STATUS_SETUP", platform)
+        self.assertIn(
+            "connected ? &tg_img_wifi_strong : &tg_img_wifi_offline",
+            platform,
+        )
+        self.assertNotIn("&tg_img_wifi_weak", platform)
+        self.assertNotIn("&tg_img_wifi_medium", platform)
 
     def test_repository_runner_wires_contract(self):
         runner = (ROOT / "test/run.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- renders the complete Wi-Fi fan for every connected signal level
- renders the equally large slashed fan only when disconnected
- keeps signal strength available internally without making the header icon shrink
- aligns the saved design and structural/480x480 raster contracts

## Verification

- RED: the new two-state raster contract failed because levels 1, 2, and 3 produced different-size marks
- GREEN: all 51 exact-size visual tests
- GREEN: onboarding design, LVGL layer safety, and native asset tests
- GREEN: complete repository gate, including 757 server tests and both Worker suites
- 1:1 review of connected and offline captures
- independent review of hidden/setup/normal and disconnect/reconnect transitions

The change does not alter networking, relay health, Wi-Fi onboarding, or OTA behavior.
