### PR TITLE
docs: sync README and release history through v0.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Designsystemet: **spec/ui-spec.md**. Hårdvarusanningen routas under
 `Hardware-aware work` nedan; läs den kanoniska femfilslistan där före
 hårdvaruarbete.
 
-## Status (2026-08-13, första flashen gjord)
+## Status (2026-08-23, v0.7.0)
 
 Plattformen bröts ut ur underhållarens tidigare solcells-firmware (den
 historiken ligger i ett privat repo och är inget du behöver) och stöptes om
@@ -34,9 +34,11 @@ enligt granskningens tre krav: (1) versionerat appkontrakt
 äger bara WiFi/SNTP/lås/ljus/rotation; (3) MIT-licens.
 
 **Det här repot innehåller EN app: VibePulse** (Claude/Codex-användning via
-tools/tokenserver på Macen, platt JSON över LAN). Den ligger först i
-registret, så en färsk klon utifrån bygger en binär som startar i VibePulse
-och ingenting annat.
+tools/tokenserver på macOS eller Windows, normalt platt JSON över LAN).
+Valfria och oberoende Cloudflare-reläer kan bära siffror respektive
+end-to-end-krypterade interaktioner/live-status över separata nät; allt är
+default-off. Appen ligger först i registret, så en färsk klon utifrån bygger
+en binär som startar i VibePulse och ingenting annat.
 
 Solelkollen och Vibbe/Buddy är egna produkter i egna repon och dras in som
 companion-inputs när de finns utcheckade — `TORGET_SOLELKOLLEN_DIR`
@@ -52,8 +54,9 @@ med användarens uttryckliga tillåtelse, från mergad main; den statiska
 fysiska grinden är PASSERAD för kvotsidorna, agentmonitorn och Max Tracker,
 och Solceller-kopian är avvecklad som skärmens drivrutin. Evidens:
 `docs/superpowers/reviews/2026-08-13-max-tracker-physical-static.md`.
-Fortfarande ogrindat: rörelse/animation — den kräver
-interaktionsprotokollet i AMOLED-skillen, mätt på panelen först.
+Completion-pulsen har också passerat fysisk rörelsegranskning. Ny rörelse eller
+animation är fortfarande ogrindad tills den följer interaktionsprotokollet i
+AMOLED-skillen och mäts på panelen.
 
 ## Arbetsregler
 
@@ -69,6 +72,19 @@ interaktionsprotokollet i AMOLED-skillen, mätt på panelen först.
   Tokenmätaren, blev andra användaren — det är mallen).
 - **Ärlighetsinvarianten:** aldrig påhittade nollor — utan data visas
   streck; räknare backar aldrig; copyn säger vad siffran faktiskt mäter.
+
+## Releaser och utåtriktad dokumentation
+
+- En viktig användarfunktion är inte klar förrän `README.md` visar den i
+  tagline/intro och i en egen aktuell sektion med riktiga 480×480-bilder.
+- När en tagg skapas flyttas innehållet från `Unreleased` till en daterad
+  rubrik i `CHANGELOG.md`, en ny tom `Unreleased` lämnas överst och README:ns
+  `Latest release` uppdateras i samma arbete.
+- Varje GitHub-release får en ren, bildsatt release body under
+  `docs/releases/`. Bild-URL:er ska vara absoluta
+  `raw.githubusercontent.com/.../<tag>/...`-URL:er, releasen ska inte börja
+  med en H1 och `torget.bin` får aldrig bifogas eftersom den innehåller
+  användarens Wi-Fi-uppgifter och device key.
 
 ## AMOLED visual work
 
@@ -113,9 +129,6 @@ firmware-enabled genom det build-inputet; exakt revision och evidens finns i
 `spec/hardware-sources.yaml`. Fysisk mikrofon-/högtalarfunktion är fortfarande
 overifierad.
 
-- WiFi-provisionering + OTA + konfig-UI — trigger: första enheten som lämnar
-  huset (kompilerad secrets.h duger inte för sålda enheter; ESP-IDF:s
-  wifi_provisioning finns färdig).
 - Responsiv layout för andra Waveshare-storlekar — trigger: andra skärmtypen.
 - Butiks-/paketmaskineri och appar i egna repon via Espressifs registry —
   trigger: bevisad traktion efter open source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,35 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+No user-facing changes yet.
+
+## v0.7.0 — 2026-08-23
+
+Codex joins the answerable Needs You flow, the panel gains phone-first Wi-Fi
+onboarding, and the host service becomes portable across macOS and Windows.
+Optional encrypted interaction and live-status relays keep the panel useful
+when it and the computer are on unrelated ordinary internet Wi-Fi. Illustrated
+notes: [Codex and any Wi-Fi](docs/releases/2026-08-23-codex-and-any-wifi.md).
+
 ### Added
+
+- **Codex interactions on the panel.** The optional plugin bridges supported
+  questions and a narrow safe-command approval tier into the shared Needs You
+  UI. Provider/view-bound verdicts, bounded text, fail-closed setup, and strict
+  allowlists keep unknown, mutating, secret-bearing, or ambiguous requests on
+  the computer.
+- **Encrypted Needs You across unrelated Wi-Fi.** A user-owned Cloudflare
+  Durable Object mailbox carries fixed-size end-to-end encrypted request and
+  verdict frames. It is separate from the numbers relay, uses outbound HTTPS
+  only, and stays off until a provider, bounded detail, and the relay are each
+  explicitly enabled.
+- **Encrypted live agent status across unrelated Wi-Fi.** A third independent
+  transport carries only minimized Claude/Codex rows, never the pending
+  decision. Direct LAN wins; stale relay rows clear honestly.
+- **Phone-first Wi-Fi setup.** The panel shows a scannable QR, serves a local
+  network picker, tests credentials before saving them, and keeps every old
+  recovery network after a failed trial. The top-right Wi-Fi mark now appears
+  consistently across the launcher, apps, Needs You, OTA, and setup.
 
 - **The panel travels.** It remembers six places in NVS and joins the one
   that worked most recently; arriving somewhere new no longer means editing
