### PR TITLE
docs: publish VibePulse v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
-Release candidate notes:
+## v0.7.1 — 2026-08-27
+
+Release notes:
 [v0.7.1 — health and panel reliability](docs/releases/2026-08-27-health-and-panel-reliability.md).
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,18 +39,17 @@ the room, no window to switch to, no menu bar to squint at.
 > opening it up now rather than when it feels "done". Expect rough edges and
 > frequent commits.
 
-## Latest release: v0.7.0
+## Latest release: v0.7.1
 
-The 23 August release closes the loop for both providers: supported Claude
-Code **and Codex** questions can be answered from the panel, the screen can be
-moved to a new 2.4 GHz network from a phone, and the host service now runs on
-Windows as well as macOS. Optional, separately controlled encrypted relays can
-carry Needs You decisions and live agent rows when the panel and computer are
-on unrelated WiFi.
+The 27 August reliability release warns before the Claude credential readable
+by VibePulse expires, proves whether the physical panel is actually polling,
+keeps startup responsive while relay history is scanned, fixes mixed-case and
+localized project-name glyphs, and standardizes one strict Codex panel smoke
+test. Silence and computer fallback are never treated as approval.
 
-[Read the illustrated v0.7.0 notes](docs/releases/2026-08-23-codex-and-any-wifi.md)
+[Read the v0.7.1 notes](docs/releases/2026-08-27-health-and-panel-reliability.md)
 · [Full changelog](CHANGELOG.md)
