### PR TITLE
Harden Windows validation and host diagnostics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Outcome
+
+<!-- What changes for the user? -->
+
+## Root cause / rationale
+
+<!-- Why was this needed? -->
+
+## Verification
+
+- [ ] Relevant focused tests pass.
+- [ ] `./test/run.sh` passes, or the exact omission and reason are stated.
+- [ ] No secret, credential, raw session content, production payload, or
+      `torget.bin` is included.
+- [ ] Documentation and changelog match the behavior.
+
+### Platform claims
+
+- [ ] This does not change a platform support claim; or
+- [ ] the support matrix and release validation evidence were updated.
+- [ ] A green CI runner is described only as automated evidence, not as a
+      real-host or physical-panel pass.
+- [ ] Windows-affecting changes follow `docs/windows-validation.md`.
+- [ ] Linux is not called supported before issue #2 and every real-host/panel
+      gate pass.
+
+### Hardware / UI
+
+- [ ] No hardware or UI behavior changed; or
+- [ ] exact 480×480 simulator evidence is attached.
+- [ ] A physical flash was separately and explicitly authorized.
+- [ ] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were
+      not treated as approval.
+
+## Not tested / remaining risk
+
+<!-- Be explicit. “None” is acceptable only after checking. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,32 @@ jobs:
           # now one list exists and run.sh guards its completeness.
           python -m unittest \
             $(tr -d '\r' < test/tokenserver-suite.txt | grep -v '^#') -v
+      - name: Validate the Windows Task Scheduler installer without installing
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $tokens = $null
+          $parseErrors = $null
+          $allErrors = @()
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path 'tools\tokenserver\install-windows-task.ps1'),
+            [ref]$tokens,
+            [ref]$parseErrors
+          ) | Out-Null
+          $allErrors += $parseErrors
+          $parseErrors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path 'tools\tokenserver\run-windows-task.ps1'),
+            [ref]$tokens,
+            [ref]$parseErrors
+          ) | Out-Null
+          $allErrors += $parseErrors
+          if ($allErrors.Count -gt 0) {
+            $allErrors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+          .\tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+          .\test\windows-task-runner.ps1
 
   firmware:
     name: ESP32-S3 firmware build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Designsystemet: **spec/ui-spec.md**. Hårdvarusanningen routas under
 `Hardware-aware work` nedan; läs den kanoniska femfilslistan där före
 hårdvaruarbete.
 
-## Status (2026-08-23, v0.7.0)
+## Status (2026-08-27, v0.7.1)
 
 Plattformen bröts ut ur underhållarens tidigare solcells-firmware (den
 historiken ligger i ett privat repo och är inget du behöver) och stöptes om
@@ -100,7 +100,7 @@ tokenserver stdout/launchd file, `GET /` diagnostics, state files, the screen
 itself) and contains the periodic comb routine — follow it when asked to
 comb, audit, or investigate logs or odd behavior. Findings go to
 `docs/observability-backlog.md`. Read `docs/lessons.md` before touching
-pollers, parsers, staleness logic, or the launchd setup; fixes with a
+pollers, parsers, staleness logic, or the host-service setup; fixes with a
 root-cause story add an entry there.
 
 ## Hårdvarufällorna i kortform (detaljer i spec/hardware.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+### Added
+
+- A versioned host-platform support matrix and reproducible Windows release
+  gate now separate CI portability, real-host service evidence, and the
+  physical panel loop. Linux remains explicitly unsupported until its XDG,
+  credential, systemd, real-host, and panel gates pass.
+- The Windows Task Scheduler installer has a non-mutating `-ValidateOnly`
+  mode, rejects Python older than 3.11 before registration, and is parsed plus
+  dry-validated on every Windows CI run. The runner's stdout/stderr capture,
+  bounded rotation, and a path containing spaces plus non-ASCII characters
+  are exercised there as well.
+- Windows autostart now keeps a bounded diagnostic log under
+  `%LOCALAPPDATA%\VibePulse\Logs` instead of discarding stdout/stderr; provider
+  choices remain in the private saved config rather than the scheduled command.
+- Setup doctor no longer rejects a healthy Python 3.11+ interpreter because
+  of a cross-platform whitespace mismatch in its exact sentinel.
+- A security policy, contribution guide, and pull-request evidence checklist
+  document private reporting, secret handling, platform-claim discipline, and
+  the difference between CI, real-host, and physical-panel validation.
+
 ## v0.7.1 — 2026-08-27
 
 Release notes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ authorization for the physical install.
 periodic comb routine — follow it when asked to comb, audit, or investigate
 logs or odd behavior. Findings go to `docs/observability-backlog.md`. Read
 `docs/lessons.md` before touching pollers, parsers, staleness logic, or the