@@ -13,8 +41,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   since OTA needs the network the panel cannot reach. Two ways to teach it a
   place: `tools/wifi-here.sh` on the Mac hands over the network it is
   already on (reading the password from the keychain, one prompt, nothing
-  typed), or the panel raises `VibePulse-setup` with the password on the
-  glass and serves a captive portal listing what its *own* radio can see.
+  typed), or the panel raises `VibePulse-setup` with a phone-first QR; the
+  temporary password stays behind the Manual Setup fallback. Its captive
+  portal lists what the panel's *own* radio can see.
   The window opens by itself after 90 s without an IP, or on a 3 s KEY3
   hold, and closes after ten minutes — the access point, HTTP server and DNS
   responder do not exist outside it (the lazy-surface rule from the
@@ -38,16 +67,20 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
     freshest-per-pool on read using the observation stamps the staleness
     logic already carries — Claude from whichever machine asked Anthropic
     last, Codex from whichever machine ran Codex last.
-  The boundary is enforced from three directions
+  The numbers-only boundary is enforced from three directions
   (`test/test_relay_boundary.py`, `test_publisher.py`, the Worker's path
   allowlist): the relay carries *numbers* (quota, burn rate, Max Tracker,
-  GitHub), never *activity* (agent status, Needs You, the device key's
-  answer path — those stay on the LAN). Full design: `docs/relay.md`.
+  GitHub), never *activity*. The separately enabled encrypted interaction and
+  live-status relays use a different Worker, credentials, protocol, and
+  privacy boundary. Full designs: `docs/relay.md` and
+  `docs/interaction-relay.md`.
 - **Windows autostart** for the tokenserver
   (`tools/tokenserver/install-windows-task.ps1`): a scheduled task running
   as the logged-in user (never SYSTEM — the credential file lives in the
-  user profile), restarting on failure, logs in `%LOCALAPPDATA%\VibePulse\`.
-  Closes the gap in issue #3.
+  user profile), restarting on failure, with state in
+  `%LOCALAPPDATA%\VibePulse\`. The current background task does not persist
+  stdout/stderr; use the root health endpoint or run manually for diagnostic
+  logs. Closes the gap in issue #3.
 - **Hold KEY3 twice to reach WiFi setup on a connected panel.** The setup
   window used to open only when the panel had no network — you could not
   pre-load the phone hotspot at home before a trip. Now a second full 3 s
@@ -114,7 +147,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   `NameError` in the rebased Windows branch (PR #11): the missing
   `test_interactions` catches it immediately.
 
-### Added
+### Desktop support
 
 - The tokenserver reads Claude's OAuth token on Windows. Claude Code has no
   keychain integration there, so `claude login` writes the same
@@ -147,19 +180,56 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   The old paths worked literally on Windows but planted a `Library` tree in
   the user profile that nothing else on the machine recognises.
 
-  What remains for [#3](https://github.com/niclasvestlund-YT/vibepulse/issues/3)
-  is autostart: the launchd plist has no Windows equivalent, and `smoke.py`
-  now finds the right state directory but still tells you to run `launchctl`.
-  Reported by Erik Elfström, who found it porting a fork to a LilyGO
-  T-Display-S3.
-- The completion alert finally pulses. The accent outline and icon ring
-  breathe (full → 39 % → full, ease-in-out, four 1200 ms cycles filling the
-  PULSE phase exactly) and then rest; text and the provider icon stay solid
-  for readability. Proven pixel-by-pixel in the simulator and reviewed on
-  the physical panel
-  ([review](docs/superpowers/reviews/2026-08-14-completion-pulse-physical-motion.md)).
-  The static attention gate now permits exactly this one animation and pins
-  its shape.
+  Native Task Scheduler autostart, immediate start, restart-on-failure, and
+  saved interaction-provider choices complete the Windows host path in this
+  release. Reported by Erik Elfström, who found the original gaps while
+  porting a fork to a LilyGO T-Display-S3.
+- Renewed Claude credentials are detected and published promptly. A stale
+  Claude Desktop process token can no longer leave a valid new login hidden
+  behind cached `401` data until the next long probe interval.
+
+## v0.6.0 — 2026-08-16
+
+- **Needs You becomes an input device for Claude Code.** A held question or
+  supported permission takes over the panel; a tap reveals the bounded view
+  and APPROVE / DENY / LEAVE IT returns a signed verdict to the same live
+  session. Walking away always falls back to the terminal.
+- The shared LVGL takeover was rebuilt around the approved
+  attract → decision → payoff flow, including long-text fit guards and a
+  private fallback state.
+- The LVGL pool moved to PSRAM to restore the internal DMA headroom the AMOLED
+  flush needs, fixing a physical panel freeze.
+
+## v0.5.0 — 2026-08-15
+
+- Added the **value multiple** page: priced month-to-date Claude/Codex token
+  usage divided by the plan cost the user explicitly declares. Unknown prices
+  degrade to a dash instead of being guessed.
+- Added the optional **GitHub project pulse**: stars/forks page plus a named
+  new-star takeover, with screen, notification, and future sound as separate
+  default-off switches.
+- Fixed Codex resume/fork replay overcounting by grouping rollouts by session
+  and using the most complete copy. Illustrated notes:
+  [value and GitHub](docs/releases/2026-08-15-value-and-github.md).
+
+## v0.4.0 — 2026-08-14
+
+- Added the consent-gated A/B OTA platform: physical KEY3/touch consent,
+  authenticated inactive-slot upload, image verification, a 15-second boot
+  health gate, and automatic rollback.
+- Added UPDATE READY, the OTA progress ring, and a boot screen driven by real
+  Wi-Fi/time/data signals.
+- Hardened the tokenserver against rejected tokens, concurrent probing, 429
+  penalties, and stale build delivery. Illustrated notes:
+  [OTA platform](docs/releases/2026-08-14-ota-platform.md).
+
+## v0.3.0 — 2026-08-14
+
+- Added the observability map, transition logs, smoke-test contract, backlog,
+  and lessons log so a stale or foreign tokenserver is visible instead of
+  looking healthy.
+- The completion alert gained its first measured pulse and physical motion
+  review; text and provider marks remain solid for readability.
 
 ## v0.2.1 — 2026-08-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,9 @@ Two rules, learned 2026-08-16, not optional:
   compiled in). The per-release OG card is auto-generated and NOT customisable;
   the one shared-link image you can set is the repo's Social preview (Settings ->
   Social preview) — refresh it for a major feature.
+- **Tagging includes the documentation cut.** In the same effort, move the
+  shipped entries out of `Unreleased` into a dated version in `CHANGELOG.md`,
+  leave a new empty `Unreleased` section at the top, update README's `Latest
+  release`, and save the GitHub-ready body under `docs/releases/`. A tag on a
+  commit whose changelog still calls its features unreleased is not a finished
+  release.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ too: one command moves it onto whatever WiFi you are on today.**
 
 Claude Code and Codex usage, live agent activity, and a full-screen
 **NEEDS YOU** alert you can answer with a tap. A ~$30 ESP32-S3 panel plus a
-pure-stdlib Python service on your Mac or Windows PC. Local mode needs no
+core, pure-stdlib Python service on your Mac or Windows PC. Local mode needs no
 VibePulse account and keeps agent activity on your LAN. The optional
 numbers-only relay can carry quota data across isolated WiFi; a separate,
 default-off encrypted interaction relay can carry supported Needs You
 decisions without requiring the panel and computer to share a LAN. A third,
 independent **Live agent status relay** can keep the Claude/Codex activity rows
-current across ordinary internet WiFi. Every cloud feature is off by default.
+current across ordinary internet WiFi. Every cloud feature is off by default;
+only the encrypted interaction/status relay adds the pinned Python
+`cryptography` dependency.
 
 ## The problem
 
@@ -36,6 +38,19 @@ the room, no window to switch to, no menu bar to squint at.
 > of tweaks are still on the list, but enough people asked about it that I'm
 > opening it up now rather than when it feels "done". Expect rough edges and
 > frequent commits.
+
+## Latest release: v0.7.0
+
+The 23 August release closes the loop for both providers: supported Claude
+Code **and Codex** questions can be answered from the panel, the screen can be
+moved to a new 2.4 GHz network from a phone, and the host service now runs on
+Windows as well as macOS. Optional, separately controlled encrypted relays can
+carry Needs You decisions and live agent rows when the panel and computer are
+on unrelated WiFi.
+
+[Read the illustrated v0.7.0 notes](docs/releases/2026-08-23-codex-and-any-wifi.md)
+· [Full changelog](CHANGELOG.md)
+· [Compare v0.6.0...v0.7.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.6.0...v0.7.0)
 
 ## What's on screen
 
@@ -64,7 +79,8 @@ weekly quota. Each with a reset countdown and how much you've burned today.
 **NEEDS YOU** — when an agent blocks on your input, the whole screen turns
 into the alert, in that provider's colour, naming the project it's waiting
 on. Tap to dismiss — or, with the opt-in Needs You bridge, **tap to answer
-it** without switching windows ([see below](#answer-claude-from-the-panel)).
+it** without switching windows
+([see below](#answer-claude-or-codex-from-the-panel)).
 
 </td>
 </tr>
@@ -199,7 +215,7 @@ previous page after two minutes.
 
 <img src="docs/img/github/sim-star-popup.png" alt="Full-screen popup celebrating a new GitHub star" width="320">
 
-The Mac service polls GitHub's public API and republishes a small, validated
+The computer service polls GitHub's public API and republishes a small, validated
 LAN payload. The ESP32 never talks to GitHub, and a GitHub timeout or rate
 limit cannot stall the Claude/Codex endpoints. Configure it with:
 
@@ -253,7 +269,7 @@ swipeable strip, alongside GitHub — neither replaces the other.
 </table>
 
 ```
