### PR TITLE
fix: harden VibePulse startup and panel health

### DIFF
--- a/.agents/plugins/plugins/vibepulse/.codex-plugin/plugin.json
+++ b/.agents/plugins/plugins/vibepulse/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibepulse",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Optional local VibePulse panel interactions for Codex.",
   "author": {
     "name": "Niclas Vestlund",

--- a/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
@@ -261,7 +261,7 @@ def _initialize(params):
     return {
         "protocolVersion": selected,
         "capabilities": {"tools": {"listChanged": False}},
-        "serverInfo": {"name": "vibepulse", "version": "0.1.0"},
+        "serverInfo": {"name": "vibepulse", "version": "0.1.1"},
     }
 
 

--- a/.agents/plugins/plugins/vibepulse/skills/vibepulse/SKILL.md
+++ b/.agents/plugins/plugins/vibepulse/skills/vibepulse/SKILL.md
@@ -17,6 +17,15 @@ questions, unsupported shapes, an unavailable panel, timeout, or computer
 fallback. Never treat silence, panel absence, or fallback as approval.
 Permission decisions remain subject to Codex policy.
 
+For a physical Codex smoke test, use the exact short question
+`Ser du APPROVE?` with `Ja` (`APPROVE syns`) and `Nej` (`APPROVE saknas`),
+marking only `Ja` recommended. Pass only when the panel visibly shows
+**APPROVE**, a human taps it, and the call returns `status: answered`,
+`option_index: 0`, `answer: Ja`. **SOMETHING IS WAITING** without answer
+buttons is the fit/privacy fallback, not a pass. After a flash, compare
+`git describe --tags --always --dirty` from the build checkout with the service's
+`otaAvailableVersion` before testing.
+
 Explain that the encrypted relay is not enabled by this plugin. Activity and
 interaction content remain local in this phase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+Release candidate notes:
+[v0.7.1 — health and panel reliability](docs/releases/2026-08-27-health-and-panel-reliability.md).
+
+### Added
+
+- Startup diagnostics now expose content-free Claude credential readiness and
+  recent physical panel polling. `doctor` and the host smoke check warn before
+  the readable credential expires and distinguish an authenticated client
+  from a live panel path without returning tokens or panel addresses.
+- A canonical Codex → panel → touch → Codex smoke test and recovery table now
+  cover missing recommendations, physical fit/privacy fallback, stale
+  worktree flashes, and font-glyph failures. Silence and computer fallback
+  remain failures, never implicit approval.
+
+### Changed
+
+- The VibePulse Codex plugin is `0.1.1`. Its skill carries the verified short
+  physical smoke payload and pre-flash version comparison so a fresh task does
+  not invent a longer, buttonless diagnostic prompt.
+- Relay publishing performs its first potentially expensive producer scan on
+  its background thread, allowing the local tokenserver to bind immediately
+  at login.
+
 ### Fixed
 
 - Claude's general weekly quota no longer goes stale merely because the OAuth
@@ -12,6 +35,15 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   A strict passive fallback reads only the official client's bounded local
   percentage history and reuses a still-valid authenticated reset; named
   Fable/Opus limits remain honestly stale until OAuth recovers.
+- Claude login state can no longer make startup health look green when the
+  separate credential readable by VibePulse is near expiry or already dead.
+  The root endpoint reports only `ready`, `expiring`, `expired`, `unavailable`,
+  or `unknown` plus whole minutes remaining; local recovery is rechecked every
+  15 seconds.
+- Mixed-case, numeric, and punctuated project names no longer render as boxes
+  on the Needs You attract screen. The label now uses the existing full-ASCII
+  `plex_ui_21` raster and is guarded by simulator and physical Swedish-copy
+  checks.
 
 ## v0.7.0 — 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
-No user-facing changes yet.
+### Fixed
+
+- Claude's general weekly quota no longer goes stale merely because the OAuth
+  copies visible to the tokenserver expired while Claude Desktop kept working.
+  A strict passive fallback reads only the official client's bounded local
+  percentage history and reuses a still-valid authenticated reset; named
+  Fable/Opus limits remain honestly stale until OAuth recovers.
 
 ## v0.7.0 — 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ mutating, secret-bearing, or text that does not fit stays on the computer;
 silence never means approval. Recommended questions are equally strict: Codex
 must mark one of two or three options itself. VibePulse never guesses.
 
+After a firmware or Codex-bridge change, use the canonical physical smoke test
+in [docs/agent-setup.md](docs/agent-setup.md#post-flash-physical-codex-smoke-test).
+A pass requires visible **APPROVE**, a real panel tap, and the matching answered
+result back in Codex. A waiting screen, timeout, **LEAVE IT**, or computer
+fallback is not a pass.
+
 ### Independent switches
 
 VibePulse is open source, so installing one part never silently enables
@@ -303,6 +309,13 @@ The computer must be on for fresh local data. It does not have to stay in the
 same house when a relay is enabled, but it does have to run the tokenserver so
 there is something to publish. A phone hotspot is fine after it has been taught
 to the panel; captive portals and 5 GHz-only networks are not.
+
+The startup/doctor health check also guards Claude's saved usage credential.
+`GET /` exposes only `claudeCredential.status` and whole minutes remaining—
+never an access or refresh token—and warns 30 minutes before expiry. This
+matters because Claude Desktop can remain logged in after the separate
+credential readable by VibePulse has aged out; stale Fable data is never
+reported as current.
 
 ## What you need
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -147,6 +147,19 @@ agentstatusen över LAN. VibePulse sparar högst en content-fri quotapunkt per
 endast tid, leverantör, fönster, procent och resetcykel. Se README:n där för
 kontrakt, integritetsgräns och autostart via launchd.
 
+Startup-/doctor-kontrollen bevakar också Claudes sparade usage-credential.
+`GET /` visar bara `claudeCredential.status` och hela minuter kvar—aldrig
+åtkomst- eller refresh-token—och varnar 30 minuter före utgång. Det behövs
+eftersom Claude Desktop kan fortsätta vara inloggad efter att den separata
+credential VibePulse får läsa har blivit för gammal; gammal Fable-data märks
+alltid som stale.
+
+Efter firmware- eller Codex-bridgeändringar ska den fysiska rökkontrollen i
+[agent-setup](docs/agent-setup.md#post-flash-physical-codex-smoke-test) köras.
+Godkänt kräver synlig **APPROVE**, ett verkligt tryck på panelen och samma svar
+tillbaka i Codex. Vänteskärm, timeout, **LEAVE IT** eller datorfallback räknas
+inte som godkänt och betyder aldrig ett tyst godkännande.
+
 ## Hårdvarufällorna
 
 Översikten finns i `spec/hardware.md`; capability-, source- och unitstatus

--- a/components/app_tokens/agent_monitor.c
+++ b/components/app_tokens/agent_monitor.c
@@ -19,12 +19,12 @@ extern const lv_font_t plex_ui_16;
 extern const lv_font_t plex_ui_21; /* full ASCII incl. lowercase — long-question step-down */
 /* Needs You v2 takeover fonts. The command payload is the one element the
  * design keeps in real mono; the question/title need a shelf-readable full-
- * ASCII face (plex_body_27). headline_48 carries the one-word heroes, text_21
- * the attract project line. See docs/needs-you-investigation.md. */
+ * ASCII face (plex_body_27). headline_48 carries the one-word heroes. The
+ * attract project line deliberately uses ui_21: project labels may contain
+ * digits and .-_?, which the uppercase-only text_21 raster cannot draw. */
 extern const lv_font_t plex_body_27;
 extern const lv_font_t plex_mono_40;
 extern const lv_font_t plex_headline_48;
-extern const lv_font_t plex_text_21;
 
 #define COL_BLACK   lv_color_hex(VP_COLOR_BACKGROUND)
 #define COL_WHITE   lv_color_hex(VP_COLOR_TEXT)
@@ -743,7 +743,7 @@ static void create_needs_you(lv_obj_t *app_root) {
   v->a_codex_icon = ny_codex_icon(v->a_group, 208, 118);
   v->a_word = ny_text(v->a_group, &plex_headline_48, COL_WHITE, 0, 278, 480, 0, C);
   lv_label_set_text(v->a_word, "NEEDS YOU");
-  v->a_project = ny_text(v->a_group, &plex_text_21, COL_CLAUDE, 0, 332, 480, 3, C);
+  v->a_project = ny_text(v->a_group, &plex_ui_21, COL_CLAUDE, 0, 332, 480, 3, C);
   v->a_tap = ny_text(v->a_group, &plex_ui_16, COL_DIM, 0, 424, 480, 2, C);
   lv_label_set_text(v->a_tap, "TAP TO ANSWER");
 

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -24,15 +24,15 @@ dependencies:
       type: service
     version: 0.5.3
   espressif/esp-nn:
-    component_hash: d341d40c8a135158f2bd47bd3c956bb8eda43358cd555cd887b410310a14c547
+    component_hash: 83eca824ef501eb0d8ac7d090970d8a2997ac369e5edb86366a5943e4368d5a5
     dependencies:
     - name: idf
       require: private
-      version: '>=4.2'
+      version: '>=5.1'
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.2.5
+    version: 1.3.0
   espressif/esp-tflite-micro:
     component_hash: 22fc501ab0b1bd39377048d608e6fce0e7b55cd07d244cbf41044b24d9b7db2e
     dependencies:
@@ -166,7 +166,7 @@ dependencies:
       type: service
     version: 1.0.1
   espressif/esp_lvgl_adapter:
-    component_hash: 74ad06b34ee7aec3f2a4f4fd8ed20852527a780d35d0154488624383d9e72972
+    component_hash: bcb316bedda9e934d32567082a969a8e8f8f406dd32d23c359a299249dc18e81
     dependencies:
     - name: espressif/button
       registry_url: https://components.espressif.com
@@ -202,9 +202,9 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 0.6.3
+    version: 0.6.4
   espressif/esp_mmap_assets:
-    component_hash: b7c559238d9f4c11048b1d7302f5474e4f4f590902433efd792bd0cbf5324f2a
+    component_hash: 42310c362596de2a37248c2937b1754bc29cd0356b9839e2a77cf791e6bcdde1
     dependencies:
     - name: espressif/cmake_utilities
       registry_url: https://components.espressif.com
@@ -216,7 +216,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 2.0.0
+    version: 2.0.1
   espressif/esp_new_jpeg:
     component_hash: e1e7e6991193c41ed6c9fc386702aa7821433319e7aa9c3147cd3236310cd69c
     dependencies: []
@@ -237,15 +237,15 @@ dependencies:
     - esp32h4
     version: 1.0.2
   espressif/freetype:
-    component_hash: 381eab0d52cbfadbdde4e7a80c1196a0a22b1a0bde4830b1201b1ae6e0fd8c90
+    component_hash: aa9f7657a69b2b1c1f49044017fc424081d4e0fe6e97834cb43883548d44e3ca
     dependencies:
     - name: idf
       require: private
-      version: '>=4.4'
+      version: '>=5.1'
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 2.14.3
+    version: 2.14.3~1
   espressif/knob:
     component_hash: b56694054cd34a683ac2a6f3661963ba00b1dab741a4f3bb59ed6666cbc9f3fb
     dependencies:
@@ -261,11 +261,11 @@ dependencies:
       type: service
     version: 1.1.0
   espressif/libpng:
-    component_hash: 30b1f2f8ddf13754b3e21d7ac134b3cc8f02957bb01d0c6deb5e9a68080d69d5
+    component_hash: b8c715f76b79a127d9b1b632e09acc23e7b29d2194af890a837adc2be5a2804b
     dependencies:
     - name: idf
       require: private
-      version: '>=5.0'
+      version: '>=5.1'
     - name: espressif/zlib
       registry_url: https://components.espressif.com
       require: private
@@ -273,7 +273,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.6.58
+    version: 1.6.58~1
   espressif/tinyusb:
     component_hash: a40b7f67df6ac254a4afd96c6401cc56f2059ae747d6d7e66b568bca53ad0edc
     dependencies:
@@ -315,15 +315,15 @@ dependencies:
     - esp32h4
     version: 1.3.1
   espressif/zlib:
-    component_hash: 64ea2fd6754c5a05951f1ddb312ac835cd782e68cb5bd9dfcd1c3a107c8fbfbc
+    component_hash: 9083cada65f1c9d298ef92266232d071c6f2f335164e2799554b3eae73aedc55
     dependencies:
     - name: idf
       require: private
-      version: '>=4.4'
+      version: '>=5.1'
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.3.2
+    version: 1.3.2~1
   idf:
     source:
       type: idf
@@ -408,6 +408,6 @@ direct_dependencies:
 - lvgl/lvgl
 - waveshare/esp32_s3_touch_amoled_2_16
 - waveshare/qmi8658
-manifest_hash: 4b6d2b2d10e093fb47b1807f66f26ceac9e562af80c63cc292db8ed275f131fd
+manifest_hash: 130297078a6dff12a09f4fa306e440a310ff443c5672636e7fc6eed2271ed8dd
 target: esp32s3
 version: 2.0.0

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -168,16 +168,17 @@ it does not publish agent activity or Needs You prompts.
 curl -s localhost:8737/ | python3 -m json.tool
 ```
 
-Read `claudeProbe` in that output — it is the single most useful diagnostic
-in the whole system, and it tells you exactly why Claude's numbers are or
-are not arriving:
+Read `claudeProbe` and `claudeLocalUsage` in that output. The first explains
+the authenticated source; the second explains whether Claude Desktops
+content-free local plan history safely keeps the general week fresh while a
+readable OAuth copy is expired:
 
 | `claudeProbe` | Meaning | What to do |
 |---|---|---|
 | `usage_http_200 + ok` | Working. Limits parsed. | Nothing |
 | `not_run` | Probe has not fired yet | It runs every 120 s — wait |
 | `no_claude_oauth_token` | No Claude Desktop / Claude Code token found | Have them sign in to Claude Code on this computer |
-| `token_expired_…` | Token found but expired | Re-authenticate in Claude Code |
+| `token_expired_…` | Token found but expired | The service rechecks every 15 s. `claudeLocalUsage: fresh_applied` can keep the general week live; re-authenticate only if the model week must recover too |
 | `usage_http_401` / `usage_http_403` | Every token source rejected (on macOS the probe tries Claude Desktop's process token, then the keychain, and falls back automatically; on Windows there is only `%USERPROFILE%\.claude\.credentials.json`) | Re-authenticate in Claude Code |
 | `usage_http_200 + no_mapped_limits` | Authenticated, but nothing in the usage response mapped (a `; fallback_…` suffix records the header-probe outcome) | Plan may not expose limits; Codex half still works |
 | `usage_request_failed: …` | Network/DNS failure from the computer | Check the computer's own connectivity |
@@ -386,7 +387,7 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 | `wifi-here.sh` cannot join the setup AP | The window is closed, or `TG_OTA_TOKEN` is missing so the password is random | Check the glass says WIFI SETUP; without a token run `TG_AP_PASS=<what the glass shows> tools/wifi-here.sh` |
 | Panel joined the venue WiFi but still shows dashes | Client isolation, or a captive portal the panel cannot pass | Not fixable on the device. Use the phone hotspot instead |
 | "This project has no OTA" / partitions.csv shows one factory partition | Reading a tree from before the OTA foundation (A/B slots + otadata + `components/torget_ota/`) | Check which branch/commit the checkout is on; read `partitions.csv` in THAT tree before concluding. OTA workflow: `tools/ota-flash.sh <ip>` + a 3 s KEY3 hold |
-| Panel shows stale quota / empty Fable weekly in the morning | Upstream 429 penalty from the shared account bucket | Self-heals: dead tokens are never resent, the penalty persists across restarts, deltas serve from cache. Check `claudeProbe` on `curl localhost:8737/` |
+| Panel shows stale quota / empty Fable weekly in the morning | The readable OAuth copy expired/rejected, or an upstream 429 penalty is active | The general week can recover from Claude Desktops bounded local plan history; the named Fable/Opus pool still requires OAuth. Check both `claudeProbe` and `claudeLocalUsage` on `curl localhost:8737/` |
 | Panel shows stale while powered from the computer USB port | The Mac port cannot feed WiFi TX bursts — fetches time out | Expected on Mac USB; run from wall power. Logs stay valid on Mac USB, data does not |
 | OTA boots always show state 0xffffffff and the health gate always rests | `sdkconfig` generated before the rollback line landed in `sdkconfig.defaults` (defaults only apply on fresh generation) | `grep BOOTLOADER_APP_ROLLBACK sdkconfig` — set `=y`, rebuild, and USB-flash ONCE (the bootloader carries the logic; OTA never writes it) |
 | No `/dev/cu.usbmodem*` or Windows `COM` port | Not in download mode | Hold BOOT, tap RESET, release BOOT |

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -178,7 +178,7 @@ readable OAuth copy is expired:
 | `usage_http_200 + ok` | Working. Limits parsed. | Nothing |
 | `not_run` | Probe has not fired yet | It runs every 120 s — wait |
 | `no_claude_oauth_token` | No Claude Desktop / Claude Code token found | Have them sign in to Claude Code on this computer |
-| `token_expired_…` | Token found but expired | The service rechecks every 15 s. `claudeLocalUsage: fresh_applied` can keep the general week live; re-authenticate only if the model week must recover too |
+| `token_expired_…` | Token found but expired; Claude may still say logged in because login state and the exported usage credential are different | The service rechecks locally every 15 s. `claudeLocalUsage: fresh_applied` can keep the general week live; for Fable, start a **new Claude Code CLI turn** and send one short message so Claude's supported client refreshes Keychain |
 | `usage_http_401` / `usage_http_403` | Every token source rejected (on macOS the probe tries Claude Desktop's process token, then the keychain, and falls back automatically; on Windows there is only `%USERPROFILE%\.claude\.credentials.json`) | Re-authenticate in Claude Code |
 | `usage_http_200 + no_mapped_limits` | Authenticated, but nothing in the usage response mapped (a `; fallback_…` suffix records the header-probe outcome) | Plan may not expose limits; Codex half still works |
 | `usage_request_failed: …` | Network/DNS failure from the computer | Check the computer's own connectivity |
@@ -187,6 +187,15 @@ readable OAuth copy is expired:
 
 Codex is read separately from its local app-server, so a bad `claudeProbe`
 never explains missing Codex numbers, and vice versa.
+
+Also read `claudeCredential` on the same `GET /` response. It contains only a
+safe status and whole minutes remaining—never either OAuth token. `expiring`
+starts 30 minutes before failure; `expired` is actionable even when
+`claude auth status` still says logged in. `python3 tools/vibepulse_setup.py
+doctor`, Codex `SessionStart`, and `python3 tools/tokenserver/smoke.py` all
+consume this guard. After Claude's supported client refreshes the credential,
+the service notices locally within 15 seconds; it does not call an
+undocumented refresh endpoint or mutate the refresh token itself.
 
 Then check the endpoints the screen polls:
 
@@ -372,6 +381,31 @@ On the glass: a tap opens the decision; APPROVE / DENY / LEAVE IT answer it; on
 the private screen a tap hands it to the terminal. KEY3 held ~1.5–3 s and
 released is the panic — deny everything parked; the 3 s hold still opens OTA.
 
+### Post-flash physical Codex smoke test
+
+After a firmware flash or a VibePulse/Codex setup change, send one exact short
+question through `mcp__vibepulse__ask`:
+
+- header `Test`
+- question `Ser du APPROVE?`
+- `Ja` — description `APPROVE syns` — recommended
+- `Nej` — description `APPROVE saknas`
+
+A pass requires all of the following: the panel opens the question, shows the
+recommended `Ja` card plus **APPROVE** and **LEAVE IT**, accepts the physical
+tap on **APPROVE**, and the waiting call returns `status: answered`,
+`option_index: 0`, `answer: Ja`. The non-recommended option stays on the
+computer by design. `DENY` is used for readable permission cards, not as the
+second button for a recommended question.
+
+Silence, timeout, **LEAVE IT**, panel absence, computer fallback, or a private
+**SOMETHING IS WAITING** screen without answer buttons is not a pass and never
+means approval. Before flashing, record `git describe --tags --always --dirty` from
+the exact build checkout and compare it with `otaAvailableVersion`; preview,
+test, build, and flash from that same checkout. The full verified evidence and
+recovery sequence is in
+[the 2026-08-27 physical review](superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md).
+
 ## When it does not work
 
 After the first USB flash, day-to-day updates go over the air — the full
@@ -387,6 +421,10 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 | `wifi-here.sh` cannot join the setup AP | The window is closed, or `TG_OTA_TOKEN` is missing so the password is random | Check the glass says WIFI SETUP; without a token run `TG_AP_PASS=<what the glass shows> tools/wifi-here.sh` |
 | Panel joined the venue WiFi but still shows dashes | Client isolation, or a captive portal the panel cannot pass | Not fixable on the device. Use the phone hotspot instead |
 | "This project has no OTA" / partitions.csv shows one factory partition | Reading a tree from before the OTA foundation (A/B slots + otadata + `components/torget_ota/`) | Check which branch/commit the checkout is on; read `partitions.csv` in THAT tree before concluding. OTA workflow: `tools/ota-flash.sh <ip>` + a 3 s KEY3 hold |
+| **UPDATE READY** appears immediately after USB flash | The flashed image is older than the advertised OTA build, often because it came from another worktree | Compare the booted version, `git describe --tags --always --dirty`, and `otaAvailableVersion`; rebuild and flash from the intended checkout |
+| A test question shows only **LEAVE IT** | The request has no single explicit recommendation | Use 2–3 short options and mark exactly one genuinely recommended option |
+| **SOMETHING IS WAITING** appears with no answer buttons | The question failed the physical fit/privacy gate | Finish on the computer. For a diagnostic only, use the canonical short smoke test above |
+| Letters become boxes in project/status text | The UI selected an uppercase-only font | Use `plex_ui_21` for mixed-case/localized text and verify with `RÄKSMÖRGÅS` |
 | Panel shows stale quota / empty Fable weekly in the morning | The readable OAuth copy expired/rejected, or an upstream 429 penalty is active | The general week can recover from Claude Desktops bounded local plan history; the named Fable/Opus pool still requires OAuth. Check both `claudeProbe` and `claudeLocalUsage` on `curl localhost:8737/` |
 | Panel shows stale while powered from the computer USB port | The Mac port cannot feed WiFi TX bursts — fetches time out | Expected on Mac USB; run from wall power. Logs stay valid on Mac USB, data does not |
 | OTA boots always show state 0xffffffff and the health gate always rests | `sdkconfig` generated before the rollback line landed in `sdkconfig.defaults` (defaults only apply on fresh generation) | `grep BOOTLOADER_APP_ROLLBACK sdkconfig` — set `=y`, rebuild, and USB-flash ONCE (the bootloader carries the logic; OTA never writes it) |

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,21 @@ point at the backlog item.
 
 ---
 
+## 2026-08-23 · Claude kept working after every readable token copy had died
+
+**What happened:** the panel showed Claude `STALE` while Claude Desktop was
+actively consuming the plan on both Mac and PC. **Root cause:** Desktop can
+refresh and use credentials inside its running client without replacing the
+launch-time environment token or the expired Claude Code keychain record that
+the tokenserver is allowed to read. The previous recovery assumed real client
+use always replaced one of those copies. **The rule:** authentication health
+and quota-observation health are separate truths; use a bounded official local
+usage artifact when it proves freshness, but never infer a named model pool or
+reset it does not contain. **Guards:** strict v2/size/age/percentage parsing,
+authenticated-reset reuse, OAuth-newer precedence, and regression coverage in
+`ClaudePlanUsageFallbackTests`. **Watch for:** Claude changing the local file's
+version, cadence, path, or `fh`/`sd` fields.
+
 ## 2026-08-19 · `sdkconfig.defaults` did not migrate the existing LVGL pool
 
 **What happened:** v0.6 froze on any full redraw while the LVGL task held

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,33 @@ point at the backlog item.
 
 ---
 
+## 2026-08-27 · A green build from an old tree hid the panel test
+
+**What happened:** the panel first showed **UPDATE READY**, then questions with
+only **LEAVE IT** or a buttonless private screen, while localized project text
+contained boxes. **Root cause:** a valid but older worktree was flashed, the
+attract label used an uppercase-only font, and the diagnostic questions did
+not satisfy the one-recommendation/physical-fit contract. **The rule:**
+preview, test, build, and flash from one identified checkout, then verify the
+whole Codex → panel → touch → Codex round trip with one canonical short
+question. **Guards:** the post-flash smoke recipe in `docs/agent-setup.md`, the
+physical review dated 2026-08-27, plugin documentation assertions, and the
+hardware registry. **Watch for:** treating a successful build, a visible
+waiting screen, silence, or computer fallback as an end-to-end pass.
+
+## 2026-08-26 · Logged in did not mean the exported usage token was fresh
+
+**What happened:** Claude kept working all evening while Fable alone became
+stale; `claude auth status` still said logged in. **Root cause:** Claude
+Desktop's long-lived child retained a frozen process token, while the separate
+Keychain access token VibePulse can read expired at 21:52; the passive general
+week fallback masked the split. **The rule:** login state and an out-of-process
+usage credential are separate health dimensions, and expiry must be warned
+before the first failed request. **Guards:** content-free `claudeCredential`
+readiness on `GET /`, a 30-minute startup/doctor/smoke warning, 15-second local
+recovery checks, and honest stale rendering. **Watch for:** hidden keepalive
+prompts or undocumented refresh-token calls—neither is an acceptable fix.
+
 ## 2026-08-23 · Claude kept working after every readable token copy had died
 
 **What happened:** the panel showed Claude `STALE` while Claude Desktop was

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -144,6 +144,11 @@ Returns live server state, added after real debugging nights:
   `usage_http_401`, `usage_http_429 + backoff_until_HH:MM`,
   `usage_request_failed: <Type>`, `probe_crashed: <Type>` (the probe
   itself hit a bug — the log has the traceback).
+- `claudeCredential` — the content-free pre-expiry guard for the saved Claude
+  Code credential: `ready`, `expiring`, `expired`, `unavailable`, or
+  `unknown`, plus whole `expiresInMin` when known. It never contains OAuth
+  token values or account data. Startup, doctor, and the smoke test warn 30
+  minutes before expiry instead of waiting for Fable to become stale.
 - `claudeLocalUsage` — the passive Claude Desktop fallback for the general
   week: `fresh_applied` means the official local plan history is newer than
   the readable OAuth copy and was combined with a still-valid authenticated

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -144,6 +144,13 @@ Returns live server state, added after real debugging nights:
   `usage_http_401`, `usage_http_429 + backoff_until_HH:MM`,
   `usage_request_failed: <Type>`, `probe_crashed: <Type>` (the probe
   itself hit a bug — the log has the traceback).
+- `claudeLocalUsage` — the passive Claude Desktop fallback for the general
+  week: `fresh_applied` means the official local plan history is newer than
+  the readable OAuth copy and was combined with a still-valid authenticated
+  reset; `oauth_newer` means the normal probe already has newer truth.
+  `fresh_without_reset` refuses to invent a reset, while `missing`, `stale`,
+  `invalid*`, and `unsupported` explain why the local file was not trusted.
+  This fallback never marks the named Fable/Opus model pool fresh.
 - `ratelimitHeaders` / `unknownRateLimitBuckets` — header names seen by
   the fallback probe. A non-empty `unknownRateLimitBuckets` means
   Anthropic added a bucket we don't map yet: file it.

--- a/docs/releases/2026-08-27-health-and-panel-reliability.md
+++ b/docs/releases/2026-08-27-health-and-panel-reliability.md
@@ -1,0 +1,85 @@
+<!-- GitHub-ready v0.7.1 release body. Intentionally starts without an H1. -->
+
+VibePulse v0.7.1 is a reliability patch for the path that must never merely
+*look* healthy. It warns before the Claude credential readable by VibePulse
+expires, proves whether the physical panel is actually polling, fixes missing
+project-name glyphs, and records one exact end-to-end Codex panel test.
+
+## What changed
+
+- **Claude credential expiry is visible before Fable goes stale.** Claude can
+  remain signed in and working while the separate Keychain credential an
+  out-of-process quota reader is allowed to use has stopped refreshing. The
+  tokenserver now publishes only a content-free readiness state and whole
+  minutes remaining, warns 30 minutes before expiry, and rechecks local
+  recovery every 15 seconds. It never returns or logs an access token, refresh
+  token, account id, or Keychain body.
+- **Startup health distinguishes service from panel.** Two close, non-loopback
+  panel polls are required before diagnostics report recent panel contact; one
+  curl cannot create a false green. The candidate address stays in process
+  memory and is neither returned nor logged. Old evidence expires instead of
+  remaining green forever.
+- **The Codex smoke test is now deterministic.** The documented payload is
+  `Ser du APPROVE?`, with `Ja` as the one explicit recommendation and `Nej` as
+  the computer-side alternative. A pass requires visible **APPROVE**, a real
+  panel tap, and `status: answered`, `option_index: 0`, `answer: Ja` back in
+  Codex. Timeout, silence, **LEAVE IT**, private fallback, and computer
+  fallback are not passes.
+- **Project names render with the right glyph set.** The Needs You attract
+  label used an uppercase-only font even though real project names contain
+  lowercase letters, digits, dots, dashes, underscores, and replacement
+  question marks. It now uses the existing full-ASCII `plex_ui_21` font.
+- **Host startup no longer waits for relay history scans.** The first relay
+  producer pass runs immediately but asynchronously, so a large local history
+  cannot delay the LAN service binding at login.
+- **The Codex plugin advances to 0.1.1.** Its skill includes the canonical
+  physical test, strict pass criteria, and the build-versus-OTA version check.
+
+## Upgrade
+
+Pull or check out the eventual `v0.7.1` tag, then restart the tokenserver so
+the new root diagnostics and startup behavior are active:
+
+```sh
+python3 tools/vibepulse_setup.py status
+python3 tools/vibepulse_setup.py doctor
+python3 tools/tokenserver/smoke.py
+```
+
+Existing Codex users should rerun the transactional guided setup to refresh
+`vibepulse@torget`, choosing the same provider/detail options they want to
+keep, then restart Codex, review VibePulse in `/hooks` if Codex asks again,
+and start a new Codex task:
+
+```sh
+python3 tools/vibepulse_setup.py install
+```
+
+The release does not silently enable Claude, Codex, detail sharing, either
+relay, or any other setting.
+
+The host-side credential/startup fixes do not require a firmware flash. The
+project-name glyph fix does. Use the normal consent-gated OTA flow only after
+the release tag has green CI and the built image version matches the intended
+checkout. Then run the canonical physical smoke test in
+[`docs/agent-setup.md`](../agent-setup.md#post-flash-physical-codex-smoke-test).
+
+VibePulse deliberately does not call an undocumented refresh endpoint or
+mutate Claude's refresh token. When the readable credential is expiring or
+expired, start a new Claude Code CLI turn and send one short message; the
+supported client refreshes its own credential and VibePulse notices locally.
+
+## Verified
+
+- The full host gate passed: 778 Python/C tests, the numbers-relay suites,
+  29 encrypted interaction-relay tests, and TypeScript type checking.
+- The physical panel passed localized `RÄKSMÖRGÅS` rendering and the complete
+  Codex question/touch/answer round trip on `torget-home-01` using the
+  pre-tag build `v0.7.0-5-ge6feb29-dirty`. The exact evidence and recovery
+  table are in the
+  [2026-08-27 physical review](../superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md).
+- A clean `v0.7.1` tag still requires its own green CI before publication.
+  This physical evidence does not authorize an unattended flash.
+
+This release remains source-only. Do not attach `torget.bin`: a locally built
+image contains the installer's Wi-Fi credentials and device key.

--- a/docs/superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md
+++ b/docs/superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md
@@ -1,0 +1,85 @@
+# VibePulse Codex question — physical end-to-end review (2026-08-27)
+
+## Outcome
+
+**PASS** on `torget-home-01`. The physical panel displayed the recommended
+answer and the **APPROVE** action, accepted the touch, and returned the same
+answer to the waiting Codex call.
+
+The verified USB flash was built from the main Torget checkout and identified
+itself as `v0.7.0-5-ge6feb29-dirty` (ESP-IDF 5.5.2, boot ELF SHA prefix
+`ee300ac90`). Display, touch, Wi-Fi and the first token fetch all initialized
+without an immediate OTA takeover.
+
+## What failed before the pass
+
+1. A successful build from an older worktree flashed
+   `v0.6.0-114-gdf04327-dirty`. The server already advertised
+   `v0.6.0-150-g052ac77`, so **UPDATE READY** immediately took over the screen.
+2. The project attract label used the uppercase-only `plex_text_21` font.
+   Swedish lowercase characters became boxes. It now uses `plex_ui_21`; the
+   physical `RÄKSMÖRGÅS` fixture rendered correctly.
+3. A question without exactly one explicit recommendation could only offer
+   **LEAVE IT**. A longer question that failed the firmware's physical fit gate
+   deliberately became the private **SOMETHING IS WAITING** screen with no
+   answer buttons. Neither state is approval.
+
+## Canonical physical smoke test
+
+Use this exact short payload after a VibePulse/Codex setup change or firmware
+flash:
+
+- header: `Test`
+- question: `Ser du APPROVE?`
+- option 1: `Ja`, description `APPROVE syns`, `recommended: true`
+- option 2: `Nej`, description `APPROVE saknas`
+
+Expected sequence on the panel:
+
+1. the waiting/attract screen appears;
+2. a tap opens the decision;
+3. the recommended `Ja` card, **APPROVE**, and **LEAVE IT** are visible;
+4. the other option remains available on the computer by design;
+5. tapping **APPROVE** closes the physical flow;
+6. the waiting tool call returns `status: answered`, `option_index: 0`,
+   `answer: Ja`.
+
+`DENY` belongs to readable permission cards; it is not the second button for
+a recommended question. The verified request was
+`dql6ESFSyAY49W4b6EKd9w` and the tokenserver recorded verdict `approve` at
+00:21:35 local time. The human observer also confirmed the visible result.
+
+Silence, timeout, **LEAVE IT**, panel absence, computer fallback, or the private
+fit-gate screen are all failures of this smoke test. Never reinterpret them as
+approval.
+
+## Mandatory flash guards
+
+Before flashing:
+
+1. run `git describe --tags --always --dirty` in the checkout being built;
+2. compare that version with the service's `otaAvailableVersion`;
+3. preview, test, build, and flash from the same checkout;
+4. include a Swedish text fixture in the preview when fonts changed.
+
+After flashing:
+
+1. verify the written image hash and the booted firmware version;
+2. wait through the first Wi-Fi and token poll — an immediate
+   **UPDATE READY** usually means the wrong or older checkout was flashed;
+3. run the canonical smoke test above;
+4. require both the physical observation and the returned tool result to agree.
+
+## Recovery table
+
+| Symptom | Meaning | Recovery |
+|---|---|---|
+| Immediate **UPDATE READY** after USB flash | Flashed image is older than the advertised OTA build, commonly due to the wrong worktree | Stop testing, compare both versions, rebuild and flash from the intended checkout |
+| Only **LEAVE IT** is visible | No single option was explicitly marked recommended | Resend one short question with 2–3 options and exactly one genuine recommendation |
+| **SOMETHING IS WAITING** with no answer buttons | Text/detail did not pass the physical fit/privacy gate | Continue on the computer; shorten only a non-secret diagnostic prompt and retry |
+| Boxes instead of letters | The selected font lacks those glyphs | Use `plex_ui_21` for mixed-case/localized UI and rerun the Swedish fixture |
+| Tool reports computer fallback or timeout | The panel path did not complete | Use the computer prompt; do not count the run as passed |
+| Tool reports `answered`, but the observer saw something else | UI/result mismatch | Treat as a failed end-to-end test and inspect the request ID in tokenserver logs |
+
+This review records evidence; it does not authorize future flashes, change
+interaction opt-ins, or weaken Codex permission policy.

--- a/spec/device-units.yaml
+++ b/spec/device-units.yaml
@@ -10,6 +10,6 @@ units:
     battery: not_fitted
     microsd: unknown
     antenna: onboard
-    installed_firmware: unknown-after-next-flash
-    last_physical_verification: "2026-08-06"
+    installed_firmware: v0.7.0-5-ge6feb29-dirty
+    last_physical_verification: "2026-08-27"
     secrets: false

--- a/spec/hardware-capabilities.yaml
+++ b/spec/hardware-capabilities.yaml
@@ -111,8 +111,8 @@ capabilities:
       board_wired: "yes"
       bsp_support: "yes"
       firmware_enabled: "yes"
-      unit_verified: unknown
-    confidence: source_inspected
+      unit_verified: "yes"
+    confidence: measured
     resources:
       - "shared I2C port 1 at 400 kHz"
       - "GPIO14 SCL"
@@ -131,12 +131,17 @@ capabilities:
       - waveshare-cst9217-driver-1.0.0
       - waveshare-board-docs-2026-08-10
       - torget-main-1fad449
+      - torget-physical-2026-08-27-vibepulse
     evidence:
       - {field: soc_capable, value: "yes", source: waveshare-schematic-2026-08-10}
       - {field: board_wired, value: "yes", source: waveshare-schematic-2026-08-10}
       - {field: bsp_support, value: "yes", source: waveshare-bsp-2.0.1}
       - {field: firmware_enabled, value: "yes", source: torget-main-1fad449}
-    last_verified: "2026-08-10"
+      - {field: unit_verified, value: "yes", source: torget-physical-2026-08-27-vibepulse}
+    last_verified: "2026-08-27"
+    verification:
+      unit: torget-home-01
+      test: vibepulse-codex-approve-roundtrip-2026-08-27
 
   - id: radio.wifi-24
     name: 2.4 GHz 802.11 b/g/n Wi-Fi

--- a/spec/hardware-sources.yaml
+++ b/spec/hardware-sources.yaml
@@ -1,5 +1,19 @@
 schema_version: 1
 sources:
+  - id: torget-physical-2026-08-27-vibepulse
+    kind: physical-test
+    rank: 1
+    title: VibePulse Codex physical end-to-end findings for torget-home-01
+    publisher: Torget
+    locator: docs/superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md
+    revision: findings-2026-08-27; unit=torget-home-01; firmware=v0.7.0-5-ge6feb29-dirty
+    accessed: "2026-08-27"
+    board_revision: unknown
+    unit: torget-home-01
+    tests:
+      - vibepulse-codex-approve-roundtrip-2026-08-27
+      - localized-project-font-physical-render-2026-08-27
+
   - id: torget-physical-2026-08-06
     kind: physical-test
     rank: 1

--- a/test/test_preview_ui.py
+++ b/test/test_preview_ui.py
@@ -138,6 +138,11 @@ WIFI_GLOBAL_BMPS = {
     for bars in range(4)
 }
 EXPECTED_BMPS.update(WIFI_GLOBAL_BMPS)
+WIFI_DRIFT_BMPS = {
+    f"torget-wifi-drift-{tag}.bmp"
+    for tag in ("0", "1", "2", "3", "return")
+}
+EXPECTED_BMPS.update(WIFI_DRIFT_BMPS)
 EXPECTED_PNGS = {
     f"{Path(name).stem.removeprefix('torget-')}.png"
     for name in EXPECTED_BMPS
@@ -211,7 +216,7 @@ class PreviewWiringTests(unittest.TestCase):
         self.assertIn("os.O_NOFOLLOW", self.script)
         self.assertIn("image.size != expected", self.script)
         self.assertIn("Preview directory:", self.script)
-        for name in EXPECTED_BMPS - WIFI_GLOBAL_BMPS:
+        for name in EXPECTED_BMPS - WIFI_GLOBAL_BMPS - WIFI_DRIFT_BMPS:
             with self.subTest(name=name):
                 self.assertIn(name, self.script)
         self.assertIn("wifi_global_surfaces", self.script)
@@ -220,6 +225,7 @@ class PreviewWiringTests(unittest.TestCase):
         self.assertIn('"needs-you"', self.script)
         self.assertIn('"companion"', self.script)
         self.assertIn('f"torget-wifi-global-{surface}-{bars}.bmp"', self.script)
+        self.assertIn('f"torget-wifi-drift-{tag}.bmp"', self.script)
 
     def test_simulator_uses_private_dir_nofollow_and_propagates_failures(self):
         self.assertIn('getenv("TORGET_CAPTURE_DIR")', self.sim)

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -149,7 +149,7 @@ assert "default n" in status_option.split("endmenu", 1)[0]
 # do not belong in a visible, stale process command line.
 plist = plistlib.loads(mac_service.encode("utf-8"))
 assert plist["ProgramArguments"] == [
-    "/usr/bin/python3", "-u", "tokenserver.py"
+    "/Users/niclasvestlund/Torget/.venv/bin/python", "-u", "tokenserver.py"
 ]
 for source, name in ((mac_service, "macOS launchd template"),
                      (windows_service, "Windows Task Scheduler installer")):

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -744,6 +744,7 @@ class McpServerTests(unittest.TestCase):
         initialized = responses[0]["result"]
         self.assertEqual(initialized["protocolVersion"], "2025-06-18")
         self.assertEqual(initialized["serverInfo"]["name"], "vibepulse")
+        self.assertEqual(initialized["serverInfo"]["version"], "0.1.1")
         self.assertEqual(initialized["capabilities"], {"tools": {"listChanged": False}})
         self.assertEqual(responses[1]["result"], {})
         tools = responses[2]["result"]["tools"]
@@ -1198,7 +1199,7 @@ class PluginPackageTests(unittest.TestCase):
         self.assertRegex(
             manifest["version"], r"^(0|[1-9][0-9]*)\."
             r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
-        self.assertEqual(manifest["version"], "0.1.0")
+        self.assertEqual(manifest["version"], "0.1.1")
         self.assertEqual(manifest["author"]["name"], "Niclas Vestlund")
         self.assertNotIn("email", manifest["author"])
         self.assertEqual(manifest["license"], "MIT")
@@ -1268,6 +1269,45 @@ class PluginPackageTests(unittest.TestCase):
         self.assertIn("python3 tools/vibepulse_setup.py status", body)
         self.assertIn("python3 tools/vibepulse_setup.py doctor", body)
         self.assertRegex(body.lower(), r"relay (?:is|remains) not enabled")
+        for physical_guard in (
+                "Ser du APPROVE?", "SOMETHING IS WAITING",
+                "status: answered", "option_index: 0",
+                "git describe --tags --always --dirty", "otaAvailableVersion"):
+            self.assertIn(physical_guard, body)
+
+    def test_physical_smoke_contract_and_failure_record_are_documented(self):
+        setup = (ROOT / "docs/agent-setup.md").read_text(encoding="utf-8")
+        review = (ROOT / "docs/superpowers/reviews/"
+                  "2026-08-27-vibepulse-codex-physical-end-to-end.md").read_text(
+                      encoding="utf-8")
+        lessons = (ROOT / "docs/lessons.md").read_text(encoding="utf-8")
+
+        for text in (setup, review):
+            for contract in (
+                    "Ser du APPROVE?", "APPROVE syns", "APPROVE saknas",
+                    "status: answered", "option_index: 0", "answer: Ja",
+                    "SOMETHING IS WAITING", "computer fallback",
+                    "git describe --tags --always --dirty", "otaAvailableVersion"):
+                self.assertIn(contract, text)
+        self.assertIn("v0.7.0-5-ge6feb29-dirty", review)
+        self.assertIn("A green build from an old tree hid the panel test",
+                      lessons)
+
+    def test_v071_release_candidate_is_upgradeable_safe_and_evidence_backed(self):
+        release = (ROOT / "docs/releases/"
+                   "2026-08-27-health-and-panel-reliability.md").read_text(
+                       encoding="utf-8")
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        for required in (
+                "VibePulse v0.7.1", "30 minutes", "every 15 seconds",
+                "Ser du APPROVE?", "status: answered", "option_index: 0",
+                "restart the tokenserver", "vibepulse@torget",
+                "python3 tools/vibepulse_setup.py install",
+                "green CI", "source-only", "Do not attach `torget.bin`"):
+            self.assertIn(required, release)
+        self.assertIn("v0.7.1 — health and panel reliability", changelog)
+        self.assertIn("plugin is `0.1.1`", changelog)
+        self.assertNotIn("## v0.7.1 —", changelog)
 
     def test_default_runner_invokes_plugin_suite_once(self):
         runner = (ROOT / "test/run.sh").read_text(encoding="utf-8")

--- a/test/test_vibepulse_layout_wiring.py
+++ b/test/test_vibepulse_layout_wiring.py
@@ -272,6 +272,15 @@ for path, symbol in attention_fonts:
 project_font_source = attention_fonts[1][0].read_text()
 assert "--range 0x20,0x2D,0x2E,0x30-0x39,0x3F,0x41-0x5A,0x5F,0xC4,0xC5,0xD6" in project_font_source
 
+# The Needs You attract label receives the same normalized project alphabet as
+# the completion overlay (digits plus .-_ and replacement ?).  Pin it to the
+# existing native 21 px full-ASCII raster so those bytes can never become LVGL
+# missing-glyph boxes on the physical display.
+ui_21_source = (root / "platform/fonts/plex_ui_21.c").read_text()
+assert "--range 0x20-0x7E" in ui_21_source
+assert "v->a_project = ny_text(v->a_group, &plex_ui_21" in monitor
+assert "v->a_project = ny_text(v->a_group, &plex_text_21" not in monitor
+
 assert "provider_lane" not in monitor
 assert "render_rail" not in monitor
 assert "mon.rail" not in monitor

--- a/tools/preview-ui.sh
+++ b/tools/preview-ui.sh
@@ -204,6 +204,10 @@ expected_names.update(
     for surface in wifi_global_surfaces
     for bars in range(4)
 )
+expected_names.update(
+    f"torget-wifi-drift-{tag}.bmp"
+    for tag in ("0", "1", "2", "3", "return")
+)
 actual_names = {path.name for path in capture_dir.iterdir()}
 missing = sorted(expected_names - actual_names)
 unexpected = sorted(actual_names - expected_names)

--- a/tools/test_hardware_registry.py
+++ b/tools/test_hardware_registry.py
@@ -888,7 +888,7 @@ class RepositoryRegistryTests(unittest.TestCase):
         }
         self.assertEqual(
             verified_ids,
-            {"display.amoled", "radio.wifi-24"},
+            {"display.amoled", "touch.controller", "radio.wifi-24"},
         )
         for capability_id in verified_ids:
             with self.subTest(capability=capability_id):
@@ -902,7 +902,12 @@ class RepositoryRegistryTests(unittest.TestCase):
                     finding["source"] for finding in capability["evidence"]
                     if finding["field"] == "unit_verified"
                 }
-                self.assertEqual(sources, {"torget-physical-2026-08-06"})
+                expected_source = (
+                    "torget-physical-2026-08-27-vibepulse"
+                    if capability_id == "touch.controller"
+                    else "torget-physical-2026-08-06"
+                )
+                self.assertEqual(sources, {expected_source})
 
     def test_repository_required_truth_distinctions(self):
         registry = self.load_repository_registry()
@@ -984,6 +989,15 @@ class RepositoryRegistryTests(unittest.TestCase):
             "wifi-channel-13-scan-and-connect-2026-08-06",
         ])
 
+        vibepulse = registry.sources[
+            "torget-physical-2026-08-27-vibepulse"
+        ]
+        self.assertEqual(vibepulse.get("unit"), "torget-home-01")
+        self.assertEqual(vibepulse.get("tests"), [
+            "vibepulse-codex-approve-roundtrip-2026-08-27",
+            "localized-project-font-physical-render-2026-08-27",
+        ])
+
     def test_repository_firmware_source_records_buddy_companion(self):
         registry = self.load_repository_registry()
         source = registry.sources["torget-main-1fad449"]
@@ -1014,7 +1028,7 @@ class RepositoryRegistryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
             result.stdout,
-            "OK: 30 capabilities, 9 sources, 1 units\n",
+            "OK: 30 capabilities, 10 sources, 1 units\n",
         )
 
     def test_repository_registry_loads(self):
@@ -1082,6 +1096,11 @@ class RepositoryRegistryTests(unittest.TestCase):
                 self.assertTrue(expected_fields.issubset(evidenced_fields))
 
         expected_sources = {
+            "torget-physical-2026-08-27-vibepulse": (
+                "physical-test", 1,
+                "findings-2026-08-27; unit=torget-home-01; "
+                "firmware=v0.7.0-5-ge6feb29-dirty",
+            ),
             "torget-physical-2026-08-06": (
                 "physical-test", 1,
                 "findings-2026-08-06; unit=torget-home-01",
@@ -1134,7 +1153,7 @@ class RepositoryRegistryTests(unittest.TestCase):
             registry.capabilities["touch.controller"]["states"][
                 "unit_verified"
             ],
-            "unknown",
+            "yes",
         )
         self.assertEqual(
             registry.capabilities["audio.speaker-output"]["states"][
@@ -1172,7 +1191,7 @@ class RepositoryRegistryTests(unittest.TestCase):
             "battery": "not_fitted",
             "microsd": "unknown",
             "antenna": "onboard",
-            "installed_firmware": "unknown-after-next-flash",
-            "last_physical_verification": "2026-08-06",
+            "installed_firmware": "v0.7.0-5-ge6feb29-dirty",
+            "last_physical_verification": "2026-08-27",
             "secrets": False,
         })

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -43,6 +43,14 @@ After installation, open Codex, run `/hooks`, review the VibePulse
 **Start a new Codex task** so the hooks and MCP tool are freshly loaded. Doctor
 reports trust/setup problems but does not bypass review.
 
+The same doctor path reads a content-free Claude credential guard from
+`GET /`: `ready`, `expiring`, `expired`, `unavailable`, or `unknown`, plus
+whole minutes remaining when known. It warns 30 minutes before expiry and
+never returns or logs an access token, refresh token, account id, or Keychain
+body. A new Claude Code CLI turn is the supported refresh path; the service
+then detects the new local credential within 15 seconds without retrying a
+dead token upstream.
+
 The Codex safe-command tier only offers **ALLOW ONCE** for recognized
 read-only, test, and build commands. Unknown, mutating, secret-bearing, or
 truncated commands use the computer fallback. Questions do too unless Codex

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -1,6 +1,7 @@
 # tokenserver — VibePulse computer service
 
-> **English quickstart:** `python3 tokenserver.py`. Pure Python 3 stdlib,
+> **English quickstart:** `python3 tokenserver.py`. Python 3.11+ is required;
+> the core service uses only the standard library,
 > nothing to install. It reads your local Claude Code/Codex logs and serves
 > `/api/tokens` + `/api/agent-status` + `/api/max-tracker` on port 8737 for
 > the screen. Add `--github-repo owner/repository` for the optional public
@@ -100,7 +101,13 @@ sekund. Ren Python 3-stdlib — inget att installera. Tre källor:
    (`max_tokens: 0` — prefill utan output, i praktiken gratis) var 240:e
    sekund; rate-limit-headrarna i svaret bär usage-panelens tre fönster:
    5-timmars, veckan och veckan för tyngsta modellen (Fable/Opus).
-   Tokenen lämnar aldrig datorn — skärmen får bara procenttal.
+   Tokenen lämnar aldrig datorn — skärmen får bara procenttal. Om de
+   tokenkopior tokenservern kan läsa har gått ut men den officiella Claude
+   Desktop-klienten fortfarande arbetar, används dess innehållsfria
+   `plan-usage-history.json` passivt för den generella veckan. Filen måste
+   vara högst 20 minuter gammal och en tidigare autentiserad cachepost måste
+   fortfarande bära poolens giltiga reset. Modellveckan gissas aldrig och
+   förblir därför stale tills OAuth-proben återhämtar sig.
 3. **Codex tak** — tjänsten frågar Codex lokala, skrivskyddade app-server via
    `account/rateLimits/read`, alltså samma aktuella snapshot som Codex-panelen
    visar. Om app-servern saknas används en passiv fallback: begränsad läsning
@@ -439,8 +446,10 @@ cp se.torget.tokenserver.plist ~/Library/LaunchAgents/
 launchctl load ~/Library/LaunchAgents/se.torget.tokenserver.plist
 ```
 
-Plisten antar att repot bor i `~/Torget` och användaren `niclasvestlund` —
-redigera sökvägarna annars. Loggen hamnar i
+Plisten antar att repot bor i `~/Torget`, att repots Python 3.11+-miljö finns
+i `.venv` och att användaren är `niclasvestlund` — redigera sökvägarna
+annars. Med krypterat interaktionsrelä aktiverat ska den miljön även ha
+`requirements-interaction-relay.txt` installerad. Loggen hamnar i
 `~/Library/Logs/torget-tokenserver.log` (syns i Konsol-appen, överlever
 omstart; servern roterar den själv vid start om den vuxit förbi ~5 MB, med
 svansen bevarad i `.old`). Raderna har tidsstämplar och loggar övergångar,

--- a/tools/tokenserver/publisher.py
+++ b/tools/tokenserver/publisher.py
@@ -182,11 +182,14 @@ class Publisher:
 
     def start(self):
         def run():
+            # The first producer pass can scan large local histories.  Keep
+            # it off the startup thread so the LAN server can bind at once.
+            self.publish_once()
             while not self._stop.wait(CHECK_EVERY_S):
                 self.publish_once()
-        # First pass immediately: the mailbox should be warm within one
-        # cadence of service start, not one heartbeat.
-        self.publish_once()
+        # Start the first pass immediately, but asynchronously: the mailbox
+        # still warms without waiting one cadence and local startup stays
+        # independent of producer cost or relay latency.
         self._thread = threading.Thread(target=run, name="relay-publisher",
                                         daemon=True)
         self._thread.start()

--- a/tools/tokenserver/se.torget.tokenserver.plist
+++ b/tools/tokenserver/se.torget.tokenserver.plist
@@ -17,7 +17,7 @@
   <string>se.torget.tokenserver</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/usr/bin/python3</string>
+    <string>/Users/niclasvestlund/Torget/.venv/bin/python</string>
     <string>-u</string>
     <string>tokenserver.py</string>
   </array>

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -204,6 +204,25 @@ def check_server(base_url, checkout_rev=None, checkout_src=None):
     else:
         results.append((VARN, f"claude-proben: {probe} — se tabellen i "
                               f"docs/agent-setup.md"))
+    credential = root.get("claudeCredential")
+    if isinstance(credential, dict):
+        credential_status = credential.get("status")
+        remaining = credential.get("expiresInMin")
+        if credential_status == "ready" and isinstance(remaining, int):
+            results.append((OK, f"claude-credential: {remaining} min kvar"))
+        elif credential_status == "expiring" and isinstance(remaining, int):
+            results.append((VARN, f"claude-credential går ut om {remaining} "
+                                  "min — starta en ny Claude Code CLI-turn "
+                                  "innan dess"))
+        elif credential_status == "expired":
+            results.append((VARN, "claude-credential har gått ut — en ny "
+                                  "Claude Code CLI-turn måste förnya den"))
+        else:
+            results.append((VARN, "claude-credential kan inte "
+                                  "utgångsbevakas — kör setup doctor"))
+    else:
+        results.append((VARN, "claude-credential saknas i diagnostiken — "
+                              "starta om tokenservern med aktuell kod"))
     unknown = root.get("unknownRateLimitBuckets") or []
     if unknown:
         results.append((VARN, f"okända rate-limit-buckets: {unknown} — "

--- a/tools/tokenserver/test_publisher.py
+++ b/tools/tokenserver/test_publisher.py
@@ -6,6 +6,8 @@ must name its publisher (the mailbox merges freshest-per-source) and wear
 the project's own User-Agent, not somebody else's.
 """
 
+import threading
+import time
 import unittest
 
 try:
@@ -163,6 +165,27 @@ class PublisherTests(unittest.TestCase):
                                       "/api/github": lambda: {"ok": 1}})
         self.assertEqual(p.publish_once(), 1)
         self.assertEqual(len(sent), 1)
+
+    def test_start_never_blocks_the_server_on_first_producer_pass(self):
+        entered = threading.Event()
+        release = threading.Event()
+
+        def slow_first_payload():
+            entered.set()
+            release.wait(timeout=2)
+            return {"ok": 1}
+
+        publisher, _sent, _clock = self._publisher({
+            "/api/tokens": slow_first_payload,
+        })
+        try:
+            started = time.monotonic()
+            publisher.start()
+            self.assertLess(time.monotonic() - started, 0.2)
+            self.assertTrue(entered.wait(timeout=1))
+        finally:
+            release.set()
+            publisher.stop()
 
     def test_the_user_agent_is_our_own(self):
         # The Anthropic probe imitating claude-cli is a separate, deliberate

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -25,6 +25,7 @@ HEALTHY_ROOT = {
     "rev": "abc1234",
     "startedAt": "2026-08-13T20:00:00+02:00",
     "claudeProbe": "usage_http_200 + ok",
+    "claudeCredential": {"status": "ready", "expiresInMin": 480},
     "ratelimitHeaders": [],
     "unknownRateLimitBuckets": [],
     "usageComputeOk": True,
@@ -77,7 +78,7 @@ class ServerCheckTests(unittest.TestCase):
     def test_healthy_server_with_matching_rev_is_all_ok(self):
         with canned_server({"/": HEALTHY_ROOT}) as base:
             results = smoke.check_server(base, checkout_rev="abc1234")
-        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK, smoke.OK])
 
     def test_unreachable_server_is_fail(self):
         results = smoke.check_server("http://127.0.0.1:9")  # discard-porten
@@ -97,6 +98,16 @@ class ServerCheckTests(unittest.TestCase):
         self.assertEqual(len(warn), 1)
         self.assertIn("usage_http_401", warn[0])
         self.assertIn("agent-setup", warn[0])
+
+    def test_expiring_credential_warns_before_probe_fails(self):
+        root = dict(HEALTHY_ROOT, claudeCredential={
+            "status": "expiring", "expiresInMin": 19})
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        warnings = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("19 min", warnings[0])
+        self.assertIn("ny Claude Code CLI-turn", warnings[0])
 
     def test_unknown_buckets_warn(self):
         root = dict(HEALTHY_ROOT, unknownRateLimitBuckets=["7d_haiku"])
@@ -134,13 +145,13 @@ class ServerCheckTests(unittest.TestCase):
         with canned_server({"/": root}) as base:
             results = smoke.check_server(base, checkout_rev="abc1234",
                                          checkout_src="aaaa11112222")
-        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK, smoke.OK])
 
     def test_missing_fingerprint_on_older_server_is_not_judged(self):
         with canned_server({"/": HEALTHY_ROOT}) as base:
             results = smoke.check_server(base, checkout_rev="abc1234",
                                          checkout_src="bbbb33334444")
-        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK, smoke.OK])
 
     def test_frozen_usage_compute_is_fail(self):
         # OBS-08: siffror som fryst men ser färska ut är värsta sortens fel
@@ -159,7 +170,7 @@ class ServerCheckTests(unittest.TestCase):
                 if not k.startswith("usageCompute")}
         with canned_server({"/": root}) as base:
             results = smoke.check_server(base, checkout_rev="abc1234")
-        self.assertEqual(levels(results), [smoke.OK, smoke.OK])
+        self.assertEqual(levels(results), [smoke.OK, smoke.OK, smoke.OK])
 
 
 class EndpointCheckTests(unittest.TestCase):

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -71,6 +71,108 @@ class _FakeUsageResponse:
         return json.dumps(self._payload).encode()
 
 
+class ClaudePlanUsageFallbackTests(unittest.TestCase):
+    NOW = 1_800_000_000
+
+    def _write(self, root, *, timestamp_ms=None, fh=7, sd=14,
+               version=2):
+        path = Path(root) / "plan-usage-history.json"
+        path.write_text(json.dumps({
+            "version": version,
+            "samples": [{
+                "t": (int(self.NOW * 1000) if timestamp_ms is None
+                      else timestamp_ms),
+                "org": "bounded-local-org-id",
+                "u": {"fh": fh, "sd": sd},
+            }],
+        }), encoding="utf-8")
+        return path
+
+    def test_reads_fresh_bounded_percentages_without_exposing_org(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            parsed = tokenserver._read_claude_plan_usage(
+                self._write(temp_dir), now_ts=self.NOW)
+
+        self.assertEqual(parsed, {
+            "session_pct": 7.0,
+            "week_pct": 14.0,
+            "observed_at": self.NOW,
+        })
+        self.assertNotIn("org", parsed)
+
+    def test_rejects_stale_future_malformed_and_out_of_range_samples(self):
+        cases = (
+            ("stale", {"timestamp_ms": int(
+                (self.NOW - tokenserver.CLAUDE_PLAN_USAGE_FRESH_S - 1)
+                * 1000)}),
+            ("future", {"timestamp_ms": int((self.NOW + 61) * 1000)}),
+            ("bad-version", {"version": 3}),
+            ("bad-five-hour", {"fh": -1}),
+            ("bad-week", {"sd": 101}),
+        )
+        for name, kwargs in cases:
+            with self.subTest(name=name), \
+                    tempfile.TemporaryDirectory() as temp_dir:
+                parsed = tokenserver._read_claude_plan_usage(
+                    self._write(temp_dir, **kwargs), now_ts=self.NOW)
+                self.assertIsNone(parsed)
+
+    def test_windows_path_uses_roaming_application_data(self):
+        with mock.patch.object(tokenserver, "_IS_WINDOWS", True), \
+                mock.patch.dict(os.environ, {"APPDATA": r"C:\Users\n\AppData\Roaming"}):
+            path = tokenserver._claude_plan_usage_path()
+
+        self.assertEqual(
+            path,
+            Path(r"C:\Users\n\AppData\Roaming") / "Claude" /
+            "plan-usage-history.json")
+
+    def test_fresh_local_week_reuses_authenticated_reset_and_becomes_live(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache = QuotaCache(Path(temp_dir) / "quota.json",
+                               now=lambda: self.NOW)
+            cache.put(CachedQuota(
+                provider="claude", scope="general_weekly",
+                identity="opaque-cache-identity", pct=13,
+                reset_at=self.NOW + 3600, observed_at=self.NOW - 300))
+            merged = tokenserver._merge_claude_plan_usage(
+                {}, cache, self.NOW, path=self._write(temp_dir))
+
+        self.assertEqual(merged["weekPct"], 14.0)
+        self.assertEqual(merged["weekResetAt"], self.NOW + 3600)
+        self.assertEqual(merged["weekObservedAt"], self.NOW)
+        self.assertEqual(merged["weekIdentity"], "opaque-cache-identity")
+        self.assertNotIn("modelPct", merged)
+        self.assertEqual(tokenserver._claude_plan_usage_status,
+                         "fresh_applied")
+
+    def test_newer_oauth_observation_wins_over_local_file(self):
+        oauth = {
+            "weekPct": 15.0,
+            "weekObservedAt": self.NOW + 1,
+            "modelPct": 10.0,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            merged = tokenserver._merge_claude_plan_usage(
+                oauth, mock.Mock(), self.NOW,
+                path=self._write(temp_dir))
+
+        self.assertIs(merged, oauth)
+        self.assertEqual(tokenserver._claude_plan_usage_status,
+                         "oauth_newer")
+
+    def test_fresh_file_without_authenticated_reset_does_not_invent_one(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache = QuotaCache(Path(temp_dir) / "quota.json",
+                               now=lambda: self.NOW)
+            merged = tokenserver._merge_claude_plan_usage(
+                {}, cache, self.NOW, path=self._write(temp_dir))
+
+        self.assertEqual(merged, {})
+        self.assertEqual(tokenserver._claude_plan_usage_status,
+                         "fresh_without_reset")
+
+
 class ClaudeLimitHeaderTests(unittest.TestCase):
     def setUp(self):
         # Probelåset och straffrutefilen pekas om till en tempkatalog så
@@ -1617,6 +1719,34 @@ class UsageSnapshotTests(unittest.TestCase):
         self.assertEqual(snapshot["claudeModelWeekObservedAt"], now_ts - 2)
         self.assertEqual(snapshot["codexWeekObservedAt"], now_ts - 1)
 
+    def test_snapshot_uses_fresh_local_claude_week_when_oauth_is_stale(self):
+        now_ts = 1_800_000_000
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache = QuotaCache(Path(temp_dir) / "quota.json",
+                               now=lambda: now_ts)
+            cache.put(CachedQuota(
+                provider="claude", scope="general_weekly",
+                identity="opaque-cache-identity", pct=13,
+                reset_at=now_ts + 300 * 60, observed_at=now_ts - 300))
+            cache.put(CachedQuota(
+                provider="claude", scope="model_weekly",
+                identity="opaque-model-identity", pct=10,
+                reset_at=now_ts + 300 * 60, observed_at=now_ts - 300,
+                label="FABLE · WEEK"))
+            with mock.patch.object(
+                    tokenserver, "_read_claude_plan_usage",
+                    return_value={"session_pct": 7.0, "week_pct": 14.0,
+                                  "observed_at": now_ts - 1}), \
+                    mock.patch.object(
+                        tokenserver, "_persist_quota_records_async"):
+                snapshot = self._snapshot(
+                    StubHistory(), now_ts, claude={}, quota_cache=cache)
+
+        self.assertEqual(snapshot["claudeWeekPct"], 14.0)
+        self.assertFalse(snapshot["claudeWeekStale"])
+        self.assertEqual(snapshot["claudeWeekObservedAt"], now_ts - 1)
+        self.assertTrue(snapshot["claudeModelWeekStale"])
+
     def test_snapshot_flattens_collecting_and_exhaustion_states(self):
         now_ts = 1_800_000_000
         history = StubHistory({
@@ -2339,6 +2469,8 @@ class HandlerPrivacyTests(unittest.TestCase):
     def test_root_diagnostics_contain_names_but_no_header_values_or_body(self):
         handler = self._handler("/")
         with mock.patch.object(tokenserver, "_probe_status", "http_401"), \
+                mock.patch.object(tokenserver, "_claude_plan_usage_status",
+                                  "fresh_applied"), \
                 mock.patch.object(tokenserver, "_probe_headers", [
                     "anthropic-ratelimit-unified-7d-utilization"]), \
                 mock.patch.object(tokenserver, "_probe_unknown_buckets", [
@@ -2351,6 +2483,7 @@ class HandlerPrivacyTests(unittest.TestCase):
         self.assertEqual(payload["ratelimitHeaders"], [
             "anthropic-ratelimit-unified-7d-utilization"])
         self.assertEqual(payload["unknownRateLimitBuckets"], ["7d_haiku"])
+        self.assertEqual(payload["claudeLocalUsage"], "fresh_applied")
 
     def test_root_diagnostics_report_only_safe_interaction_switches(self):
         handler = self._handler("/")

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -371,6 +371,27 @@ class ClaudeLimitHeaderTests(unittest.TestCase):
         self.assertEqual(
             candidates, [("standalone-token", 1_900_000_000_000)])
 
+    def test_credential_snapshot_warns_before_expiry_without_exposing_token(self):
+        now = 1_800_000_000
+        cases = (
+            ([], {"status": "unavailable"}),
+            ([("process-secret", None)], {"status": "unknown"}),
+            ([("ready-secret", (now + 31 * 60) * 1000)],
+             {"status": "ready", "expiresInMin": 31}),
+            ([("expiring-secret", (now + 20 * 60) * 1000)],
+             {"status": "expiring", "expiresInMin": 20}),
+            ([("expired-secret", (now - 60) * 1000)],
+             {"status": "expired", "expiresInMin": 0}),
+        )
+        for candidates, expected in cases:
+            with self.subTest(expected=expected):
+                snapshot = tokenserver._oauth_credential_snapshot(
+                    candidates, now_s=now)
+                self.assertEqual(snapshot, expected)
+                serialized = json.dumps(snapshot)
+                for token, _expiry in candidates:
+                    self.assertNotIn(token, serialized)
+
     def test_windows_reads_the_credentials_file_claude_login_writes(self):
         """Windows har ingen nyckelring — `claude login` skriver samma
         claudeAiOauth-post till %USERPROFILE%\\.claude\\.credentials.json."""
@@ -2471,6 +2492,8 @@ class HandlerPrivacyTests(unittest.TestCase):
         with mock.patch.object(tokenserver, "_probe_status", "http_401"), \
                 mock.patch.object(tokenserver, "_claude_plan_usage_status",
                                   "fresh_applied"), \
+                mock.patch.object(tokenserver, "_claude_credential", {
+                    "status": "expiring", "expiresInMin": 17}), \
                 mock.patch.object(tokenserver, "_probe_headers", [
                     "anthropic-ratelimit-unified-7d-utilization"]), \
                 mock.patch.object(tokenserver, "_probe_unknown_buckets", [
@@ -2484,6 +2507,8 @@ class HandlerPrivacyTests(unittest.TestCase):
             "anthropic-ratelimit-unified-7d-utilization"])
         self.assertEqual(payload["unknownRateLimitBuckets"], ["7d_haiku"])
         self.assertEqual(payload["claudeLocalUsage"], "fresh_applied")
+        self.assertEqual(payload["claudeCredential"], {
+            "status": "expiring", "expiresInMin": 17})
 
     def test_root_diagnostics_report_only_safe_interaction_switches(self):
         handler = self._handler("/")
@@ -2496,6 +2521,11 @@ class HandlerPrivacyTests(unittest.TestCase):
             getattr(tokenserver.Handler, "interaction_relay_reason", None),
             getattr(tokenserver.Handler, "agent_status_relay_status", "off"),
             getattr(tokenserver.Handler, "agent_status_relay_reason", None),
+            tokenserver.Handler.panel_poll_candidate_host,
+            tokenserver.Handler.panel_poll_candidate_at,
+            tokenserver.Handler.panel_poll_candidate_count,
+            tokenserver.Handler.panel_last_seen_at,
+            tokenserver.Handler.panel_last_seen_route,
         )
         self.addCleanup(setattr, tokenserver.Handler,
                         "claude_interactions", saved[0])
@@ -2513,6 +2543,16 @@ class HandlerPrivacyTests(unittest.TestCase):
                         "agent_status_relay_status", saved[6])
         self.addCleanup(setattr, tokenserver.Handler,
                         "agent_status_relay_reason", saved[7])
+        self.addCleanup(setattr, tokenserver.Handler,
+                        "panel_poll_candidate_host", saved[8])
+        self.addCleanup(setattr, tokenserver.Handler,
+                        "panel_poll_candidate_at", saved[9])
+        self.addCleanup(setattr, tokenserver.Handler,
+                        "panel_poll_candidate_count", saved[10])
+        self.addCleanup(setattr, tokenserver.Handler,
+                        "panel_last_seen_at", saved[11])
+        self.addCleanup(setattr, tokenserver.Handler,
+                        "panel_last_seen_route", saved[12])
         tokenserver.Handler.claude_interactions = False
         tokenserver.Handler.codex_interactions = True
         tokenserver.Handler.interaction_detail = True
@@ -2521,6 +2561,11 @@ class HandlerPrivacyTests(unittest.TestCase):
         tokenserver.Handler.interaction_relay_reason = None
         tokenserver.Handler.agent_status_relay_status = "off"
         tokenserver.Handler.agent_status_relay_reason = None
+        tokenserver.Handler.panel_poll_candidate_host = None
+        tokenserver.Handler.panel_poll_candidate_at = None
+        tokenserver.Handler.panel_poll_candidate_count = 0
+        tokenserver.Handler.panel_last_seen_at = None
+        tokenserver.Handler.panel_last_seen_route = None
 
         handler.do_GET()
 
@@ -2532,6 +2577,7 @@ class HandlerPrivacyTests(unittest.TestCase):
             "legacyClaudePanelV1": True,
             "relay": {"status": "off"},
             "agentStatusRelay": {"status": "off"},
+            "panel": {"status": "waiting"},
             "transport": "lan",
         })
         serialized = json.dumps(payload["interactions"])
@@ -2563,6 +2609,71 @@ class HandlerPrivacyTests(unittest.TestCase):
         self.assertEqual(disabled["transport"], "lan")
 
 
+class PanelStartupHealthTests(unittest.TestCase):
+    def setUp(self):
+        self.cls = tokenserver.Handler
+        self.saved = (
+            self.cls.panel_poll_candidate_host,
+            self.cls.panel_poll_candidate_at,
+            self.cls.panel_poll_candidate_count,
+            self.cls.panel_last_seen_at,
+            self.cls.panel_last_seen_route,
+        )
+        self.cls.panel_poll_candidate_host = None
+        self.cls.panel_poll_candidate_at = None
+        self.cls.panel_poll_candidate_count = 0
+        self.cls.panel_last_seen_at = None
+        self.cls.panel_last_seen_route = None
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        (self.cls.panel_poll_candidate_host,
+         self.cls.panel_poll_candidate_at,
+         self.cls.panel_poll_candidate_count,
+         self.cls.panel_last_seen_at,
+         self.cls.panel_last_seen_route) = self.saved
+
+    @staticmethod
+    def _handler(host):
+        handler = tokenserver.Handler.__new__(tokenserver.Handler)
+        handler.client_address = (host, 12345)
+        handler.path = "/api/agent-status"
+        return handler
+
+    def test_two_close_panel_polls_turn_health_ready_without_exposing_ip(self):
+        handler = self._handler("192.0.2.40")
+        with mock.patch.object(tokenserver.time, "monotonic",
+                               side_effect=(100.0, 101.0, 102.0, 103.0)):
+            handler._record_panel_poll()
+            self.assertEqual(handler._panel_health_snapshot(), {
+                "status": "waiting"})
+            with self.assertLogs("tokenserver", level="INFO") as captured:
+                handler._record_panel_poll()
+            snapshot = handler._panel_health_snapshot()
+        self.assertEqual(snapshot, {
+            "status": "ready", "ageS": 1,
+            "route": "/api/agent-status"})
+        self.assertIn("panelkontakt READY", "\n".join(captured.output))
+        self.assertNotIn("192.0.2.40", json.dumps(snapshot))
+
+    def test_loopback_or_one_lan_request_cannot_claim_panel_ready(self):
+        loopback = self._handler("127.0.0.1")
+        lan = self._handler("192.0.2.41")
+        with mock.patch.object(tokenserver.time, "monotonic",
+                               side_effect=(100.0, 101.0, 102.0)):
+            loopback._record_panel_poll()
+            lan._record_panel_poll()
+            snapshot = lan._panel_health_snapshot()
+        self.assertEqual(snapshot, {"status": "waiting"})
+
+    def test_recent_proof_expires_instead_of_staying_green(self):
+        self.cls.panel_last_seen_at = 100.0
+        self.cls.panel_last_seen_route = "/api/tokens"
+        with mock.patch.object(tokenserver.time, "monotonic", return_value=116.0):
+            self.assertEqual(self.cls._panel_health_snapshot(), {
+                "status": "stale", "ageS": 16, "route": "/api/tokens"})
+
+
 class HandlerErrorLoggingTests(unittest.TestCase):
     """500-kontraktet plus loggning: felen ska synas lokalt, aldrig på LAN:et,
     och en försvunnen klient är inte ett serverfel."""
@@ -2572,7 +2683,7 @@ class HandlerErrorLoggingTests(unittest.TestCase):
         handler.path = path
         handler.projects_dir = Path("/private/source/path")
         handler.agent_status = mock.Mock()
-        handler.client_address = ("192.0.2.10", 4711)
+        handler.client_address = ("127.0.0.1", 4711)
         handler._send = mock.Mock()
         return handler
 

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -121,6 +121,8 @@ LIMITS_EVERY_S = 240  # rate-limit-proben: 15 anrop/h — kontots bucket delas
 AUTH_RECOVERY_EVERY_S = 15.0  # lokal tokenkontroll; ingen upstream vid väntan
                       # med Claude Code självt, och kvoten rör sig långsamt;
                       # panelens 30 s-pollar får ändå cachat svar direkt
+CLAUDE_PLAN_USAGE_FRESH_S = 20 * 60
+CLAUDE_PLAN_USAGE_MAX_BYTES = 2 * 1024 * 1024
 HTTP_MAX_WORKERS = 32
 JSON_BODY_TIMEOUT_S = 2.0
 
@@ -128,6 +130,7 @@ JSON_BODY_TIMEOUT_S = 2.0
 # konfiguration. Testerna patchar konstanten för att köra Windows-grenarna
 # på en Mac.
 _IS_WINDOWS = sys.platform == "win32"
+_claude_plan_usage_status = "not_checked"
 
 
 def _state_dir():
@@ -144,6 +147,90 @@ def _state_dir():
                 else Path.home() / "AppData" / "Local")
         return base / "VibePulse"
     return Path.home() / "Library" / "Application Support" / "VibePulse"
+
+
+def _claude_plan_usage_path():
+    """Claude Desktops lokala, innehållsfria planhistorik.
+
+    Filen ägs och uppdateras av den officiella klienten. Den innehåller bara
+    tid, organisation och procentsatser för femtimmars-/veckofönstret — inga
+    promptar, svar, kommandon eller OAuth-hemligheter.
+    """
+    if _IS_WINDOWS:
+        app_data = os.environ.get("APPDATA")
+        base = (Path(app_data) if app_data
+                else Path.home() / "AppData" / "Roaming")
+        return base / "Claude" / "plan-usage-history.json"
+    return (Path.home() / "Library" / "Application Support" / "Claude" /
+            "plan-usage-history.json")
+
+
+def _read_claude_plan_usage(path=None, now_ts=None):
+    """Returnera senaste strikta, färska lokala usageprovet eller ``None``.
+
+    Det här är en passiv reserv när åtkomsttokenen som tokenservern kan läsa
+    har gått ut men Claude Desktop fortfarande har en aktuell usagebild. Hela
+    filen är storleksbegränsad och den senaste posten valideras fail-closed;
+    rått organisations-id lämnar aldrig funktionen.
+    """
+    global _claude_plan_usage_status
+    usage_path = (_claude_plan_usage_path() if path is None else Path(path))
+    current_ts = time.time() if now_ts is None else now_ts
+    try:
+        size = usage_path.stat().st_size
+        if size <= 0 or size > CLAUDE_PLAN_USAGE_MAX_BYTES:
+            _claude_plan_usage_status = "invalid_size"
+            return None
+        payload = json.loads(usage_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        _claude_plan_usage_status = "missing"
+        return None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        _claude_plan_usage_status = "invalid"
+        return None
+
+    if (not isinstance(payload, dict) or payload.get("version") != 2 or
+            not isinstance(payload.get("samples"), list) or
+            not payload["samples"]):
+        _claude_plan_usage_status = "unsupported"
+        return None
+
+    samples = payload["samples"]
+    latest = samples[-1]
+    if not isinstance(latest, dict):
+        _claude_plan_usage_status = "invalid"
+        return None
+    timestamp_ms = latest.get("t")
+    org = latest.get("org")
+    usage = latest.get("u")
+    if (not isinstance(timestamp_ms, int) or isinstance(timestamp_ms, bool) or
+            timestamp_ms <= 0 or not isinstance(org, str) or
+            not 1 <= len(org.encode("utf-8")) <= 128 or
+            not isinstance(usage, dict)):
+        _claude_plan_usage_status = "invalid"
+        return None
+
+    values = []
+    for key in ("fh", "sd"):
+        value = usage.get(key)
+        if (not isinstance(value, (int, float)) or isinstance(value, bool) or
+                not math.isfinite(value) or not 0 <= value <= 100):
+            _claude_plan_usage_status = "invalid"
+            return None
+        values.append(round(float(value), 1))
+
+    observed_at = timestamp_ms / 1000
+    age_s = current_ts - observed_at
+    if age_s < -60 or age_s > CLAUDE_PLAN_USAGE_FRESH_S:
+        _claude_plan_usage_status = "stale"
+        return None
+
+    _claude_plan_usage_status = "fresh"
+    return {
+        "session_pct": values[0],
+        "week_pct": values[1],
+        "observed_at": int(observed_at),
+    }
 
 
 def _log_dir():
@@ -342,6 +429,44 @@ def _quota_identity(provider, scope, raw_identity=None):
     stable = "default-v1" if raw_identity is None else str(raw_identity)
     material = f"{provider}\0{scope}\0{stable}".encode("utf-8")
     return hashlib.sha256(material).hexdigest()
+
+
+def _merge_claude_plan_usage(claude, quota_cache, now_ts, path=None):
+    """Låt en färsk officiell lokal veckoprocent slå en äldre OAuthbild.
+
+    Den lokala filen saknar reset-tid och modellpool. Därför får den endast
+    komplettera den generella veckan när en fortfarande giltig, tidigare
+    autentiserad cachepost bär samma pools reset. Modellkvoten förblir ärligt
+    stale tills OAuth-proben återhämtar sig.
+    """
+    global _claude_plan_usage_status
+    local = _read_claude_plan_usage(path=path, now_ts=now_ts)
+    if local is None:
+        return claude
+
+    existing_at = claude.get("weekObservedAt")
+    if (isinstance(existing_at, (int, float)) and
+            not isinstance(existing_at, bool) and
+            math.isfinite(existing_at) and
+            existing_at >= local["observed_at"]):
+        _claude_plan_usage_status = "oauth_newer"
+        return claude
+
+    cached = quota_cache.latest("claude", "general_weekly", now=now_ts)
+    if cached is None or cached.reset_at <= now_ts:
+        _claude_plan_usage_status = "fresh_without_reset"
+        return claude
+
+    merged = dict(claude)
+    merged.update({
+        "weekPct": local["week_pct"],
+        "weekResetAt": cached.reset_at,
+        "weekResetMin": max(0, int(round((cached.reset_at - now_ts) / 60))),
+        "weekObservedAt": local["observed_at"],
+        "weekIdentity": cached.identity,
+    })
+    _claude_plan_usage_status = "fresh_applied"
+    return merged
 
 
 def _parse_file(path: Path, month_start: datetime, start_offset=0):
@@ -1883,11 +2008,12 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
 
     # null = ärlig frånvaro (nyckelring/probe/loggar otillgängliga) — skärmen
     # visar streck, aldrig hittade procent. Samma regel som sharePct.
-    claude = get_limits() or {}
-    codex = _read_codex_limits()
     current_ts = time.time() if now_ts is None else now_ts
     usage_history = _get_usage_history() if history is None else history
     cache = _get_quota_cache() if quota_cache is None else quota_cache
+    claude = _merge_claude_plan_usage(
+        get_limits() or {}, cache, current_ts)
+    codex = _read_codex_limits()
 
     session_pct = claude.get("sessionPct")
     session_reset_at = claude.get("sessionResetAt")
@@ -2571,6 +2697,7 @@ class Handler(BaseHTTPRequestHandler):
                            if self.github_monitor is not None
                            else disabled_snapshot()),
                 "claudeProbe": _probe_status,
+                "claudeLocalUsage": _claude_plan_usage_status,
                 "ratelimitHeaders": _probe_headers,
                 "unknownRateLimitBuckets": _probe_unknown_buckets,
                 # GET / parsas aldrig av skärmen — fält kan läggas till

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -121,6 +121,7 @@ LIMITS_EVERY_S = 240  # rate-limit-proben: 15 anrop/h — kontots bucket delas
 AUTH_RECOVERY_EVERY_S = 15.0  # lokal tokenkontroll; ingen upstream vid väntan
                       # med Claude Code självt, och kvoten rör sig långsamt;
                       # panelens 30 s-pollar får ändå cachat svar direkt
+CLAUDE_CREDENTIAL_WARNING_S = 30 * 60
 CLAUDE_PLAN_USAGE_FRESH_S = 20 * 60
 CLAUDE_PLAN_USAGE_MAX_BYTES = 2 * 1024 * 1024
 HTTP_MAX_WORKERS = 32
@@ -667,6 +668,9 @@ _probe_unknown_buckets = []
 _probe_cooldown_until = 0.0
 _probe_failure_streak = 0
 _probe_status_logged = None  # senast loggade status — övergångar loggas, tillstånd inte
+# Content-free credential readiness captured on the probe thread. GET / must
+# never reread Keychain synchronously: startup health has a sub-second budget.
+_claude_credential = {"status": "unknown"}
 # Döda tokens (värde → orsak): en kandidat som fått 401/403 skickas ALDRIG
 # igen. Det var mönstret bakom 429-straffrutan: nyckelringstokenen dog på
 # natten och Desktops frusna processtoken hamrade API:t varje probecykel i
@@ -795,6 +799,30 @@ def _read_oauth_candidates():
     if keychain_token and keychain_token != process_token:
         candidates.append((keychain_token, expires_at))
     return candidates
+
+
+def _oauth_credential_snapshot(candidates, now_s=None):
+    """Return saved-credential expiry readiness without exposing tokens."""
+    if not candidates:
+        return {"status": "unavailable"}
+    expiries = []
+    for _token, raw_expiry in candidates:
+        try:
+            expiry_s = float(raw_expiry) / 1000
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if math.isfinite(expiry_s) and expiry_s > 0:
+            expiries.append(expiry_s)
+    if not expiries:
+        return {"status": "unknown"}
+
+    remaining_s = max(expiries) - (time.time() if now_s is None else now_s)
+    if remaining_s <= 0:
+        return {"status": "expired", "expiresInMin": 0}
+    remaining_min = max(1, int(math.ceil(remaining_s / 60)))
+    status = ("expiring" if remaining_s <= CLAUDE_CREDENTIAL_WARNING_S
+              else "ready")
+    return {"status": status, "expiresInMin": remaining_min}
 
 
 def _parse_reset_minutes(value: str, now_ts: float):
@@ -1098,8 +1126,9 @@ def _probe_limits():
 
 def _probe_limits_locked():
     global _probe_status, _probe_headers, _probe_unknown_buckets, \
-        _probe_cooldown_until
+        _probe_cooldown_until, _claude_credential
     candidates = _read_oauth_candidates()
+    _claude_credential = _oauth_credential_snapshot(candidates)
     if not candidates:
         _probe_status = "no_claude_oauth_token"
         return None
@@ -2240,6 +2269,19 @@ class Handler(BaseHTTPRequestHandler):
     interaction_relay_reason = None
     agent_status_relay_status = "off"
     agent_status_relay_reason = None
+    # Innehållsfritt närvarobevis för startup-hälsan. Den befintliga panelen
+    # pollar /api/agent-status varje sekund. Två kända panel-GET från samma
+    # icke-loopback-klient inom ett kort fönster är starkare evidens än en
+    # ensam curl. Kandidatadressen hålls bara i processminnet och returneras
+    # eller loggas aldrig.
+    panel_poll_lock = threading.Lock()
+    panel_poll_candidate_host = None
+    panel_poll_candidate_at = None
+    panel_poll_candidate_count = 0
+    panel_last_seen_at = None
+    panel_last_seen_route = None
+    panel_confirm_window_s = 10.0
+    panel_fresh_s = 15.0
     json_body_timeout_s = JSON_BODY_TIMEOUT_S
 
     def _send(self, code, payload):
@@ -2277,6 +2319,52 @@ class Handler(BaseHTTPRequestHandler):
         mapped = getattr(address, "ipv4_mapped", None)
         return bool(mapped.is_loopback if mapped is not None
                     else address.is_loopback)
+
+    def _record_panel_poll(self):
+        """Confirm a live panel without trusting one anonymous LAN request."""
+        if not getattr(self, "client_address", None):
+            return
+        if self._is_loopback():
+            return
+        host = self.client_address[0] if self.client_address else None
+        if not isinstance(host, str) or not host:
+            return
+        now = time.monotonic()
+        cls = type(self)
+        became_ready = False
+        with cls.panel_poll_lock:
+            if (cls.panel_poll_candidate_host == host and
+                    cls.panel_poll_candidate_at is not None and
+                    now - cls.panel_poll_candidate_at <=
+                    cls.panel_confirm_window_s):
+                cls.panel_poll_candidate_count += 1
+            else:
+                cls.panel_poll_candidate_host = host
+                cls.panel_poll_candidate_count = 1
+            cls.panel_poll_candidate_at = now
+            if cls.panel_poll_candidate_count >= 2:
+                was_fresh = (cls.panel_last_seen_at is not None and
+                             now - cls.panel_last_seen_at <= cls.panel_fresh_s)
+                cls.panel_last_seen_at = now
+                cls.panel_last_seen_route = self.path
+                became_ready = not was_fresh
+        if became_ready:
+            log.info("startup-health: panelkontakt READY via %s", self.path)
+
+    @classmethod
+    def _panel_health_snapshot(cls):
+        now = time.monotonic()
+        with cls.panel_poll_lock:
+            seen = cls.panel_last_seen_at
+            route = cls.panel_last_seen_route
+        if seen is None:
+            return {"status": "waiting"}
+        age_s = max(0, int(now - seen))
+        return {
+            "status": "ready" if age_s <= cls.panel_fresh_s else "stale",
+            "ageS": age_s,
+            "route": route,
+        }
 
     def _header_values(self, name):
         get_all = getattr(self.headers, "get_all", None)
@@ -2662,6 +2750,9 @@ class Handler(BaseHTTPRequestHandler):
             self._send(404, {"error": "not found"})
 
     def do_GET(self):
+        if self.path in ("/api/tokens", "/api/agent-status",
+                         "/api/max-tracker", "/api/github"):
+            self._record_panel_poll()
         if self.path == "/api/tokens":
             self._reply(lambda: get_snapshot(
                 self.projects_dir,
@@ -2697,6 +2788,7 @@ class Handler(BaseHTTPRequestHandler):
                            if self.github_monitor is not None
                            else disabled_snapshot()),
                 "claudeProbe": _probe_status,
+                "claudeCredential": dict(_claude_credential),
                 "claudeLocalUsage": _claude_plan_usage_status,
                 "ratelimitHeaders": _probe_headers,
                 "unknownRateLimitBuckets": _probe_unknown_buckets,
@@ -2724,6 +2816,7 @@ class Handler(BaseHTTPRequestHandler):
                            if self.agent_status_relay_reason is not None
                            else {}),
                     }),
+                    "panel": self._panel_health_snapshot(),
                     "transport": (
                         "lan+encrypted-relay"
                         if (self.interaction_relay_status == "ready" or

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1507,7 +1507,58 @@ def _doctor(
             fixes = True
         else:
             print("PASS Tokenserver", file=stdout)
+            if config.claude_interactions and not _doctor_claude_quota(
+                    payload, stdout):
+                fixes = True
     return not fixes
+
+
+def _doctor_claude_quota(payload: dict, stdout) -> bool:
+    """Report the safe credential/probe guard published by tokenserver."""
+    credential = payload.get("claudeCredential")
+    probe = payload.get("claudeProbe")
+    if not isinstance(credential, dict):
+        print("FIX Claude quota credential: diagnostics are too old; "
+              "restart the VibePulse tokenserver", file=stdout)
+        return False
+
+    status = credential.get("status")
+    remaining = credential.get("expiresInMin")
+    if status == "ready" and isinstance(remaining, int) and remaining >= 0:
+        if probe == "usage_http_200 + ok":
+            print(f"PASS Claude quota credential: ready ({remaining} min "
+                  "remaining)", file=stdout)
+            return True
+        if probe == "not_run":
+            print("WAIT Claude quota probe: credential is ready but the "
+                  "first probe has not completed", file=stdout)
+            return False
+        print("FIX Claude quota probe: credential is ready but the usage "
+              "source is unavailable; see docs/agent-setup.md", file=stdout)
+        return False
+
+    if status == "expiring" and isinstance(remaining, int) and remaining >= 0:
+        print(f"FIX Claude quota credential: expires in {remaining} min; "
+              "start a new Claude Code CLI turn before then so its supported "
+              "client refreshes Keychain", file=stdout)
+        return False
+    if status == "expired":
+        print("FIX Claude quota credential: expired; login status alone is "
+              "not enough—start a new Claude Code CLI turn, then restart "
+              "the VibePulse tokenserver", file=stdout)
+        return False
+    if status == "unavailable":
+        print("FIX Claude quota credential: no supported Claude credential "
+              "was found on this computer", file=stdout)
+        return False
+    if status == "unknown":
+        print("FIX Claude quota credential: a process token exists but its "
+              "expiry cannot be guarded; sign in with Claude Code so the "
+              "supported credential store is populated", file=stdout)
+        return False
+
+    print("FIX Claude quota credential: invalid diagnostics", file=stdout)
+    return False
 
 
 def _resolve_executables(python, codex):


### PR DESCRIPTION
<!-- GitHub-ready v0.7.1 release body. Intentionally starts without an H1. -->

VibePulse v0.7.1 is a reliability patch for the path that must never merely
*look* healthy. It warns before the Claude credential readable by VibePulse
expires, proves whether the physical panel is actually polling, fixes missing
project-name glyphs, and records one exact end-to-end Codex panel test.

## What changed

- **Claude credential expiry is visible before Fable goes stale.** Claude can
  remain signed in and working while the separate Keychain credential an
  out-of-process quota reader is allowed to use has stopped refreshing. The
  tokenserver now publishes only a content-free readiness state and whole
  minutes remaining, warns 30 minutes before expiry, and rechecks local
  recovery every 15 seconds. It never returns or logs an access token, refresh
  token, account id, or Keychain body.
- **Startup health distinguishes service from panel.** Two close, non-loopback
  panel polls are required before diagnostics report recent panel contact; one
  curl cannot create a false green. The candidate address stays in process
  memory and is neither returned nor logged. Old evidence expires instead of
  remaining green forever.
- **The Codex smoke test is now deterministic.** The documented payload is
  `Ser du APPROVE?`, with `Ja` as the one explicit recommendation and `Nej` as
  the computer-side alternative. A pass requires visible **APPROVE**, a real
  panel tap, and `status: answered`, `option_index: 0`, `answer: Ja` back in
  Codex. Timeout, silence, **LEAVE IT**, private fallback, and computer
  fallback are not passes.
- **Project names render with the right glyph set.** The Needs You attract
  label used an uppercase-only font even though real project names contain
  lowercase letters, digits, dots, dashes, underscores, and replacement
  question marks. It now uses the existing full-ASCII `plex_ui_21` font.
- **Host startup no longer waits for relay history scans.** The first relay
  producer pass runs immediately but asynchronously, so a large local history
  cannot delay the LAN service binding at login.
- **The Codex plugin advances to 0.1.1.** Its skill includes the canonical
  physical test, strict pass criteria, and the build-versus-OTA version check.

## Upgrade

Pull or check out the eventual `v0.7.1` tag, then restart the tokenserver so
the new root diagnostics and startup behavior are active:

```sh
python3 tools/vibepulse_setup.py status
python3 tools/vibepulse_setup.py doctor
python3 tools/tokenserver/smoke.py
```

Existing Codex users should rerun the transactional guided setup to refresh
`vibepulse@torget`, choosing the same provider/detail options they want to
keep, then restart Codex, review VibePulse in `/hooks` if Codex asks again,
and start a new Codex task:

```sh
python3 tools/vibepulse_setup.py install
```

The release does not silently enable Claude, Codex, detail sharing, either
relay, or any other setting.

The host-side credential/startup fixes do not require a firmware flash. The
project-name glyph fix does. Use the normal consent-gated OTA flow only after
the release tag has green CI and the built image version matches the intended
checkout. Then run the canonical physical smoke test in
[`docs/agent-setup.md`](../agent-setup.md#post-flash-physical-codex-smoke-test).

VibePulse deliberately does not call an undocumented refresh endpoint or
mutate Claude's refresh token. When the readable credential is expiring or
expired, start a new Claude Code CLI turn and send one short message; the
supported client refreshes its own credential and VibePulse notices locally.

## Verified

- The full host gate passed: 778 Python/C tests, the numbers-relay suites,
  29 encrypted interaction-relay tests, and TypeScript type checking.
- The physical panel passed localized `RÄKSMÖRGÅS` rendering and the complete
  Codex question/touch/answer round trip on `torget-home-01` using the
  pre-tag build `v0.7.0-5-ge6feb29-dirty`. The exact evidence and recovery
  table are in the
  [2026-08-27 physical review](../superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md).
- A clean `v0.7.1` tag still requires its own green CI before publication.
  This physical evidence does not authorize an unattended flash.

This release remains source-only. Do not attach `torget.bin`: a locally built
image contains the installer's Wi-Fi credentials and device key.
