### PR TITLE
Fix multi-computer quota relay failover

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -69,10 +69,13 @@ never enables either encrypted activity feature.
 
 ## Multiple publishers
 
-Every quota pool carries its own observation timestamp (`weekObservedAt`,
-`modelObservedAt`, and similar fields). `/api/tokens` merges each pool from the
-publisher that observed that pool most recently. Claude numbers can therefore
-come from an always-on PC while Codex numbers come from the Mac where Codex ran.
+Every quota pool carries its own observation timestamp
+(`claudeWeekObservedAt`, `claudeModelWeekObservedAt`,
+`codexWeekObservedAt`, and similar fields). `/api/tokens` merges each pool from
+the publisher that observed that pool most recently. Claude numbers can
+therefore come from an always-on PC while Codex numbers come from the Mac where
+Codex ran. Cached stale values retain their original observation time, so a
+recently published old cache cannot outrank a genuinely newer reading.
 
 Max Tracker and GitHub retain whole-document semantics. For those endpoints,
 the mailbox-owned receipt counter makes the most recently stored publication

--- a/tools/relay/mailbox.vitest.mjs
+++ b/tools/relay/mailbox.vitest.mjs
@@ -423,20 +423,23 @@ describe("public numbers Worker routing and wire contract", () => {
     const stub = env.NUMBERS_MAILBOX.getByName(MAILBOX_NAME);
     await stub.publish("/api/tokens", "mac", JSON.stringify({
       v: 2,
-      weekPct: 70, weekObservedAt: 150,
+      claudeWeekPct: 70, claudeWeekStale: true,
+      claudeWeekObservedAt: 150,
       codexWeekPct: 41, codexWeekObservedAt: 190,
     }));
     await stub.publish("/api/tokens", "pc", JSON.stringify({
       v: 2,
-      weekPct: 73, weekObservedAt: 205,
+      claudeWeekPct: 73, claudeWeekStale: false,
+      claudeWeekObservedAt: 205,
       codexWeekPct: 39, codexWeekObservedAt: 100,
     }));
 
     const response = await relayRequest(env, "/api/tokens");
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
-      weekPct: 73,
-      weekObservedAt: 205,
+      claudeWeekPct: 73,
+      claudeWeekStale: false,
+      claudeWeekObservedAt: 205,
       codexWeekPct: 41,
       codexWeekObservedAt: 190,
     });