-python3 tools/tokenserver/tokenserver.py --claude-plan max5x --plan-cost-usd 100
+python3 tools/tokenserver/tokenserver.py --claude-plan max5x --plan claude=100
 ```
 
 It counts cache tokens, which is the whole point — a real record here reads
@@ -268,7 +284,7 @@ the figure to a dash rather than being silently free.
 ## How it works
 
 ```
-        your Mac                             your shelf
+      your computer                          your shelf
 ┌────────────────────────────┐          ┌──────────────┐
 │ ~/.claude/projects/*.jsonl │          │              │
 │ ~/.codex/sessions/*.jsonl  │ ───────► │   ESP32-S3   │
@@ -293,9 +309,9 @@ to the panel; captive portals and 5 GHz-only networks are not.
 - **[Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm)**
   (~$30). No soldering, just a USB-C cable. It's the same board Clawdmeter
   uses, so if you already own one you're 10 minutes away.
-- **A Mac or PC** running the tokenserver. Direct LAN mode needs the panel to
-  reach that computer; the optional relays remove the same-WiFi requirement.
-  Claude quota log reading remains macOS-only for now.
+- **A Mac or Windows PC** running the tokenserver. Claude and Codex quota
+  collection are supported on both. Direct LAN mode needs the panel to reach
+  that computer; the optional relays remove the same-WiFi requirement.
 - **Claude Code and/or Codex.** Either alone is fine.
 - **2.4 GHz WiFi.** The ESP32-S3 can't see 5 GHz networks.
 
@@ -305,7 +321,7 @@ Clone the repo, open your coding agent inside it (Claude Code, Codex,
 Cursor, whatever you run), and say:
 
 > Set up VibePulse for me: help me fill in secrets.h, build and flash the
-> board over USB, and start the tokenserver on this Mac.
+> board over USB, and start the tokenserver on this Mac or Windows PC.
 
 The repo is built for this. `CLAUDE.md` and `AGENTS.md` point your agent
 straight at **[docs/agent-setup.md](docs/agent-setup.md)** — an English
@@ -317,6 +333,10 @@ Reading rather than running? That runbook is also the fastest way to
 understand how the pieces fit together.
 
 ## Setup, the manual way
+
+The commands below show the macOS path. Windows is supported for the host
+service too; use the Windows ESP-IDF environment and the OS-specific host
+address/autostart steps in [the agent runbook](docs/agent-setup.md).
 
 1. Install [ESP-IDF 5.5](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/get-started/index.html)
    and `brew install cmake ninja`
@@ -346,7 +366,8 @@ understand how the pieces fit together.
    panel's draw makes the board bounce off the bus or hang, which looks
    like a flaky cable. After flashing, run the screen from its own USB
    power supply, not your computer.
-3. Start the service on your Mac. Pure Python stdlib, nothing to install:
+3. Start the core service on your computer. Pure Python stdlib, nothing to
+   install for local mode:
 
    ```
    python3 tools/tokenserver/tokenserver.py
@@ -380,7 +401,7 @@ USB-C remains the rescue path and is never written by an OTA. After an OTA
 reboot the window re-arms itself once, so a build-test-build session needs
 one hold, not one per build.
 
-The tokenserver announces the newest build on your Mac
+The tokenserver announces the newest build on your computer
 (`otaAvailableVersion` on `/api/tokens`); when the screen runs an older
 version it takes the glass with an **UPDATE READY** notice — hold KEY3 to
 receive — or answer the on-glass LATER/UPDATE pills by touch; tapping
@@ -510,18 +531,23 @@ Max Tracker fixtures, `T` re-feeds tokens, `G` simulates a new GitHub star,
 
 ## Privacy
 
-- Agent activity and usage stay on your LAN; the screen only ever receives
-  percentages, counts and coarse status — a project name, a model, an effort
-  level.
+- In local mode, agent activity and usage stay on your LAN; the screen only
+  ever receives percentages, counts and coarse status — a project name, a
+  model, an effort level.
 - No prompts, no code, no commands, no file contents are stored or served.
   The service keeps only content-free quota points (at most one per 15
   minutes, kept 8 days) for the trends.
-- Your OAuth token never leaves the Mac.
-- If the optional GitHub module is enabled, the Mac anonymously reads only
-  public repository and stargazer metadata from GitHub. The ESP32 still
-  talks only to the Mac over your LAN.
+- Your OAuth token never leaves the computer.
+- The optional numbers relay publishes only quota, reset, Max Tracker, and
+  optional public GitHub numbers. The separate interaction and live-status
+  relays send fixed-size end-to-end encrypted ciphertext; all three are off
+  by default and independently controlled.
+- If the optional GitHub module is enabled, the computer anonymously reads
+  only public repository and stargazer metadata from GitHub. In local mode,
+  the ESP32 still talks only to that computer over your LAN.
 - A lost or stolen screen leaks your WiFi credentials and the LAN hostname
-  of your Mac — both of which you rotate yourself, not in any cloud.
+  or address of your computer — both of which you rotate yourself, not in any
+  cloud.
 
 ## Tweak it
 
@@ -551,8 +577,8 @@ zeros, and provider accents locked to Claude `#D97757` and Codex `#6F78FF`.
 platform/            app contract + launcher + fonts (IBM Plex)
 main/                ESP32 host layer: boot, WiFi, SNTP, app registry
 components/app_*     the app (VibePulse lives in app_tokens/)
-tools/tokenserver/   the Mac service (Python stdlib)
-sim/                 SDL simulator, the whole platform on your Mac
+tools/tokenserver/   the computer service (core is Python stdlib)
+sim/                 SDL simulator, the whole platform on your computer
 test/                host tests, run with ./test/run.sh (no ESP-IDF needed)
 spec/                hardware truth + UI design system
 ```
@@ -589,12 +615,15 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   `{"claudeAiOauth": {...}}` record to
   `%USERPROFILE%\.claude\.credentials.json` and the service reads it; the
   Codex app-server read and the single-probe lock no longer depend on
-  macOS-only syscalls; state and logs live under `%LOCALAPPDATA%\VibePulse\`.
+  macOS-only syscalls; state lives under `%LOCALAPPDATA%\VibePulse\`.
   For autostart, run the shipped Task Scheduler installer from the repo root:
   `powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1`.
   It runs as your signed-in user, starts immediately, restarts on failure, and
-  keeps interaction-provider choices in the tokenserver's saved config.
-- **Linux for the Mac service?** Not yet —
+  keeps interaction-provider choices in the tokenserver's saved config. The
+  current background task does not persist stdout/stderr; use
+  `curl http://localhost:8737/` for health and run the service in a terminal
+  when you need a diagnostic log.
+- **Linux for the tokenserver?** Not yet —
   [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2);
   contributions very welcome.
 - **Other boards or panel sizes?** Not yet. The platform is pinned to this
@@ -605,7 +634,8 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   [#4](https://github.com/niclasvestlund-YT/vibepulse/issues/4).
 - **Just Claude, no Codex (or vice versa)?** Works. The other half shows
   dashes.
-- **Does it need internet?** No. The board talks to one host on your LAN.
+- **Does it need internet?** Local-only mode does not. The optional relays and
+  GitHub pulse do; each stays off until you enable it.
 
 ## License
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -9,9 +9,10 @@ Appplattformen för hyllskärmen (Waveshare ESP32-S3-Touch-AMOLED-2.16,
 firmware-binär som flashas; appar pluggar in som ESP-IDF-komponenter och
 kan bo i egna repon. En skärm = en binär = ett bygge här. MIT-licens.
 
-Utbruten ur [Solelkollen](https://solelkollen.se)s firmware (P25 i
-Solceller-repots `docs/roadmap-hyllskarmen.md`); Solceller-kopian fortsätter
-driva skärmen tills det här repot bevisat sig med en lyckad flash.
+Utbruten ur [Solelkollen](https://solelkollen.se)s firmware. VibePulse-repot
+äger nu skärmens firmware; den första fysiska flashen och den statiska grinden
+passerade 2026-08-13, OTA-kedjan följde 2026-08-14 och v0.7.0 släpptes
+2026-08-23.
 
 ## Arkitekturen i tre meningar
 
@@ -38,12 +39,12 @@ components/
   app_solelkollen/        companion: fyra vyer, /api/glance + /api/glance-sverige
 ~/Buddy/components/
   app_buddy/              companion: Vibbe/Buddy, companion build input
-sim/                      SDL-simulatorn: hela plattformen + apparna på Macen
+sim/                      SDL-simulatorn: hela plattformen + apparna på datorn
 sim-fixtures/             inspelade API-svar simulatorn och testerna delar
 test/                     hosttester, körs med clang utan ESP-IDF: ./test/run.sh
-tools/tokenserver/        Mac-tjänsten som serverar VibePulse-data över LAN
+tools/tokenserver/        datorservicen som serverar VibePulse-data över LAN
 spec/                     hardware.md (alla hårdvarufällor) + ui-spec.md (designsystemet)
-third_party/cjson/        vendrad cJSON 1.7.18 — samma parser på Macen som på kortet
+third_party/cjson/        vendrad cJSON 1.7.18 — samma parser på datorn som på kortet
 ```
 
 Repot innehåller alltså EN app: VibePulse. Solelkollen och Vibbe/Buddy är

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -38,8 +38,10 @@ cannot determine yourself.
 
 1. **macOS or Windows?** Both serve data. On Windows the Claude token comes
    from `%USERPROFILE%\.claude\.credentials.json` instead of the keychain,
-   and state and logs live under `%LOCALAPPDATA%\VibePulse\`. The supplied
-   `install-windows-task.ps1` adds autostart through Task Scheduler. On Linux
+   and state lives under `%LOCALAPPDATA%\VibePulse\`. The supplied
+   `install-windows-task.ps1` adds autostart through Task Scheduler; its
+   current background task does not persist stdout/stderr, so use the root
+   health endpoint or run manually for diagnostic logs. On Linux
    the firmware still builds and the simulator still runs, but the service
    finds no Claude token at all — there is no keychain and the credential
    file is read only on Windows
@@ -66,8 +68,10 @@ Then edit `secrets.h`. Two separate things must be right:
   the only network it knows before it has ever been anywhere. Every network
   *after* the first is taught to the panel at the place itself, with no
   rebuild — see [wifi.md](wifi.md).
-- **Replace `DIN-MAC` in `TK_VIBEPULSE_BASE_URL`** with their Mac's Bonjour
-  name.
+- **Replace `DIN-MAC` in `TK_VIBEPULSE_BASE_URL`** with an address the panel
+  can reach. On macOS, use the Mac's Bonjour name. On Windows, use the active
+  LAN IPv4 address and reserve that address in the router; the tokenserver does
+  not advertise an mDNS name on Windows.
 
 Those `#define`s ship active on purpose, with an obvious placeholder. Do not
 comment them out or delete them: `components/app_tokens/net.c` guards every
@@ -76,26 +80,31 @@ out entirely and the firmware then compiles cleanly, boots cleanly, connects
 to WiFi cleanly — and shows dashes forever, with no error anywhere to tell
 you why. A wrong hostname at least shows up in the serial log.
 
-Use the Bonjour name, not an IP, so the same binary works at home and on a
-phone hotspot:
+On macOS, use the Bonjour name instead of a raw IP so the same binary works at
+home and on a phone hotspot:
 
 ```sh
 scutil --get LocalHostName     # e.g. "Niclas-MacBook" -> Niclas-MacBook.local
 ```
 
-**Verify:** `secrets.h` has a non-empty SSID, and
+On Windows, use `ipconfig` to find the IPv4 address of the active adapter. A
+DHCP reservation matters: if that address changes, direct-LAN mode shows
+dashes until the URL is rebuilt. The optional relays remove the same-LAN
+requirement but do not make a stale local URL correct.
+
+**Verify:** `secrets.h` has a non-empty SSID and no `DIN-MAC` placeholder:
 
 ```sh
-grep -q 'DIN-MAC' secrets.h && echo "PLACEHOLDER STILL THERE" || echo "hostname set"
-grep -nE 'http://[0-9]' secrets.h && echo "WARNING: raw IP in a URL" || echo "no raw IPs"
+grep -q 'DIN-MAC' secrets.h && echo "PLACEHOLDER STILL THERE" || echo "host set"
 ```
 
-prints `hostname set` and `no raw IPs`. If the placeholder is still there,
+It must print `host set`. If the placeholder is still there,
 the board will look for a host that does not exist and every page will stay
-on dashes. If the second line finds a raw IP: that is a snapshot of a DHCP
-lease, and it *will* go stale — it cost an entire evening of network
-debugging in the wrong direction before anyone read what the URL actually
-contained (`docs/lessons.md` 2026-08-17). Use the Bonjour name.
+on dashes. On macOS, a raw IP is a snapshot of a DHCP lease and should be
+replaced with the Bonjour name. On Windows, document the DHCP reservation
+that keeps the chosen IPv4 stable. A stale compiled address cost an entire
+evening of network debugging before anyone read the URL
+(`docs/lessons.md` 2026-08-17).
 
 Ask the user for the WiFi password. Do not guess it, and do not commit
 `secrets.h` — it is gitignored, keep it that way.
@@ -122,8 +131,10 @@ Ask first. Then:
 idf.py -p /dev/cu.usbmodem101 flash    # confirm the real port first
 ```
 
-Find the port with `ls /dev/cu.usbmodem*`. Two hardware facts decide whether
-this works, both learned the hard way:
+On macOS, find the port with `ls /dev/cu.usbmodem*`. On Windows, use the
+board's `COM` port instead, for example `idf.py -p COM5 flash`, after
+confirming it in Device Manager or the ESP-IDF terminal. Two hardware facts
+decide whether this works, both learned the hard way:
 
 - **Flash in download mode, with the panel dark.** Hold **BOOT**, tap
   **RESET**, release **BOOT**. The board re-enumerates as a ROM device.
@@ -137,7 +148,10 @@ up after reset.
 
 ## Step 4 — tokenserver
 
-Pure stdlib, nothing to install:
+The core local service is pure stdlib, with nothing to install. The optional
+encrypted interaction/status relay adds the pinned dependency in
+`requirements-interaction-relay.txt`; install it only when enabling that
+relay.
 
 ```sh
 python3 tools/tokenserver/tokenserver.py
@@ -148,7 +162,7 @@ the panel talks directly to it. On WiFi with client isolation, the optional
 numbers relay can still carry quota data as long as this service is running;
 it does not publish agent activity or Needs You prompts.
 
-**Verify**, from the same Mac:
+**Verify**, from the same computer:
 
 ```sh
 curl -s localhost:8737/ | python3 -m json.tool
@@ -162,13 +176,13 @@ are not arriving:
 |---|---|---|
 | `usage_http_200 + ok` | Working. Limits parsed. | Nothing |
 | `not_run` | Probe has not fired yet | It runs every 120 s — wait |
-| `no_claude_oauth_token` | No Claude Desktop / Claude Code token found | Have them sign in to Claude Code on this Mac |
+| `no_claude_oauth_token` | No Claude Desktop / Claude Code token found | Have them sign in to Claude Code on this computer |
 | `token_expired_…` | Token found but expired | Re-authenticate in Claude Code |
 | `usage_http_401` / `usage_http_403` | Every token source rejected (on macOS the probe tries Claude Desktop's process token, then the keychain, and falls back automatically; on Windows there is only `%USERPROFILE%\.claude\.credentials.json`) | Re-authenticate in Claude Code |
 | `usage_http_200 + no_mapped_limits` | Authenticated, but nothing in the usage response mapped (a `; fallback_…` suffix records the header-probe outcome) | Plan may not expose limits; Codex half still works |
-| `usage_request_failed: …` | Network/DNS failure from the Mac | Check the Mac's own connectivity |
+| `usage_request_failed: …` | Network/DNS failure from the computer | Check the computer's own connectivity |
 | `usage_http_429 + backoff_until_HH:MM` | Rate-limited by the API; the probe rests until the shown time | Wait — it retries by itself |
-| `probe_crashed: <Type>` | The probe itself hit a bug (crash before it could classify the failure) | Read the traceback in `~/Library/Logs/torget-tokenserver.log`; worth filing |
+| `probe_crashed: <Type>` | The probe itself hit a bug (crash before it could classify the failure) | Read `~/Library/Logs/torget-tokenserver.log` on macOS. On Windows, stop the background task and run the service in a terminal to capture stderr; worth filing |
 
 Codex is read separately from its local app-server, so a bad `claudeProbe`
 never explains missing Codex numbers, and vice versa.
@@ -249,10 +263,11 @@ the shared device key.
 
 To opt in to encrypted decisions across isolated Wi-Fi, first read the exact
 privacy boundary in [interaction-relay.md](interaction-relay.md). Enable at
-least one provider and detail above, install the pinned Worker dependencies,
-then run:
+least one provider and detail above, install the pinned Python and Worker
+dependencies, then run:
 
 ```sh
+python3 -m pip install -r requirements-interaction-relay.txt
 cd tools/interaction-relay && npm ci && npx wrangler login && cd ../..
 python3 tools/vibepulse_setup.py relay install \
   --url https://vibepulse-interaction-relay.YOUR-SUBDOMAIN.workers.dev \
@@ -363,8 +378,8 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Screen boots, everything is dashes, forever | `DIN-MAC` never replaced in `secrets.h`, or the `TK_*` defines were removed | Set the real Bonjour name, rebuild, reflash |
-| Dashes, and the Mac's URL is set | tokenserver not running, or Mac asleep, or firewall | Start it; check `curl localhost:8737/` |
+| Screen boots, everything is dashes, forever | `DIN-MAC` never replaced in `secrets.h`, the Windows LAN IP changed, or the `TK_*` defines were removed | Set the reachable host (Bonjour on macOS; reserved LAN IPv4 on Windows), rebuild, reflash |
+| Dashes, and the computer's URL is set | tokenserver not running, computer asleep, or firewall | Start it; check `curl localhost:8737/` |
 | Dashes only for Claude, Codex fine (or vice versa) | That provider's source is unavailable | Check `claudeProbe`; the other half working is by design |
 | Never joins WiFi | Network is 5 GHz | 2.4 GHz only. iPhone hotspot: enable "Maximize Compatibility". The glass names the reason itself after 60 s |
 | Moved to a new place; panel finds nothing | The new network was never taught to it | It raises `VibePulse-setup` after 90 s (or a 3 s KEY3 hold). Run `tools/wifi-here.sh` on the Mac, or join the AP from a phone. Remembered afterwards — [docs/wifi.md](wifi.md) |
@@ -374,7 +389,7 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 | Panel shows stale quota / empty Fable weekly in the morning | Upstream 429 penalty from the shared account bucket | Self-heals: dead tokens are never resent, the penalty persists across restarts, deltas serve from cache. Check `claudeProbe` on `curl localhost:8737/` |
 | Panel shows stale while powered from the computer USB port | The Mac port cannot feed WiFi TX bursts — fetches time out | Expected on Mac USB; run from wall power. Logs stay valid on Mac USB, data does not |
 | OTA boots always show state 0xffffffff and the health gate always rests | `sdkconfig` generated before the rollback line landed in `sdkconfig.defaults` (defaults only apply on fresh generation) | `grep BOOTLOADER_APP_ROLLBACK sdkconfig` — set `=y`, rebuild, and USB-flash ONCE (the bootloader carries the logic; OTA never writes it) |
-| No `/dev/cu.usbmodem*` | Not in download mode | Hold BOOT, tap RESET, release BOOT |
+| No `/dev/cu.usbmodem*` or Windows `COM` port | Not in download mode | Hold BOOT, tap RESET, release BOOT |
 | Flash starts then dies; board hangs | USB port cannot power the panel | Download mode to flash; own PSU to run |
 | Numbers freeze and go stale | Service or LAN dropped | Last good values are kept deliberately; restart the service |
 | `./test/run.sh` refuses to start | Unpinned PyYAML/Pillow | See [Hardware knowledge](../README.md#hardware-knowledge) |

--- a/docs/releases/2026-08-23-codex-and-any-wifi.md
+++ b/docs/releases/2026-08-23-codex-and-any-wifi.md
@@ -1,0 +1,95 @@
+<!-- GitHub-ready v0.7.0 release body. Intentionally starts without an H1. -->
+
+VibePulse v0.7.0 closes the loop for both coding agents and makes the panel
+far easier to move. Supported Claude Code **and Codex** questions can now be
+answered from the glass, a phone can teach the panel a new Wi-Fi network, and
+the tokenserver runs on Windows as well as macOS. When same-LAN access is not
+possible, two separate opt-in relays can carry encrypted decisions and live
+agent rows over ordinary internet Wi-Fi.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v0.7.0/docs/img/vibepulse-needs-you-codex-question.png" width="31%" alt="Codex question on the VibePulse panel">
+  &nbsp;
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v0.7.0/docs/img/vibepulse-needs-you-codex-approval.png" width="31%" alt="Codex safe-command approval on the VibePulse panel">
+  &nbsp;
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v0.7.0/docs/img/vibepulse-wifi-setup.png" width="31%" alt="Phone-first Wi-Fi setup QR on the VibePulse panel">
+</p>
+
+## Highlights
+
+- **Codex joins Needs You.** The optional VibePulse Codex plugin carries only
+  supported two/three-option questions and a narrow safe-command tier to the
+  panel. Unknown, mutating, secret-bearing, oversized, or ambiguous requests
+  stay on the computer. Silence never means approval.
+- **Phone-first Wi-Fi onboarding.** Scan the on-glass QR, choose a visible
+  2.4 GHz network, and save it only after a successful join. The panel
+  remembers six places while the networks in `secrets.h` remain an immutable
+  recovery floor. Open networks are supported; captive portals and
+  WPA2-Enterprise are not.
+- **Needs You on unrelated Wi-Fi.** A user-owned Cloudflare Worker can carry
+  fixed-size end-to-end encrypted request and verdict frames. Both sides make
+  outbound HTTPS connections; there is no public computer, inbound port, VPN,
+  or shared-LAN requirement.
+- **Live agents on unrelated Wi-Fi.** A second independent switch can relay
+  the minimized Claude/Codex activity rows. Direct LAN stays preferred and
+  stale relay activity clears rather than pretending to be live.
+- **Windows host support.** Claude credentials, Codex app-server reads,
+  persistence, locking, state paths, and Task Scheduler autostart now have
+  native Windows support. The current background task is health-checked via
+  its root endpoint; run it in a terminal when a persistent diagnostic stream
+  is needed. macOS behavior is unchanged.
+- **A clearer connection state.** The neutral top-right Wi-Fi mark is shared
+  across VibePulse, the launcher, Needs You, OTA, and setup. It reports the
+  panel-to-access-point link only—not internet, tokenserver, or relay health.
+
+## Independent and off by default
+
+Claude interactions, Codex interactions, the numbers relay, the encrypted
+interaction relay, the live agent status relay, and the GitHub page/star
+notification remain separate choices. Installing the Codex plugin enables
+none of them. The local-only setup still needs no VibePulse account and sends
+no agent activity to a cloud service.
+
+The encrypted paths expose network metadata such as connection IPs, timing,
+mailbox identifiers, and fixed ciphertext sizes to Cloudflare. They do not
+send question text, command text, project names, activity, or verdicts in
+plaintext. See
+[the relay privacy and setup guide](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.0/docs/interaction-relay.md).
+
+## Reliability work included
+
+- Full host-gate coverage now runs in CI from the same tokenserver suite list
+  used locally.
+- Codex rejects non-weekly quota windows instead of labelling them weekly.
+- The panel interaction task has an explicit stack budget for the bounded v2
+  request view, and the encrypted relay build now selects its HKDF dependency.
+- The numbers mailbox coordinates multiple publishers without list operations
+  and caps cloud writes to protect the account-wide budget.
+- Renewed Claude credentials are detected and published promptly instead of
+  leaving a valid login behind stale cached data.
+- Wi-Fi credentials are committed only after a fresh successful join; failed
+  trials keep every previous recovery network intact.
+
+## Upgrade and setup
+
+Existing v0.6.0 installations can build the tag and use the normal
+consent-gated A/B OTA path:
+
+```sh
+git switch --detach v0.7.0
+. ~/esp/esp-idf/export.sh
+idf.py build
+tools/ota-flash.sh <device-ip>
+```
+
+The phone Wi-Fi flow is documented in
+[docs/wifi.md](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.0/docs/wifi.md).
+Claude and Codex panel controls are installed through
+[docs/agent-setup.md](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.0/docs/agent-setup.md).
+The optional encrypted paths have their own pinned Python/Node dependencies
+and reviewed setup in
+[docs/interaction-relay.md](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.0/docs/interaction-relay.md).
+A fresh clone keeps all interaction, relay, and GitHub choices off.
+
+This release remains source-only. Do not attach `torget.bin`: a built image
+contains the installer's Wi-Fi credentials and device key.

--- a/docs/value-multiple.md
+++ b/docs/value-multiple.md
@@ -19,17 +19,19 @@ Nothing to install. Run the tokenserver with what you actually pay:
 ```sh
 python3 tools/tokenserver/tokenserver.py \
   --claude-plan max5x \
-  --plan-cost-usd 100
+  --plan claude=100
 ```
 
-`--plan-cost-usd` is the important one. Subscription prices are not part of
-any API price list, so the server cannot look yours up — see
+`--plan claude=100` is the important one; repeat `--plan` for every provider
+you pay for, for example `--plan codex=20`. Subscription prices are not part
+of any API price list, so the server cannot look yours up — see
 [Where the numbers come from](#where-the-numbers-come-from). Without it you
 get the US list price for the plan, and `cost_source` says `default` so the
 display can avoid implying precision.
 
-Running Codex as well? Add `--codex-plan pro`. The two monthly costs are
-added, so the multiple answers *what do I get back for everything I pay for?*
+`--claude-plan max5x` and `--codex-plan pro` select the Max Tracker badges;
+they do not replace your declared costs. The provider costs are added, so the
+multiple answers *what do I get back for everything I pay for?*
 
 The figure lands on `GET /api/tokens` under an additive `value` key:
 
@@ -210,7 +212,7 @@ supplies is the accounting convention; the rates come from the catalogue.
 | **Model rates** | Generated from [LiteLLM's price catalogue][catalogue], pinned to an exact revision. `prices.json` records the upstream `blob_sha`, verifiable with `git hash-object` on the downloaded file. |
 | **Cache rates** | The same catalogue: real per-model cache-read and cache-creation prices, including the separate 1-hour write rate. Not inferred from input. |
 | **Accounting convention** | Curated in `update_prices.py`, because no catalogue carries it — and read out of each vendor's source rather than assumed. This is the one number-affecting fact that is ours. |
-| **Subscription costs** | US public list prices as a starting point. Deliberately *not* from an API price list: those do not cover consumer subscriptions, and what you pay depends on plan, tax and currency. Pass `--plan-cost-usd`; the payload reports which was used. |
+| **Subscription costs** | US public list prices as a starting point. Deliberately *not* from an API price list: those do not cover consumer subscriptions, and what you pay depends on plan, tax and currency. Pass `--plan claude=USD` and/or `--plan codex=USD`; the payload reports which was used. |
 
 Why a catalogue rather than the vendor pricing pages: vendor prices live in
 HTML marketing pages with no stable machine-readable form, while this is one

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -69,6 +69,8 @@ For decisions across isolated Wi-Fi, read
 separate lifecycle:
 
 ```sh
+python3 -m pip install -r requirements-interaction-relay.txt
+cd tools/interaction-relay && npm ci && npx wrangler login && cd ../..
 python3 tools/vibepulse_setup.py relay install --url HTTPS_ORIGIN --yes-e2e-cloud
 python3 tools/vibepulse_setup.py relay status
 python3 tools/vibepulse_setup.py relay doctor
@@ -321,8 +323,8 @@ läser dess stdout; det gjordes förut med `select.select`, som på Windows
 bara tar sockets — aldrig pipes. Läsningen sker nu i en läsartråd med kö,
 samma kod på alla plattformar.
 
-Tillståndsfilerna (lås, probestatus, kvotcache, historik, max-spårare) och
-loggen bor under `%LOCALAPPDATA%\VibePulse\` i stället för macOS
+Tillståndsfilerna (lås, probestatus, kvotcache, historik, max-spårare) bor
+under `%LOCALAPPDATA%\VibePulse\` i stället för macOS
 `~/Library/Application Support/VibePulse`. Sökvägarna fungerade bokstavligt
 även förut — `Path.home()` löser ut — men lade ett `Library`-träd i
 användarprofilen som ingenting annat på maskinen känner igen.
@@ -336,7 +338,11 @@ powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.
 Skriptet registrerar tjänsten för den inloggade användaren, startar den
 direkt och startar om den vid fel. Det bakar inte in Claude/Codex- eller
 detaljval i kommandoraden; samma sparade tokenserver-konfiguration används
-som vid manuell start. Avinstallera själva autostarten med:
+som vid manuell start. Uppgiften kör `pythonw.exe` och den nuvarande
+installationen omdirigerar inte stdout/stderr till en beständig fil. Kontrollera
+hälsan med `curl http://localhost:8737/`; kör tjänsten manuellt med
+`python.exe` i en terminal när du behöver felsökningsloggen. Avinstallera
+själva autostarten med:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -Uninstall
@@ -403,7 +409,8 @@ alltid `false`.
 ## Lokal usagehistorik
 
 Tjänsten sparar historiken atomiskt i
-`~/Library/Application Support/VibePulse/usage-history.json`. Högst en punkt
+`~/Library/Application Support/VibePulse/usage-history.json` på macOS och
+under `%LOCALAPPDATA%\VibePulse\` på Windows. Högst en punkt
 per leverantör, fönster och 15 minuter behålls, och allt äldre än åtta dagar
 rensas. Varje punkt har exakt fem värden: tid, `claude`/`codex`, quotafönster,
 procent och avrundad resetcykel. Promptar, svar, kommandon, projekt, filnamn,
@@ -414,14 +421,16 @@ timmarna i den aktuella veckocykeln. Resultatet är antingen `collecting`,
 `unavailable`, beräknad procent vid reset (`at_reset`) eller beräknad tid då
 quotan tar slut (`exhausts`).
 
-Peka skärmen hit i repytrotens `secrets.h`:
+Peka skärmen hit i reporotens `secrets.h`. På macOS är Bonjour-namnet bäst;
+på Windows används den aktiva LAN-adressen med en DHCP-reservation eftersom
+tjänsten inte annonserar mDNS där:
 
 ```c
-#define TK_TOKENS_URL "http://<macens-lan-ip>:8737/api/tokens"
+#define TK_TOKENS_URL "http://<datorns-host-eller-lan-ip>:8737/api/tokens"
 ```
 
-Macens LAN-IP: `ipconfig getifaddr en0`. Ge gärna Macen fast DHCP-lease i
-routern — byter IP:t adress står skärmen med streck tills secrets.h flashas om.
+Macens Bonjour-namn: `scutil --get LocalHostName` (lägg till `.local`).
+Windows LAN-IP: `ipconfig`; reservera den valda IPv4-adressen i routern.
 
 ## Autostart via launchd
 
@@ -456,5 +465,5 @@ python3 tools/tokenserver/smoke.py
   generell observation räknas som källfel och följer stale-kontraktet ovan.
   Claude-proben kostar en tom förfrågan var 240:e sekund — försumbart mot
   fönstren den mäter.
-- Är Macen av visar skärmen streck efter två minuter (stale), inte gamla
+- Är datorn av visar skärmen streck efter två minuter (stale), inte gamla
   siffror som låtsas vara färska. Det är rätt beteende, inte ett fel.

--- a/tools/tokenserver/install-windows-task.ps1
+++ b/tools/tokenserver/install-windows-task.ps1
@@ -20,8 +20,9 @@ Designval, i linje med resten av repot:
   läser %USERPROFILE%\.claude\.credentials.json — en SYSTEM-tjänst hade
   läst fel profil och dessutom gett processen mer rättigheter än den
   behöver.
-- pythonw.exe (inget konsolfönster). Loggarna hamnar där de redan bor:
-  %LOCALAPPDATA%\VibePulse\ (tjänstens egen självroterande logg).
+- pythonw.exe (inget konsolfönster). Den nuvarande uppgiften omdirigerar inte
+  stdout/stderr till en beständig fil. GET / är hälsokollen; kör servern med
+  python.exe i en terminal när en felsökningslogg behövs.
 - Interaction providers and detail are read from the tokenserver's saved config.
   Keep those choices out of the scheduled command so setup changes cannot go
   stale here. The optional publish arguments below are numbers-relay settings,
@@ -80,5 +81,6 @@ Start-ScheduledTask -TaskName $TaskName
 Write-Host "Uppgiften '$TaskName' registrerad och startad."
 Write-Host "  server:  $Server"
 if ($PublishUrl) { Write-Host "  relä:    $PublishUrl" }
-Write-Host "  loggar:  $env:LOCALAPPDATA\VibePulse\"
+Write-Host "  state:   $env:LOCALAPPDATA\VibePulse\"
+Write-Host "  logg:    ingen beständig bakgrundslogg; kör manuellt för felsökning"
 Write-Host "Verifiera:  curl http://localhost:8737/  (claudeProbe ska visa ok)"


### PR DESCRIPTION
## Result

VibePulse's public documentation now matches the code and the `v0.7.0` tag.

- adds a clear **Latest release: v0.7.0** section to the README
- adds a GitHub-ready, image-backed v0.7.0 release body (no H1, absolute tag-pinned image URLs)
- cuts `Unreleased` into v0.7.0 and restores the missing v0.3.0–v0.6.0 changelog history
- documents Codex Needs You, phone-first Wi-Fi, Windows host support, and the separate encrypted interaction/live-status relays
- fixes the stale macOS-only Claude claim and the broken Needs You anchor
- makes Windows direct-LAN addressing and the current Task Scheduler logging limitation explicit
- documents the optional pinned `cryptography` install while keeping the core service stdlib-only
- replaces the deprecated value-cost example with `--plan claude=100`
- adds release-cut rules to both `AGENTS.md` and `CLAUDE.md` so future tags update README, changelog, and release notes together

No firmware behavior changes are included. The PowerShell installer only changes its explanatory text/output so it no longer promises a persistent background log that it does not create.

## Verification

- `git diff --check`
- local Markdown link targets and all tag-pinned v0.7.0 images verified
- 8 interaction/numbers-relay documentation contract tests passed
- 49 value-meter tests passed
- 104 VibePulse Codex plugin/setup tests passed