-· [Compare v0.6.0...v0.7.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.6.0...v0.7.0)
+· [Compare v0.7.0...v0.7.1](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.7.0...v0.7.1)
 
 ## What's on screen
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -11,8 +11,8 @@ kan bo i egna repon. En skärm = en binär = ett bygge här. MIT-licens.
 
 Utbruten ur [Solelkollen](https://solelkollen.se)s firmware. VibePulse-repot
 äger nu skärmens firmware; den första fysiska flashen och den statiska grinden
-passerade 2026-08-13, OTA-kedjan följde 2026-08-14 och v0.7.0 släpptes
-2026-08-23.
+passerade 2026-08-13, OTA-kedjan följde 2026-08-14, v0.7.0 släpptes
+2026-08-23 och v0.7.1:s hälso- och panelreliabilitetsfixar 2026-08-27.
 
 ## Arkitekturen i tre meningar
 

--- a/docs/releases/2026-08-27-health-and-panel-reliability.md
+++ b/docs/releases/2026-08-27-health-and-panel-reliability.md
@@ -37,7 +37,7 @@ project-name glyphs, and records one exact end-to-end Codex panel test.
 
 ## Upgrade
 
-Pull or check out the eventual `v0.7.1` tag, then restart the tokenserver so
+Pull or check out the `v0.7.1` tag, then restart the tokenserver so
 the new root diagnostics and startup behavior are active:
 
 ```sh
@@ -60,9 +60,9 @@ relay, or any other setting.
 
 The host-side credential/startup fixes do not require a firmware flash. The
 project-name glyph fix does. Use the normal consent-gated OTA flow only after
-the release tag has green CI and the built image version matches the intended
+the tagged source has green CI and the built image version matches the intended
 checkout. Then run the canonical physical smoke test in
-[`docs/agent-setup.md`](../agent-setup.md#post-flash-physical-codex-smoke-test).
+[`docs/agent-setup.md`](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.1/docs/agent-setup.md#post-flash-physical-codex-smoke-test).
 
 VibePulse deliberately does not call an undocumented refresh endpoint or
 mutate Claude's refresh token. When the readable credential is expiring or
@@ -77,9 +77,11 @@ supported client refreshes its own credential and VibePulse notices locally.
   Codex question/touch/answer round trip on `torget-home-01` using the
   pre-tag build `v0.7.0-5-ge6feb29-dirty`. The exact evidence and recovery
   table are in the
-  [2026-08-27 physical review](../superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md).
-- A clean `v0.7.1` tag still requires its own green CI before publication.
-  This physical evidence does not authorize an unattended flash.
+  [2026-08-27 physical review](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.1/docs/superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md).
+- The exact `v0.7.1` source tree passed green CI before publication: the full
+  host gate, both relay suites, tokenserver tests on Ubuntu, macOS and Windows,
+  and the ESP32-S3 firmware build. This physical evidence does not authorize
+  an unattended flash.
 
 This release remains source-only. Do not attach `torget.bin`: a locally built
 image contains the installer's Wi-Fi credentials and device key.

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1293,7 +1293,7 @@ class PluginPackageTests(unittest.TestCase):
         self.assertIn("A green build from an old tree hid the panel test",
                       lessons)
 
-    def test_v071_release_candidate_is_upgradeable_safe_and_evidence_backed(self):
+    def test_v071_release_is_upgradeable_safe_and_evidence_backed(self):
         release = (ROOT / "docs/releases/"
                    "2026-08-27-health-and-panel-reliability.md").read_text(
                        encoding="utf-8")
@@ -1307,7 +1307,12 @@ class PluginPackageTests(unittest.TestCase):
             self.assertIn(required, release)
         self.assertIn("v0.7.1 — health and panel reliability", changelog)
         self.assertIn("plugin is `0.1.1`", changelog)
-        self.assertNotIn("## v0.7.1 —", changelog)
+        self.assertIn("## v0.7.1 — 2026-08-27", changelog)
+        self.assertNotIn("eventual `v0.7.1` tag", release)
+
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("## Latest release: v0.7.1", readme)
+        self.assertIn("Compare v0.7.0...v0.7.1", readme)
 
     def test_default_runner_invokes_plugin_suite_once(self):
         runner = (ROOT / "test/run.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- GitHub-ready v0.7.1 release body. Intentionally starts without an H1. -->

VibePulse v0.7.1 is a reliability patch for the path that must never merely
*look* healthy. It warns before the Claude credential readable by VibePulse
expires, proves whether the physical panel is actually polling, fixes missing
project-name glyphs, and records one exact end-to-end Codex panel test.

## What changed

- **Claude credential expiry is visible before Fable goes stale.** Claude can
  remain signed in and working while the separate Keychain credential an
  out-of-process quota reader is allowed to use has stopped refreshing. The
  tokenserver now publishes only a content-free readiness state and whole
  minutes remaining, warns 30 minutes before expiry, and rechecks local
  recovery every 15 seconds. It never returns or logs an access token, refresh
  token, account id, or Keychain body.
- **Startup health distinguishes service from panel.** Two close, non-loopback
  panel polls are required before diagnostics report recent panel contact; one
  curl cannot create a false green. The candidate address stays in process
  memory and is neither returned nor logged. Old evidence expires instead of
  remaining green forever.
- **The Codex smoke test is now deterministic.** The documented payload is
  `Ser du APPROVE?`, with `Ja` as the one explicit recommendation and `Nej` as
  the computer-side alternative. A pass requires visible **APPROVE**, a real
  panel tap, and `status: answered`, `option_index: 0`, `answer: Ja` back in
  Codex. Timeout, silence, **LEAVE IT**, private fallback, and computer
  fallback are not passes.
- **Project names render with the right glyph set.** The Needs You attract
  label used an uppercase-only font even though real project names contain
  lowercase letters, digits, dots, dashes, underscores, and replacement
  question marks. It now uses the existing full-ASCII `plex_ui_21` font.
- **Host startup no longer waits for relay history scans.** The first relay
  producer pass runs immediately but asynchronously, so a large local history
  cannot delay the LAN service binding at login.
- **The Codex plugin advances to 0.1.1.** Its skill includes the canonical
  physical test, strict pass criteria, and the build-versus-OTA version check.

## Upgrade

Pull or check out the `v0.7.1` tag, then restart the tokenserver so
the new root diagnostics and startup behavior are active:

```sh
python3 tools/vibepulse_setup.py status
python3 tools/vibepulse_setup.py doctor
python3 tools/tokenserver/smoke.py
```

Existing Codex users should rerun the transactional guided setup to refresh
`vibepulse@torget`, choosing the same provider/detail options they want to
keep, then restart Codex, review VibePulse in `/hooks` if Codex asks again,
and start a new Codex task:

```sh
python3 tools/vibepulse_setup.py install
```

The release does not silently enable Claude, Codex, detail sharing, either
relay, or any other setting.

The host-side credential/startup fixes do not require a firmware flash. The
project-name glyph fix does. Use the normal consent-gated OTA flow only after
the tagged source has green CI and the built image version matches the intended
checkout. Then run the canonical physical smoke test in
[`docs/agent-setup.md`](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.1/docs/agent-setup.md#post-flash-physical-codex-smoke-test).

VibePulse deliberately does not call an undocumented refresh endpoint or
mutate Claude's refresh token. When the readable credential is expiring or
expired, start a new Claude Code CLI turn and send one short message; the
supported client refreshes its own credential and VibePulse notices locally.

## Verified

- The full host gate passed: 778 Python/C tests, the numbers-relay suites,
  29 encrypted interaction-relay tests, and TypeScript type checking.
- The physical panel passed localized `RÄKSMÖRGÅS` rendering and the complete
  Codex question/touch/answer round trip on `torget-home-01` using the
  pre-tag build `v0.7.0-5-ge6feb29-dirty`. The exact evidence and recovery
  table are in the
  [2026-08-27 physical review](https://github.com/niclasvestlund-YT/vibepulse/blob/v0.7.1/docs/superpowers/reviews/2026-08-27-vibepulse-codex-physical-end-to-end.md).
- The exact `v0.7.1` source tree passed green CI before publication: the full
  host gate, both relay suites, tokenserver tests on Ubuntu, macOS and Windows,
  and the ESP32-S3 firmware build. This physical evidence does not authorize
  an unattended flash.

This release remains source-only. Do not attach `torget.bin`: a locally built
image contains the installer's Wi-Fi credentials and device key.