--- a/tools/relay/test.mjs
+++ b/tools/relay/test.mjs
@@ -19,16 +19,22 @@ test("en ensam avsändare passerar orörd", () => {
 test("varje pool tas från den maskin som såg den senast", () => {
   const mac = { receivedAt: 200, publisher: "mac", body: {
     v: 2,
-    weekPct: 70, weekObservedAt: 150,        // äldre Claude-observation
+    claudeWeekPct: 70, claudeWeekStale: true,
+    claudeWeekObservedAt: 150,               // äldre Claude-observation
     codexWeekPct: 41, codexWeekObservedAt: 190,  // färsk Codex (Macen kör Codex)
   } };
   const pc = { receivedAt: 210, publisher: "pc", body: {
     v: 2,
-    weekPct: 73, weekObservedAt: 205,        // färsk Claude (PC:n frågade nyss)
+    claudeWeekPct: 73, claudeWeekStale: false,
+    claudeWeekObservedAt: 205,               // färsk Claude (PC:n frågade nyss)
     codexWeekPct: 39, codexWeekObservedAt: 100,  // gammal Codex
   } };
   const merged = mergeTokens([mac, pc]);
-  assert.equal(merged.weekPct, 73, "Claude ska komma från PC:n");
+  assert.equal(merged.claudeWeekPct, 73, "Claude ska komma från PC:n");
+  assert.equal(merged.claudeWeekStale, false,
+               "PC:ns färska Claude-status ska följa poolen");
+  assert.equal(merged.claudeWeekObservedAt, 205,
+               "Claude-stämpeln ska följa PC:ns pool");
   assert.equal(merged.codexWeekPct, 41, "Codex ska komma från Macen");
   assert.equal(merged.codexWeekObservedAt, 190,
                "stämpeln ska följa sin pools vinnare");

--- a/tools/relay/worker.js
+++ b/tools/relay/worker.js
@@ -19,8 +19,10 @@
  * samma brevlåda under eget namn. Läsningen slår ihop dem:
  *
  *   /api/tokens      — färskast VINNER PER POOL: varje kvotpool bär redan
- *                      sin egen observationsstämpel (weekObservedAt,
- *                      modelObservedAt, ... — byggda för stalenesslogiken),
+ *                      sin egen observationsstämpel
+ *                      (claudeWeekObservedAt,
+ *                      claudeModelWeekObservedAt, ... — byggda för
+ *                      stalenesslogiken),
  *                      så Codex-siffran kan komma från Macen som körde
  *                      Codex senast medan Claude-siffran kommer från PC:n
  *                      som frågade Anthropic för tio sekunder sedan.

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1588,6 +1588,35 @@ class UsageSnapshotTests(unittest.TestCase):
         self.assertIsInstance(snapshot["claudeForecastPctAtReset"], int)
         self.assertEqual(snapshot["codexForecastState"], "at_reset")
 
+    def test_snapshot_exposes_live_pool_observation_times_for_relay_merge(self):
+        now_ts = 1_800_000_000
+        snapshot = self._snapshot(
+            StubHistory(), now_ts,
+            claude={
+                "weekPct": 47.0,
+                "weekResetAt": now_ts + 300 * 60,
+                "weekObservedAt": now_ts - 3,
+                "weekIdentity": tokenserver._quota_identity(
+                    "claude", "general_weekly"),
+                "modelPct": 73.0,
+                "modelResetAt": now_ts + 300 * 60,
+                "modelObservedAt": now_ts - 2,
+                "modelIdentity": tokenserver._quota_identity(
+                    "claude", "model_weekly"),
+                "modelLabel": "FABLE · WEEK",
+            },
+            codex={
+                "codexWeekPct": 35.0,
+                "codexWeekResetAt": now_ts + 300 * 60,
+                "codexWeekObservedAt": now_ts - 1,
+                "codexWeekIdentity": tokenserver._quota_identity(
+                    "codex", "general_weekly", "synthetic"),
+            })
+
+        self.assertEqual(snapshot["claudeWeekObservedAt"], now_ts - 3)
+        self.assertEqual(snapshot["claudeModelWeekObservedAt"], now_ts - 2)
+        self.assertEqual(snapshot["codexWeekObservedAt"], now_ts - 1)
+
     def test_snapshot_flattens_collecting_and_exhaustion_states(self):
         now_ts = 1_800_000_000
         history = StubHistory({
@@ -1712,6 +1741,40 @@ class UsageSnapshotTests(unittest.TestCase):
         self.assertTrue(stale["codexWeekStale"])
         self.assertIsNone(empty["codexWeekPct"])
         self.assertFalse(empty["codexWeekStale"])
+
+    def test_stale_cache_retains_pool_observation_times_for_relay_merge(self):
+        now_ts = 1_800_000_000
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache = QuotaCache(Path(temp_dir) / "quota.json",
+                               now=lambda: now_ts)
+            records = (
+                CachedQuota(
+                    provider="claude", scope="general_weekly",
+                    identity=tokenserver._quota_identity(
+                        "claude", "general_weekly"),
+                    pct=47.0, reset_at=now_ts + 3600,
+                    observed_at=now_ts - 30),
+                CachedQuota(
+                    provider="claude", scope="model_weekly",
+                    identity=tokenserver._quota_identity(
+                        "claude", "model_weekly"),
+                    pct=73.0, reset_at=now_ts + 3600,
+                    observed_at=now_ts - 20, label="FABLE · WEEK"),
+                CachedQuota(
+                    provider="codex", scope="general_weekly",
+                    identity=tokenserver._quota_identity(
+                        "codex", "general_weekly", "general"),
+                    pct=35.0, reset_at=now_ts + 3600,
+                    observed_at=now_ts - 10),
+            )
+            for record in records:
+                cache.put(record)
+            snapshot = self._snapshot(
+                StubHistory(), now_ts, quota_cache=cache)
+
+        self.assertEqual(snapshot["claudeWeekObservedAt"], now_ts - 30)
+        self.assertEqual(snapshot["claudeModelWeekObservedAt"], now_ts - 20)
+        self.assertEqual(snapshot["codexWeekObservedAt"], now_ts - 10)
 
     def test_success_then_failed_attempt_resolves_only_through_stale_cache(self):
         now_ts = 1_800_000_000

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -1795,6 +1795,7 @@ def _resolve_weekly_quota(source, provider, scope, prefix, quota_cache,
         return {
             "pct": round(float(pct), 1),
             "reset_at": int(reset_at),
+            "observed_at": int(observed_at),
             "label": record.label,
             "stale": False,
             "live": True,
@@ -1805,6 +1806,7 @@ def _resolve_weekly_quota(source, provider, scope, prefix, quota_cache,
         return {
             "pct": round(float(cached.pct), 1),
             "reset_at": cached.reset_at,
+            "observed_at": cached.observed_at,
             "label": cached.label,
             "stale": True,
             "live": False,
@@ -1922,6 +1924,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     result["claudeWeekPct"] = claude_week["pct"]
     result["claudeWeekResetMin"] = _reset_minutes(
         claude_week["reset_at"], current_ts)
+    result["claudeWeekObservedAt"] = claude_week.get("observed_at")
     result["claudeWeekStale"] = bool(
         claude_week["pct"] is not None and claude_week["stale"])
     # The exact "*Stale: false" gate: claude_week["live"] is precisely what
@@ -1934,6 +1937,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     result["claudeModelWeekPct"] = claude_model["pct"]
     result["claudeModelWeekResetMin"] = _reset_minutes(
         claude_model["reset_at"], current_ts)
+    result["claudeModelWeekObservedAt"] = claude_model.get("observed_at")
     result["claudeModelWeekLabel"] = claude_model["label"]
     result["claudeModelWeekStale"] = bool(
         claude_model["pct"] is not None and claude_model["stale"])
@@ -1942,6 +1946,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     result["codexWeekPct"] = codex_week["pct"]
     result["codexWeekResetMin"] = _reset_minutes(
         codex_week["reset_at"], current_ts)
+    result["codexWeekObservedAt"] = codex_week.get("observed_at")
     result["codexWeekStale"] = bool(
         codex_week["pct"] is not None and codex_week["stale"])
     if max_tracker_store is not None:


### PR DESCRIPTION
## Summary
- publish per-pool Claude and Codex observation timestamps from the tokenserver
- retain the original observation time when serving stale cached quota values
- verify the relay merges real production quota fields from the freshest computer per pool

This lets an always-on Windows PC provide fresh Claude quota data when the Mac is unavailable, while another computer may still provide fresher Codex data. Recently republished stale cache can no longer displace a genuinely newer reading.

## Test plan
- `PYTHON_BIN="$PWD/.venv/bin/python" ./test/run.sh --skip-js` — 765 tests passed
- `cd tools/relay && npm ci && npm test` — 25 Workers runtime tests and 12 deployment guard tests passed
- live Mac and Cloudflare mailbox checks returned non-stale Claude values with numeric per-pool observation timestamps