-launchd setup: most sharp edges here have a story, and fixes with a
+host-service setup: most sharp edges here have a story, and fixes with a
 root-cause story add an entry there.
 
 ## Hardware-aware work

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to VibePulse
+
+Thanks for helping. Keep changes small, evidence-backed, and honest about which
+layer was tested: Python host, simulator, firmware build, real host, or physical
+panel.
+
+## Before changing code
+
+- Read [docs/agent-setup.md](docs/agent-setup.md) for a fresh setup and
+  [AGENTS.md](AGENTS.md) for maintainer constraints.
+- Read [docs/lessons.md](docs/lessons.md) before touching pollers, parsers,
+  staleness, persistence, or service-manager setup.
+- Read [docs/platform-support.md](docs/platform-support.md) before changing a
+  platform claim.
+- Never commit `secrets.h`, credentials, device/OTA/relay keys, session
+  content, or production payloads.
+- Never flash a user's device without their explicit permission.
+
+## Verification
+
+The complete local host gate is:
+
+```sh
+python3.12 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements-dev.txt \
+  -r requirements-interaction-relay.txt
+./test/run.sh
+```
+
+CI also builds the ESP32-S3 firmware and runs the tokenserver suite on Ubuntu,
+macOS, and Windows. A green platform runner is automated portability evidence,
+not by itself a real-host or physical-panel validation.
+
+For Windows changes, follow
+[docs/windows-validation.md](docs/windows-validation.md). Linux remains
+unsupported until [issue #2](https://github.com/niclasvestlund-YT/vibepulse/issues/2)
+and every gate in the platform matrix are complete.
+
+UI changes must use the exact 480×480 simulator captures and the AMOLED review
+workflow described in `AGENTS.md`. Simulator approval never authorizes a flash.
+
+## Pull requests
+
+Explain the user-visible outcome, the root cause, the exact commands/tests that
+passed, and anything not tested. Link real-host or physical evidence when the
+change affects a public support claim. Keep release artifacts free of
+`torget.bin`: it contains local Wi-Fi and device material.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ test. Silence and computer fallback are never treated as approval.
 · [Full changelog](CHANGELOG.md)
 · [Compare v0.7.0...v0.7.1](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.7.0...v0.7.1)
 
+Contributing or validating another host? Read
+[CONTRIBUTING.md](CONTRIBUTING.md), the
+[host support matrix](docs/platform-support.md), and
+[SECURITY.md](SECURITY.md) before sharing logs or test evidence.
+
 ## What's on screen
 
 Six core pages, swipe or auto-rotate, plus the always-present value-multiple
@@ -323,7 +328,11 @@ reported as current.
   uses, so if you already own one you're 10 minutes away.
 - **A Mac or Windows PC** running the tokenserver. Claude and Codex quota
   collection are supported on both. Direct LAN mode needs the panel to reach
-  that computer; the optional relays remove the same-WiFi requirement.
+  that computer; the optional relays remove the same-WiFi requirement. The
+  exact support/evidence boundary is maintained in
+  **[Host platform support](docs/platform-support.md)**; Windows release
+  candidates use the reproducible
+  **[Windows validation gate](docs/windows-validation.md)**.
 - **Claude Code and/or Codex.** Either alone is fine.
 - **2.4 GHz WiFi.** The ESP32-S3 can't see 5 GHz networks.
 
@@ -632,12 +641,16 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   `powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1`.
   It runs as your signed-in user, starts immediately, restarts on failure, and
   keeps interaction-provider choices in the tokenserver's saved config. The
-  current background task does not persist stdout/stderr; use
-  `curl http://localhost:8737/` for health and run the service in a terminal
-  when you need a diagnostic log.
+  background task writes bounded stdout/stderr to
+  `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; the server's
+  rotation guard keeps one `.old` tail. Use `-ValidateOnly` to verify the
+  checkout and Python 3.11+ interpreter without changing Task Scheduler.
 - **Linux for the tokenserver?** Not yet —
-  [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2);
-  contributions very welcome.
+  [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2). The Ubuntu
+  tokenserver CI lane is portability evidence, not a support claim: current
+  `main` still needs XDG paths, Linux credential selection, systemd user
+  service lifecycle, and a real-host + panel validation report. See
+  [Host platform support](docs/platform-support.md).
 - **Other boards or panel sizes?** Not yet. The platform is pinned to this
   exact panel so one pixel-perfect build stays pixel-perfect, but a port is
   a contained job (BSP, layout constants, fonts) —

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security policy
+
+VibePulse reads local usage metadata, can expose a LAN service, and optionally
+bridges bounded decisions to a physical panel. Please treat authentication,
+request signing, relay encryption, permission handling, and privacy-boundary
+bugs as security issues even when no prompt content is stored.
+
+## Supported versions
+
+Security fixes target the latest published release and `main`. Older releases
+may receive documentation-only mitigations, but should not be assumed safe
+after a fix ships.
+
+## Report a vulnerability privately
+
+Use **Security → Report a vulnerability** in the GitHub repository. Do not open
+a public issue for a suspected vulnerability until the maintainer has had a
+reasonable chance to investigate and publish a fix.
+
+Never include any of the following in a report, screenshot, test fixture, or
+log attachment:
+
+- OAuth access or refresh tokens;
+- the VibePulse device key, OTA token, relay bearer, or mailbox secret;
+- Wi-Fi credentials or a committed `secrets.h`;
+- raw prompts, messages, commands, session files, or account identifiers.
+
+Use synthetic values and describe the minimum conditions needed to reproduce
+the problem. Safe diagnostics include version/commit, operating system,
+endpoint status codes, content-free health states, and redacted timestamps.
+
+## Security invariants
+
+- A timeout, missing panel, computer fallback, or silence is never approval.
+- Provider, request, and exact-view bindings must be verified before a panel
+  verdict is accepted.
+- Unknown, mutating, secret-bearing, truncated, or ambiguous commands stay on
+  the computer.
+- Cloud transports remain independent, explicit, default-off choices.
+- The plaintext numbers relay never carries agent activity or interaction
+  content; the interaction/status relay carries only fixed-size ciphertext.
+- Hooks and local decision ingress remain loopback-only; the panel posts only
+  signed, bounded verdicts.
+- Secrets never belong in firmware artifacts, releases, CI logs, process
+  output, issues, or documentation.

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -40,8 +40,8 @@ cannot determine yourself.
    from `%USERPROFILE%\.claude\.credentials.json` instead of the keychain,
    and state lives under `%LOCALAPPDATA%\VibePulse\`. The supplied
    `install-windows-task.ps1` adds autostart through Task Scheduler; its
-   current background task does not persist stdout/stderr, so use the root
-   health endpoint or run manually for diagnostic logs. On Linux
+   bounded diagnostic log lives at
+   `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`. On Linux
    the firmware still builds and the simulator still runs, but the service
    finds no Claude token at all — there is no keychain and the credential
    file is read only on Windows
@@ -183,7 +183,7 @@ readable OAuth copy is expired:
 | `usage_http_200 + no_mapped_limits` | Authenticated, but nothing in the usage response mapped (a `; fallback_…` suffix records the header-probe outcome) | Plan may not expose limits; Codex half still works |
 | `usage_request_failed: …` | Network/DNS failure from the computer | Check the computer's own connectivity |
 | `usage_http_429 + backoff_until_HH:MM` | Rate-limited by the API; the probe rests until the shown time | Wait — it retries by itself |
-| `probe_crashed: <Type>` | The probe itself hit a bug (crash before it could classify the failure) | Read `~/Library/Logs/torget-tokenserver.log` on macOS. On Windows, stop the background task and run the service in a terminal to capture stderr; worth filing |
+| `probe_crashed: <Type>` | The probe itself hit a bug (crash before it could classify the failure) | Read `~/Library/Logs/torget-tokenserver.log` on macOS or `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log` on Windows; worth filing |
 
 Codex is read separately from its local app-server, so a bad `claudeProbe`
 never explains missing Codex numbers, and vice versa.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,7 +1,7 @@
 # Observability: every log this system generates
 
 VibePulse spans two machines — a screen with no persistent storage and a
-Python service on a Mac — and each produces evidence in a different place,
+Python service on a Mac or Windows PC — and each produces evidence in a different place,
 with a different lifetime, in a different language. This doc maps all of
 it: where each log lives, how long it survives, what a healthy one looks
 like, and a periodic **comb routine** for reading through them to catch
@@ -25,9 +25,9 @@ backlog IDs in parentheses track closing them.
 | # | Source | Where it lives | Survives |
 |---|--------|----------------|----------|
 | 1 | Firmware serial console | USB, only while a monitor is attached | nothing — not even a reboot |
-| 2 | Tokenserver stderr | terminal, or `~/Library/Logs/torget-tokenserver.log` under launchd | durable; self-rotated at ~5 MB (tail kept in `.old`) |
-| 3 | `GET /` diagnostic endpoint | `http://<mac>:8737/`, live state | process lifetime |
-| 4 | Server state files | `~/Library/Application Support/VibePulse/` | durable (8 d / 400 d retention) |
+| 2 | Tokenserver stderr | terminal; `~/Library/Logs/torget-tokenserver.log` under launchd; `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log` under Task Scheduler | durable; self-rotated at ~5 MB (tail kept in `.old`) |
+| 3 | `GET /` diagnostic endpoint | `http://<host>:8737/`, live state | process lifetime |
+| 4 | Server state files | `~/Library/Application Support/VibePulse/` on macOS; `%LOCALAPPDATA%\VibePulse\` on Windows | durable (8 d / 400 d retention) |
 | 5 | The screen itself | dashes, `STALE`, `NO DATA` | live only |
 | 6 | CI logs | GitHub Actions | per-run |
 
@@ -117,6 +117,16 @@ elsewhere, launchd is silently running *different code than you're
 editing* — that exact trap cost an hour once and is why `GET /` reports
 `rev` ([lessons.md](lessons.md)) and why the smoke test compares it to
 your checkout.
+
+Under Task Scheduler, `install-windows-task.ps1` starts
+`run-windows-task.ps1`, which appends both streams to
+**`%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`** as the signed-in
+user. The wrapper rotates an oversized file before Python starts; the
+tokenserver's own hourly identity-checked rotation guard keeps the running
+process bounded too. One `.old` file preserves the previous tail. The
+scheduled command contains the checkout/interpreter paths and optional
+numbers-relay URL, but provider/detail choices stay in the saved private
+configuration.
 
 Still invisible from the log: per-request keychain nuance (OBS-20) and
 the probe's backoff-streak value (OBS-18) — those live only on `GET /`
@@ -253,7 +263,7 @@ Verbatim strings worth grepping for, and what they mean:
 Run every week or two, and after any incident. Every step is a command
 plus a question; an agent asked to **"comb the logs"** follows this list
 top to bottom and reports findings against the backlog. With the
-tokenserver on the Mac and the board on its shelf, steps 1–5 need no
+tokenserver on the host computer and the board on its shelf, steps 1–5 need no
 hardware handling at all.
 
 Steps 1–4 are automated: **`python3 tools/tokenserver/smoke.py`** runs
@@ -270,16 +280,20 @@ the manual detail below is for interpreting what it flags — and steps
    `usage_http_200 + ok`. Anything else → the table in
    [agent-setup.md](agent-setup.md). `unknownRateLimitBuckets` non-empty
    → new upstream bucket, file a backlog item.
-3. **The log file.** `wc -c ~/Library/Logs/torget-tokenserver.log`
-   (missing file under launchd means the service never started).
+3. **The log file.** On macOS, `wc -c
+   ~/Library/Logs/torget-tokenserver.log`; on Windows inspect
+   `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`. A missing file
+   under launchd or Task Scheduler means the service never reached its
+   logging entrypoint.
    `grep -c serverar` — more than one per intended restart means
    crash-looping. `grep -n Traceback` — any hit is a bug; the `500 på`
    line above it names the route. `grep -c 'agent-status'` — a large
    count means a persistent throttled error has been repeating every
    30 s. `grep 'claude-probe:'` — the transition history: when did
    things break, when did they recover.
-4. **State files.** For each file in
-   `~/Library/Application Support/VibePulse/`: does it parse
+4. **State files.** For each file in the platform state directory
+   (`~/Library/Application Support/VibePulse/` on macOS or
+   `%LOCALAPPDATA%\VibePulse\` on Windows): does it parse
    (`python3 -m json.tool < f > /dev/null`)? Is the mtime recent for
    `usage-history.json` (should move every ≤15 min while you work)? Did
    `max-tracker.json` shrink dramatically since last comb (silent

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,92 @@
+# Host platform support
+
+VibePulse has two different platform surfaces:
+
+1. the ESP32-S3 firmware, which runs on the one supported Waveshare panel;
+2. the tokenserver, setup tools, and optional Codex bridge running on your
+   computer.
+
+When this document says a computer platform is supported, it means the
+**host service**. It does not claim that every developer builds or flashes the
+firmware from that operating system.
+
+## Current support
+
+| Host | Tokenserver | Autostart | Automated evidence | Real-host evidence | Public status |
+|---|---|---|---|---|---|
+| macOS | Yes | launchd | Tokenserver matrix + full host gate | Daily development and physical panel reviews | Supported |
+| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Windows host validation is required for each public support milestone | Supported; the new persistent-log path remains tracked in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) until it passes a real scheduled-task lifecycle |
+| Linux | Not on `main` | Not shipped | The Python suite runs on Ubuntu, but that alone does not exercise a supported Linux installation | No current-main release report | Not supported yet; tracked in [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2) |
+
+The v0.7.1 tokenserver matrix passed on Windows, macOS, and Ubuntu in the
+[release commit's CI run](https://github.com/niclasvestlund-YT/vibepulse/actions/runs/33061186373).
+That is strong portability evidence, but it is not a substitute for a real
+service-manager, firewall, LAN, credential, and panel test.
+
+A [read-only real-PC report for v0.7.1](superpowers/reviews/2026-08-27-windows-v0.7.1-read-only.md)
+passed the complete Windows suite, all endpoint contracts, and the Claude
+source. It remained PARTIAL because that PC had no scheduled task, the
+app-owned Codex executable could not be invoked from the validation
+environment, external LAN reachability was not tested, and the panel never
+completed the physical loop.
+
+## What “validated on Windows” means
+
+A Windows claim is release-ready only when all of these are recorded against
+an exact clean tag or commit:
+
+- the complete tokenserver suite passes on the PC with Python 3.11 or newer;
+- the Task Scheduler installer parses and its non-mutating validation mode
+  resolves the expected checkout and interpreter;
+- the real service serves safe health plus all three panel endpoints;
+- the real Codex source is current, and Claude is either current or reports an
+  honest, actionable unavailable/expired state;
+- inbound TCP 8737 is allowed on **Private** networks only and another LAN
+  device can reach it;
+- Task Scheduler starts the service after sign-in and recovers after a forced
+  process failure;
+- the physical panel reports recent polling, receives the canonical short
+  Codex question, visibly renders **APPROVE**, and a human tap returns the
+  expected answer;
+- sleep/resume and one reboot do not leave the panel silently stale.
+
+Use [Windows release validation](windows-validation.md) for the reproducible
+procedure. Silence, a missing panel, **LEAVE IT**, computer fallback, or
+**SOMETHING IS WAITING** without answer buttons is never a pass.
+
+## What remains before Linux can be announced
+
+Green Ubuntu unit tests do not make the current release a Linux product. On
+current `main`, Linux still falls into macOS-shaped state/log paths, the Claude
+credential-file source is not selected, and no systemd user-service installer
+ships. Linux needs all of the following before the README or GitHub description
+may call it supported:
+
+- XDG-compatible state and log paths;
+- Claude credential-file lookup, including `CLAUDE_CONFIG_DIR`, without
+  macOS-only commands;
+- reliable Codex executable discovery under systemd's reduced `PATH`;
+- an idempotent systemd **user** service install/validate/uninstall flow;
+- safe firewall and host-address instructions;
+- automated service-definition validation in CI;
+- the complete host suite on Ubuntu;
+- a real Linux host report covering Codex, Claude, autostart, LAN reachability,
+  restart/reboot, and the physical panel loop.
+
+The older combined Windows/Linux work in
+[PR #13](https://github.com/niclasvestlund-YT/vibepulse/pull/13) is useful
+reference material, not merge-ready code: Windows landed independently and the
+pull request now conflicts with `main`. Extract and re-test the Linux-specific
+parts rather than merging the stale branch wholesale.
+
+## Claim discipline
+
+- **Automated:** a CI runner executed the code. This proves repeatability, not
+  a household LAN, real credentials, Task Scheduler/systemd, or the panel.
+- **Real-host:** the released code ran on the named operating system with real
+  local sources. This still does not prove the physical interaction loop.
+- **Physical end to end:** computer source → tokenserver → LAN/relay → panel →
+  human touch → originating agent all completed with explicit evidence.
+
+Release notes and social posts should use the narrowest true claim. In
+particular, never turn “Ubuntu tests are green” into “Linux is supported.”

--- a/docs/superpowers/reviews/2026-08-27-windows-v0.7.1-read-only.md
+++ b/docs/superpowers/reviews/2026-08-27-windows-v0.7.1-read-only.md
@@ -1,0 +1,56 @@
+# Windows v0.7.1 read-only validation — 2026-08-27
+
+This report records a non-mutating run on a real Windows PC. It validates the
+tagged v0.7.1 host code more strongly than CI, but it is intentionally a
+**partial** release result: no task, firewall rule, authentication setting, or
+ESP32 was changed, and no missing panel response was reclassified as success.
+
+## Exact environment
+
+- Windows 10 Pro 22H2, build 19045.6466, x64
+- PowerShell 7.6.4
+- Python 3.12.10
+- Git 2.54.0
+- clean detached checkout at tag `v0.7.1`
+- commit `b7b16135644875fa1ae96b0f57df4797d4bf11e8`
+
+The checkout lived in a new validation directory. No existing project files
+or system configuration were changed.
+
+## Evidence
+
+| Gate | Result | Evidence |
+|---|---|---|
+| Exact clean release | PASS | `HEAD` equalled the v0.7.1 tag commit and `git status --porcelain` was empty |
+| Complete tokenserver suite | PASS | isolated venv, 778 tests, 11 skips, 0 failures/errors, exit 0 |
+| Installer syntax | PASS | PowerShell parser returned zero errors |
+| Temporary host service | PASS | `/`, `/api/tokens`, `/api/agent-status`, and `/api/max-tracker` returned HTTP 200 with the expected JSON contracts; the process stopped cleanly |
+| Claude quota source | PASS | credential ready, usage HTTP 200 + ok, numeric weekly observations, `stale=false` |
+| Codex quota source | FAIL | `codex` was discoverable, but Windows denied execution of the app-owned executable from the validation environment; the current app-server quota was therefore unavailable |
+| Task Scheduler | FAIL | no `VibePulse tokenserver` task existed on this PC; only the definition's syntax was tested |
+| Firewall / LAN | PARTIAL | an enabled inbound allow rule for TCP 8737 on Private profile existed and LAN self-address access worked; no second LAN device was tested |
+| Panel end to end | FAIL | panel state remained `waiting`; no recent panel contact, rendered question, or human answer was observed |
+
+The first suite attempt used system Python without the optional pinned relay
+dependency and produced three import errors. Installing
+`requirements-interaction-relay.txt` into the isolated validation venv and
+rerunning the exact module list produced the passing 778-test result above.
+
+## Bug found by the real host
+
+`tools/vibepulse_setup.py doctor` incorrectly marked Python 3.12 unhealthy on
+this PC. The v0.7.1 probe emitted an extra space while the checker required an
+exact sentinel without it. The next candidate removes the space and includes a
+test that executes the real probe rather than mocking its output.
+
+## Verdict
+
+v0.7.1 has real Windows evidence for the Python host service, endpoint
+contracts, and Claude source. This run does **not** validate Windows autostart,
+real Codex quota collection, external LAN reachability, or the physical panel
+loop. Windows must remain PARTIAL for those claims until the procedure in
+[Windows release validation](../../windows-validation.md) passes on an exact
+candidate.
+
+No credential, token, account identifier, prompt, message, session content, or
+private payload was included in the evidence.

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -1,0 +1,211 @@
+# Windows release validation
+
+This is the release gate for VibePulse's Windows **host service**. It does not
+flash the ESP32 and must not print credentials, session contents, prompts, or
+other secrets into the report.
+
+Run the procedure from PowerShell as the Windows user who actually runs Codex
+or Claude Code. The tokenserver reads that user's profile, so testing as
+Administrator or SYSTEM proves the wrong installation.
+
+## 1. Record the host without exposing account data
+
+```powershell
+[System.Environment]::OSVersion.VersionString
+$env:PROCESSOR_ARCHITECTURE
+$PSVersionTable.PSVersion
+git --version
+py -3 -c "import platform,sys; print(platform.platform()); print(sys.version)"
+```
+
+Python must be 3.11 or newer.
+
+## 2. Validate an exact clean release
+
+Use a new directory so old generated files cannot make the result greener or
+redder than the release:
+
+```powershell
+$ValidationRoot = Join-Path $env:TEMP ("vibepulse-validation-" + [guid]::NewGuid())
+git clone https://github.com/niclasvestlund-YT/vibepulse.git $ValidationRoot
+git -C $ValidationRoot checkout --detach v0.7.1
+git -C $ValidationRoot describe --tags --always --dirty
+git -C $ValidationRoot status --short
+```
+
+The description must be `v0.7.1` and status output must be empty. For a future
+release, substitute the exact candidate tag or commit everywhere in this
+document.
+
+## 3. Run the complete Windows tokenserver suite
+
+```powershell
+Set-Location $ValidationRoot
+$Modules = Get-Content test\tokenserver-suite.txt |
+  Where-Object { $_ -and -not $_.StartsWith('#') }
+py -3 -m pip install -r requirements-interaction-relay.txt
+py -3 -m unittest $Modules -v
+```
+
+Record the number of tests, skips, failures/errors, and the exit code. A skip is
+acceptable only when its reason is platform-specific and named in the output.
+
+## 4. Validate the Task Scheduler installer without installing
+
+```powershell
+$Tokens = $null
+$Errors = $null
+[System.Management.Automation.Language.Parser]::ParseFile(
+  (Resolve-Path tools\tokenserver\install-windows-task.ps1),
+  [ref]$Tokens,
+  [ref]$Errors
+) | Out-Null
+$Errors
+.\tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+```
+
+The parser must return no errors. `-ValidateOnly` must report the exact checkout
+and a Python 3.11+ interpreter, and must say that it made no Task Scheduler
+changes.
+
+## 5. Exercise the real local sources on a temporary port
+
+Start the service in a foreground PowerShell on an unused port:
+
+```powershell
+py -3 tools\tokenserver\tokenserver.py --port 8738
+```
+
+In a second PowerShell:
+
+```powershell
+$Root = Invoke-RestMethod http://127.0.0.1:8738/
+$Tokens = Invoke-RestMethod http://127.0.0.1:8738/api/tokens
+$Agent = Invoke-RestMethod http://127.0.0.1:8738/api/agent-status
+$Max = Invoke-RestMethod http://127.0.0.1:8738/api/max-tracker
+
+$Root | Select-Object service, rev, srcFingerprint, claudeProbe,
+  claudeCredential, @{Name='panel'; Expression={$_.interactions.panel}}
+$Tokens | Select-Object v, claudeWeekStale, codexWeekStale
+$Agent | Select-Object v, seq
+$Max | Select-Object v
+```
+
+Never paste the unfiltered response into an issue. Report only safe status,
+presence/type, staleness, and revision fields. Stop the foreground service with
+Ctrl+C when the checks are complete.
+
+Then run the read-only setup diagnostics from the release checkout:
+
+```powershell
+py -3 tools\vibepulse_setup.py status
+py -3 tools\vibepulse_setup.py doctor
+```
+
+Doctor may contact the local service and configured relay, but it must not
+install, enable, disable, or change provider choices.
+
+## 6. Inspect autostart and the firewall
+
+Inspect first; do not silently create or change either surface:
+
+```powershell
+Get-ScheduledTask -TaskName "VibePulse tokenserver" -ErrorAction SilentlyContinue |
+  Select-Object TaskName, State, Author
+
+Get-NetFirewallRule -ErrorAction SilentlyContinue |
+  Where-Object DisplayName -Like "*VibePulse*" |
+  Select-Object DisplayName, Enabled, Direction, Action, Profile
+```
+
+If no inbound rule exists and direct LAN mode is required, create one from an
+elevated PowerShell for TCP 8737 on **Private** networks only:
+
+```powershell
+New-NetFirewallRule -DisplayName "VibePulse tokenserver" -Direction Inbound `
+  -Protocol TCP -LocalPort 8737 -Action Allow -Profile Private
+```
+
+Do not open the service on the Public profile. From another computer on the
+same LAN, verify the PC's real address rather than localhost:
+
+```powershell
+Test-NetConnection -ComputerName <PC-LAN-IP> -Port 8737
+```
+
+The panel's direct-LAN URL must use that reachable address. Reserve it in the
+router or use the optional relays; Windows does not currently provide the
+stable `.local` discovery tracked in
+[#7](https://github.com/niclasvestlund-YT/vibepulse/issues/7).
+
+## 7. Verify the real service lifecycle
+
+Only after the release checkout and installer validation pass:
+
+```powershell
+.\tools\tokenserver\install-windows-task.ps1
+Get-ScheduledTaskInfo -TaskName "VibePulse tokenserver"
+Invoke-RestMethod http://127.0.0.1:8737/ |
+  Select-Object service, rev, srcFingerprint, claudeProbe, claudeCredential,
+    @{Name='panel'; Expression={$_.interactions.panel}}
+```
+
+Verify all of these and record timestamps:
+
+1. the task starts immediately;
+2. it starts again after sign-out/sign-in;
+3. it restarts after the process is terminated once;
+4. it returns after sleep/resume;
+5. one full Windows reboot does not leave the panel stale.
+
+The tagged v0.7.1 scheduler task has no persistent stdout/stderr log. The next
+candidate adds `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; keep
+[#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) open until the
+new wrapper, rotation, quoting, restart, and non-ASCII-profile path pass on a
+real scheduled task.
+
+## 8. Close the physical loop
+
+The final check requires the real panel and a human tap. Use the exact short
+Codex question:
+
+`Ser du APPROVE?`
+
+Options:
+
+- `Ja` — `APPROVE syns` (recommended)
+- `Nej` — `APPROVE saknas`
+
+Pass only when the panel visibly shows **APPROVE**, a human taps it, and the
+call returns `status: answered`, `option_index: 0`, `answer: Ja`. Before the
+test, compare `git describe --tags --always --dirty` from the firmware build
+checkout with the service's `otaAvailableVersion`.
+
+Silence, timeout, panel absence, **LEAVE IT**, computer fallback, or a private
+**SOMETHING IS WAITING** screen without buttons is a fail or an explicit not
+tested result—never approval.
+
+## Release verdict
+
+The first real-PC baseline for the tagged v0.7.1 release is recorded in
+[Windows v0.7.1 read-only validation](superpowers/reviews/2026-08-27-windows-v0.7.1-read-only.md).
+It is intentionally PARTIAL and must not be cited as a physical end-to-end
+pass.
+
+Record each row as PASS, FAIL, or NOT TESTED:
+
+| Gate | Required to announce Windows support |
+|---|---|
+| Exact clean release checkout | Yes |
+| Complete Windows tokenserver suite | Yes |
+| Installer parser + `-ValidateOnly` | Yes |
+| Real Codex quota source | Yes when Codex is claimed |
+| Real Claude quota source or honest unavailable state | Yes when Claude is claimed |
+| Task Scheduler start/restart/sign-in | Yes |
+| Private-profile firewall + LAN reachability | Yes for direct LAN |
+| Recent panel polling | Yes for panel support |
+| Physical Codex question and human answer | Yes for “answer from the panel” |
+| Sleep/resume and reboot | Yes |
+
+Any required FAIL or NOT TESTED means the narrow component can be described as
+automated or previewed, but not announced as physically end-to-end validated.

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -25,8 +25,15 @@ tokenserver_readme = read("tools/tokenserver/README.md")
 interaction_guide = read("docs/interaction-relay.md")
 interaction_worker_readme = read("tools/interaction-relay/README.md")
 observability = read("docs/observability.md")
+platform_support = read("docs/platform-support.md")
+windows_validation = read("docs/windows-validation.md")
+windows_host_report = read(
+    "docs/superpowers/reviews/2026-08-27-windows-v0.7.1-read-only.md")
+ci = read(".github/workflows/ci.yml")
 mac_service = read("tools/tokenserver/se.torget.tokenserver.plist")
 windows_service = read("tools/tokenserver/install-windows-task.ps1")
+windows_runner = read("tools/tokenserver/run-windows-task.ps1")
+windows_runner_test = read("test/windows-task-runner.ps1")
 
 # --- What may cross: numbers -------------------------------------------
 for name in ("TK_TOKENS_RELAY_URL", "TK_MAX_TRACKER_RELAY_URL",
@@ -152,7 +159,8 @@ assert plist["ProgramArguments"] == [
     "/Users/niclasvestlund/Torget/.venv/bin/python", "-u", "tokenserver.py"
 ]
 for source, name in ((mac_service, "macOS launchd template"),
-                     (windows_service, "Windows Task Scheduler installer")):
+                     (windows_service, "Windows Task Scheduler installer"),
+                     (windows_runner, "Windows Task Scheduler runner")):
     for forbidden in ("--interactions", "--claude-interactions",
                       "--codex-interactions", "--interaction-detail",
                       "--legacy-claude-panel-v1"):
@@ -180,5 +188,43 @@ assert "install-windows-task.ps1" in tokenserver_readme, (
 )
 assert "What is missing is **autostart**" not in readme
 assert "Kvar på Windows: **autostart**" not in tokenserver_readme
+
+# Platform claims must stay narrower than the evidence. Windows has a real,
+# non-mutating installer gate; Ubuntu unit tests alone must never be promoted
+# to Linux support while #2's host/service work remains open.
+for required in (
+        "Automated evidence", "Real-host evidence", "Physical end to end",
+        "Windows", "Linux", "Not supported yet"):
+    assert required.lower() in platform_support.lower(), (
+        f"platform support matrix must explain {required}"
+    )
+for required in (
+        "-ValidateOnly", "Private", "Task Scheduler", "Ser du APPROVE?",
+        "Silence", "reboot"):
+    assert required.lower() in windows_validation.lower(), (
+        f"Windows release gate must include {required}"
+    )
+assert "[Host platform support](docs/platform-support.md)" in readme
+assert "[Windows validation gate](docs/windows-validation.md)" in readme
+assert "-ValidateOnly" in windows_service
+assert "no Task Scheduler changes were made" in windows_service
+assert "%LOCALAPPDATA%\\VibePulse\\Logs\\torget-tokenserver.log" in readme
+assert "torget-tokenserver.log" in windows_runner
+assert "$LogCapBytes = 5MB" in windows_runner
+assert "$LogTailBytes = 256KB" in windows_runner
+assert "Write-VibePulseLogLine" in windows_runner
+assert "run-windows-task.ps1" in windows_service
+assert "-MultipleInstances StopExisting" in windows_service
+assert "Validate the Windows Task Scheduler installer without installing" in ci
+assert ".\\tools\\tokenserver\\install-windows-task.ps1 -ValidateOnly" in ci
+assert ".\\test\\windows-task-runner.ps1" in ci
+assert "VibePulse runner å" in windows_runner_test
+assert "stdout was not captured" in windows_runner_test
+assert "stderr was not captured" in windows_runner_test
+assert "Ubuntu" in readme and "not a support claim" in readme
+assert "778 tests" in windows_host_report
+assert "Panel end to end | FAIL" in windows_host_report
+assert "Codex quota source | FAIL" in windows_host_report
+assert "No credential, token, account identifier" in windows_host_report
 
 print("OK: the numbers relay carries only numbers; activity uses a separate encrypted boundary")

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1346,6 +1346,17 @@ class PluginPackageTests(unittest.TestCase):
 
 
 class SetupPlanTests(unittest.TestCase):
+    def test_real_python_probe_has_the_exact_cross_platform_sentinel(self):
+        """A stray space made healthy Python 3.12 fail doctor on Windows."""
+        setup = load_setup()
+        completed = subprocess.run(
+            [sys.executable, "-c", setup._PYTHON_PROBE],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "vibepulse-python-3.11+\n")
+        self.assertEqual(completed.stderr, "")
+
     def test_disable_preserves_unrelated_switches_and_clears_legacy_with_claude(self):
         setup = load_setup()
         saved = setup.VibePulseConfig(

--- a/test/windows-task-runner.ps1
+++ b/test/windows-task-runner.ps1
@@ -1,0 +1,58 @@
+<# Non-mutating Windows CI test for the Task Scheduler entrypoint. #>
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$Runner = Join-Path $RepoRoot "tools\tokenserver\run-windows-task.ps1"
+$Python = (Get-Command python.exe -ErrorAction Stop).Source
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "VibePulse runner å " + [guid]::NewGuid().ToString("N")
+)
+$PreviousLocalAppData = $env:LOCALAPPDATA
+
+try {
+    New-Item -ItemType Directory -Path $TempRoot -Force | Out-Null
+    $env:LOCALAPPDATA = $TempRoot
+    $Fixture = Join-Path $TempRoot "fixture med å.py"
+    @'
+import sys
+print("stdout-ok")
+print("stderr-ok", file=sys.stderr)
+'@ | Set-Content -LiteralPath $Fixture -Encoding UTF8
+
+    $LogDir = Join-Path $TempRoot "VibePulse\Logs"
+    $LogPath = Join-Path $LogDir "torget-tokenserver.log"
+    $OldLogPath = "$LogPath.old"
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+    $Filler = New-Object byte[] (5MB + 4096)
+    [System.IO.File]::WriteAllBytes($LogPath, $Filler)
+    [System.IO.File]::AppendAllText($LogPath, "rotation-sentinel")
+
+    & $Runner -Python $Python -Server $Fixture
+    if ($LASTEXITCODE -ne 0) {
+        throw "runner returned $LASTEXITCODE"
+    }
+
+    if (-not (Test-Path -LiteralPath $OldLogPath -PathType Leaf)) {
+        throw "runner did not create the rotated .old tail"
+    }
+    if ((Get-Item -LiteralPath $OldLogPath).Length -gt 256KB) {
+        throw "rotated tail exceeds 256 KiB"
+    }
+    $OldText = [System.IO.File]::ReadAllText($OldLogPath)
+    if (-not $OldText.Contains("rotation-sentinel")) {
+        throw "rotated tail lost its final marker"
+    }
+    $CurrentText = [System.IO.File]::ReadAllText($LogPath)
+    if (-not $CurrentText.Contains("stdout-ok")) {
+        throw "stdout was not captured"
+    }
+    if (-not $CurrentText.Contains("stderr-ok")) {
+        throw "stderr was not captured"
+    }
+    Write-Host "VibePulse Windows task runner: OK"
+} finally {
+    $env:LOCALAPPDATA = $PreviousLocalAppData
+    if (Test-Path -LiteralPath $TempRoot) {
+        Remove-Item -LiteralPath $TempRoot -Recurse -Force
+    }
+}

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -353,11 +353,12 @@ powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.
 Skriptet registrerar tjänsten för den inloggade användaren, startar den
 direkt och startar om den vid fel. Det bakar inte in Claude/Codex- eller
 detaljval i kommandoraden; samma sparade tokenserver-konfiguration används
-som vid manuell start. Uppgiften kör `pythonw.exe` och den nuvarande
-installationen omdirigerar inte stdout/stderr till en beständig fil. Kontrollera
-hälsan med `curl http://localhost:8737/`; kör tjänsten manuellt med
-`python.exe` i en terminal när du behöver felsökningsloggen. Avinstallera
-själva autostarten med:
+som vid manuell start. En dold PowerShell-wrapper kör den verifierade
+Python 3.11+-tolken och skriver stdout/stderr till
+`%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; loggen roteras vid
+cirka 5 MB med en `.old`-svans. Kontrollera hälsan med
+`curl http://localhost:8737/`. Kontrollera installeraren utan att röra
+Task Scheduler med `-ValidateOnly`. Avinstallera själva autostarten med:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -Uninstall

--- a/tools/tokenserver/install-windows-task.ps1
+++ b/tools/tokenserver/install-windows-task.ps1
@@ -20,9 +20,9 @@ Designval, i linje med resten av repot:
   läser %USERPROFILE%\.claude\.credentials.json — en SYSTEM-tjänst hade
   läst fel profil och dessutom gett processen mer rättigheter än den
   behöver.
-- pythonw.exe (inget konsolfönster). Den nuvarande uppgiften omdirigerar inte
-  stdout/stderr till en beständig fil. GET / är hälsokollen; kör servern med
-  python.exe i en terminal när en felsökningslogg behövs.
+- En dold PowerShell-wrapper kör python.exe och skriver en begränsad logg till
+  %LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log. En enda .old-fil
+  håller omstarter och lång drift från att växa utan gräns.
 - Interaction providers and detail are read from the tokenserver's saved config.
   Keep those choices out of the scheduled command so setup changes cannot go
   stale here. The optional publish arguments below are numbers-relay settings,
@@ -35,11 +35,52 @@ Designval, i linje med resten av repot:
 param(
     [string]$PublishUrl = "",
     [string]$PublishName = "",
+    [switch]$ValidateOnly,
     [switch]$Uninstall
 )
 
 $ErrorActionPreference = "Stop"
 $TaskName = "VibePulse tokenserver"
+
+if ($ValidateOnly -and $Uninstall) {
+    throw "-ValidateOnly and -Uninstall cannot be combined"
+}
+
+function Resolve-VibePulsePython {
+    # Task Scheduler inherits a much smaller PATH than an interactive shell.
+    # Resolve the real interpreter at install time and reject Python versions
+    # the tokenserver does not support instead of registering a task that can
+    # only fail after the next login.
+    $candidates = @()
+    $py = Get-Command py.exe -ErrorAction SilentlyContinue
+    if ($py) {
+        try {
+            $pyLauncher = $py.Source
+            $resolved = & $pyLauncher -3 -c `
+                "import sys; print(sys.executable if sys.version_info >= (3, 11) else '')"
+            if ($LASTEXITCODE -eq 0 -and $resolved) {
+                $candidates += $resolved.Trim()
+            }
+        } catch {
+            # Continue to explicit python.exe/python3.exe candidates.
+        }
+    }
+    foreach ($name in @("python.exe", "python3.exe")) {
+        $command = Get-Command $name -ErrorAction SilentlyContinue
+        if ($command) { $candidates += $command.Source }
+    }
+
+    foreach ($candidate in $candidates | Select-Object -Unique) {
+        try {
+            & $candidate -c `
+                "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)"
+            if ($LASTEXITCODE -eq 0) { return $candidate }
+        } catch {
+            # Try the next candidate and fail once with one actionable message.
+        }
+    }
+    throw "VibePulse requires Python 3.11 or newer. Install it, reopen PowerShell, and rerun this installer."
+}
 
 if ($Uninstall) {
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
@@ -54,25 +95,41 @@ if ($Uninstall) {
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 $Server = Join-Path $RepoRoot "tools\tokenserver\tokenserver.py"
 if (-not (Test-Path $Server)) { throw "hittar inte $Server" }
+$Runner = Join-Path $RepoRoot "tools\tokenserver\run-windows-task.ps1"
+if (-not (Test-Path $Runner)) { throw "hittar inte $Runner" }
 
-# pythonw = ingen konsol. Faller tillbaka till python.exe om pythonw
-# saknas (minimala installationer) — då syns ett fönster, men tjänsten kör.
-$Python = (Get-Command pythonw.exe -ErrorAction SilentlyContinue).Source
-if (-not $Python) { $Python = (Get-Command python.exe).Source }
+$PythonConsole = Resolve-VibePulsePython
+# Task Scheduler starts a hidden PowerShell wrapper. Keep python.exe rather
+# than pythonw.exe so stdout/stderr can be captured in the durable log.
+$PowerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
 
-$ServerArgs = "`"$Server`""
-if ($PublishUrl) {
-    $ServerArgs += " --publish `"$PublishUrl`""
-    if ($PublishName) { $ServerArgs += " --publish-name `"$PublishName`"" }
+if ($ValidateOnly) {
+    $Version = & $PythonConsole -c `
+        "import sys; print('.'.join(map(str, sys.version_info[:3])))"
+    Write-Host "VibePulse Windows installer validation: OK"
+    Write-Host "  repo:    $RepoRoot"
+    Write-Host "  server:  $Server"
+    Write-Host "  runner:  $Runner"
+    Write-Host "  python:  $PythonConsole ($Version)"
+    Write-Host "  action:  no Task Scheduler changes were made"
+    exit 0
 }
 
-$Action = New-ScheduledTaskAction -Execute $Python -Argument $ServerArgs `
+$RunnerArgs = "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass" +
+    " -File `"$Runner`" -Python `"$PythonConsole`" -Server `"$Server`""
+if ($PublishUrl) {
+    $RunnerArgs += " -PublishUrl `"$PublishUrl`""
+    if ($PublishName) { $RunnerArgs += " -PublishName `"$PublishName`"" }
+}
+
+$Action = New-ScheduledTaskAction -Execute $PowerShell -Argument $RunnerArgs `
     -WorkingDirectory $RepoRoot
 $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
 $Settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
     -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 5) `
-    -ExecutionTimeLimit (New-TimeSpan -Seconds 0)
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
+    -MultipleInstances StopExisting
 
 Register-ScheduledTask -TaskName $TaskName -Action $Action `
     -Trigger $Trigger -Settings $Settings -Force | Out-Null
@@ -82,5 +139,5 @@ Write-Host "Uppgiften '$TaskName' registrerad och startad."
 Write-Host "  server:  $Server"
 if ($PublishUrl) { Write-Host "  relä:    $PublishUrl" }
 Write-Host "  state:   $env:LOCALAPPDATA\VibePulse\"
-Write-Host "  logg:    ingen beständig bakgrundslogg; kör manuellt för felsökning"
+Write-Host "  logg:    $env:LOCALAPPDATA\VibePulse\Logs\torget-tokenserver.log"
 Write-Host "Verifiera:  curl http://localhost:8737/  (claudeProbe ska visa ok)"

--- a/tools/tokenserver/run-windows-task.ps1
+++ b/tools/tokenserver/run-windows-task.ps1
@@ -1,0 +1,107 @@
+<#
+Task Scheduler entrypoint for the VibePulse tokenserver.
+
+The scheduled task calls this wrapper instead of pythonw.exe directly so the
+normal unattended installation has a bounded diagnostic log. The wrapper
+contains no provider choices; tokenserver.py reads those from its saved config.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Python,
+    [Parameter(Mandatory = $true)]
+    [string]$Server,
+    [string]$PublishUrl = "",
+    [string]$PublishName = ""
+)
+
+$ErrorActionPreference = "Stop"
+$LogCapBytes = 5MB
+$LogTailBytes = 256KB
+
+if (-not (Test-Path -LiteralPath $Python -PathType Leaf)) {
+    throw "VibePulse Python interpreter is missing: $Python"
+}
+if (-not (Test-Path -LiteralPath $Server -PathType Leaf)) {
+    throw "VibePulse tokenserver is missing: $Server"
+}
+
+$LocalAppData = $env:LOCALAPPDATA
+if (-not $LocalAppData) {
+    $LocalAppData = Join-Path $env:USERPROFILE "AppData\Local"
+}
+$LogDir = Join-Path $LocalAppData "VibePulse\Logs"
+$LogPath = Join-Path $LogDir "torget-tokenserver.log"
+$OldLogPath = "$LogPath.old"
+New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+function Rotate-VibePulseLog {
+    if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) { return }
+    $Length = (Get-Item -LiteralPath $LogPath).Length
+    if ($Length -le $LogCapBytes) { return }
+
+    # The wrapper owns the append operation, so it can keep exactly one tail
+    # without renaming a file that Python still has open. This also works in
+    # Windows PowerShell 5.1 and for non-ASCII profile paths.
+    $InputStream = [System.IO.File]::Open(
+        $LogPath,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::Read
+    )
+    try {
+        $Keep = [Math]::Min([int64]$LogTailBytes, $InputStream.Length)
+        $InputStream.Seek(-$Keep, [System.IO.SeekOrigin]::End) | Out-Null
+        $Tail = New-Object byte[] $Keep
+        $Read = $InputStream.Read($Tail, 0, $Tail.Length)
+        if ($Read -lt $Tail.Length) {
+            $Tail = $Tail[0..($Read - 1)]
+        }
+        [System.IO.File]::WriteAllBytes($OldLogPath, $Tail)
+        $InputStream.SetLength(0)
+    } finally {
+        $InputStream.Dispose()
+    }
+}
+
+function Write-VibePulseLogLine {
+    param([AllowEmptyString()][string]$Text)
+    Rotate-VibePulseLog
+    [System.IO.File]::AppendAllText(
+        $LogPath,
+        $Text + [Environment]::NewLine,
+        $Utf8NoBom
+    )
+}
+
+Rotate-VibePulseLog
+
+$ServerArgs = @("-u", $Server)
+if ($PublishUrl) {
+    $ServerArgs += @("--publish", $PublishUrl)
+    if ($PublishName) { $ServerArgs += @("--publish-name", $PublishName) }
+}
+
+try {
+    # Merge the native streams into a low-volume line pipeline. The wrapper,
+    # rather than a permanently open redirect handle, can then enforce the
+    # size cap during a long-running task. Tokenserver deliberately logs state
+    # transitions instead of requests, so per-line appends stay cheap.
+    $PreviousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    & $Python @ServerArgs 2>&1 | ForEach-Object {
+        Write-VibePulseLogLine -Text $_.ToString()
+    }
+    $ExitCode = $LASTEXITCODE
+    $ErrorActionPreference = $PreviousErrorActionPreference
+    if ($null -eq $ExitCode) { $ExitCode = 1 }
+    exit $ExitCode
+} catch {
+    $ErrorActionPreference = "Stop"
+    $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    Write-VibePulseLogLine -Text (
+        "$Timestamp wrapper failure: $($_.Exception.GetType().Name): " +
+        $_.Exception.Message
+    )
+    throw
+}

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -59,7 +59,7 @@ _CODEX_VERSION = re.compile(
     r"\A(?:codex|codex-cli) [0-9]+\.[0-9]+\.[0-9]+"
     r"(?:-[0-9A-Za-z.-]+)?\n?\Z")
 _PYTHON_PROBE = (
-    "import sys; print('vibepulse-python-3.11+' "
+    "import sys; print('vibepulse-python-3.11+'"
     "if sys.version_info >= (3, 11) else 'unsupported')")
 
 


### PR DESCRIPTION
## Outcome

Adds a reproducible Windows release gate, bounded Task Scheduler logs, a non-mutating installer validation mode, and an explicit macOS/Windows/Linux evidence matrix. Linux stays unsupported until its real host and systemd gates pass.

Also fixes the Windows doctor false-negative for healthy Python 3.11+ and records the read-only v0.7.1 PC baseline without turning missing panel evidence into a pass.

## Verification

- Full local host gate passed, including 778 tokenserver tests
- Focused setup probe and relay-boundary tests passed
- Workflow YAML parsed and git diff check passed
- Windows CI now parses both PowerShell files, runs ValidateOnly, and exercises stdout/stderr capture, rotation, spaces, and a non-ASCII path

## Not tested / remaining risk

- The new scheduled task has not yet been installed and lifecycle-tested on a real Windows PC
- External LAN reachability and the physical panel answer loop remain unverified on Windows
- Linux service support is intentionally not implemented or claimed in this PR

Closes no platform issue yet. Keep #28 open until the real scheduled-task lifecycle passes; keep #2 open until Linux meets the documented gate.