### PR TITLE
Fix Windows Codex CLI discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   document private reporting, secret handling, platform-claim discipline, and
   the difference between CI, real-host, and physical-panel validation.
 
+### Fixed
+
+- Windows Codex discovery now prefers OpenAI's standalone per-user CLI and
+  rejects Store-managed `WindowsApps` aliases that can resolve successfully
+  but fail with Access Denied under Task Scheduler or other background hosts.
+  The README and tokenserver guide include the official install and doctor
+  verification commands.
+
 ## v0.7.1 — 2026-08-27
 
 Release notes:

--- a/README.md
+++ b/README.md
@@ -640,8 +640,16 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   For autostart, run the shipped Task Scheduler installer from the repo root:
   `powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1`.
   It runs as your signed-in user, starts immediately, restarts on failure, and
-  keeps interaction-provider choices in the tokenserver's saved config. The
-  background task writes bounded stdout/stderr to
+  keeps interaction-provider choices in the tokenserver's saved config.
+  The Codex desktop app alone is not enough for the background quota read:
+  its Store-managed `codex` alias can resolve but still be denied by Windows.
+  Install OpenAI's standalone CLI once in PowerShell:
+  `powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"`.
+  VibePulse prefers its stable per-user executable under
+  `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin` and ignores `WindowsApps`
+  aliases. Open a new PowerShell window, run `codex --version`, then rerun
+  `python tools\vibepulse_setup.py doctor`. The background task writes bounded
+  stdout/stderr to
   `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; the server's
   rotation guard keeps one `.old` tail. Use `-ValidateOnly` to verify the
   checkout and Python 3.11+ interpreter without changing Task Scheduler.

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1346,6 +1346,19 @@ class PluginPackageTests(unittest.TestCase):
 
 
 class SetupPlanTests(unittest.TestCase):
+    def test_auto_executable_resolution_uses_shared_codex_resolver(self):
+        setup = load_setup()
+        expected = Path(
+            r"C:\Users\Tester\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe")
+        with mock.patch.object(
+                setup, "resolve_codex_executable",
+                return_value=str(expected)):
+            python, codex = setup._resolve_executables(
+                setup._AUTO, setup._AUTO)
+
+        self.assertEqual(python, Path(sys.executable))
+        self.assertEqual(codex, expected)
+
     def test_real_python_probe_has_the_exact_cross_platform_sentinel(self):
         """A stray space made healthy Python 3.12 fail doctor on Windows."""
         setup = load_setup()

--- a/test/tokenserver-suite.txt
+++ b/test/tokenserver-suite.txt
@@ -11,6 +11,7 @@ tools.tokenserver.test_quota_cache
 tools.tokenserver.test_max_tracker
 tools.tokenserver.test_value_meter
 tools.tokenserver.test_update_prices
+tools.tokenserver.test_codex_command
 tools.tokenserver.test_codex_usage
 tools.tokenserver.test_vibepulse_config
 tools.tokenserver.test_codex_interactions

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -338,6 +338,23 @@ läser dess stdout; det gjordes förut med `select.select`, som på Windows
 bara tar sockets — aldrig pipes. Läsningen sker nu i en läsartråd med kö,
 samma kod på alla plattformar.
 
+Codex skrivbordsapp och Codex CLI är två olika installationsytor på Windows.
+Store-appens `codex`-alias kan synas för `Get-Command` men ändå nekas när en
+bakgrundsuppgift försöker starta det. Installera därför OpenAI:s fristående
+CLI en gång i PowerShell:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"
+```
+
+Öppna därefter ett nytt PowerShell-fönster och verifiera `codex --version`.
+VibePulse föredrar installerarens stabila användarsökväg
+`%LOCALAPPDATA%\Programs\OpenAI\Codex\bin\codex.exe` framför `PATH` och
+ignorerar avsiktligt `WindowsApps`-alias. Kör
+`python tools\vibepulse_setup.py doctor` efter installationen; ett grönt
+`PASS Codex executable` betyder att samma körbara CLI kan användas av
+setupverktyget och tokenserverns app-serverläsning.
+
 Tillståndsfilerna (lås, probestatus, kvotcache, historik, max-spårare) bor
 under `%LOCALAPPDATA%\VibePulse\` i stället för macOS
 `~/Library/Application Support/VibePulse`. Sökvägarna fungerade bokstavligt

--- a/tools/tokenserver/codex_command.py
+++ b/tools/tokenserver/codex_command.py
@@ -1,0 +1,56 @@
+"""Resolve the Codex CLI without mistaking a Windows app alias for it."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import sys
+from typing import Callable, Mapping
+
+
+def _is_windows_app_path(path: str | os.PathLike[str]) -> bool:
+    """Return true for Store-managed paths background jobs cannot trust."""
+    normalized = str(path).replace("/", "\\").casefold()
+    bounded = "\\" + normalized.strip("\\") + "\\"
+    return "\\windowsapps\\" in bounded
+
+
+def resolve_codex_executable(
+        *, platform: str | None = None,
+        environ: Mapping[str, str] | None = None,
+        which: Callable[[str], str | None] = shutil.which,
+        is_file: Callable[[str | os.PathLike[str]], bool] = os.path.isfile,
+        ) -> str | None:
+    """Return a background-safe Codex CLI path for this host.
+
+    OpenAI's standalone Windows installer owns a stable per-user path. It is
+    checked before ``PATH`` because the desktop app may also register an app
+    alias named ``codex``. That alias can resolve while still failing with
+    Access Denied outside the interactive app environment.
+    """
+    current_platform = sys.platform if platform is None else platform
+    current_environ = os.environ if environ is None else environ
+
+    if current_platform == "win32":
+        local_app_data = current_environ.get("LOCALAPPDATA")
+        if local_app_data:
+            standalone = (Path(local_app_data) / "Programs" / "OpenAI" /
+                          "Codex" / "bin" / "codex.exe")
+            if is_file(standalone):
+                return str(standalone)
+
+    executable = which("codex")
+    if executable:
+        if current_platform == "win32" and _is_windows_app_path(executable):
+            return None
+        return executable
+
+    if current_platform == "darwin":
+        for candidate in (
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
+            "/Applications/Codex.app/Contents/Resources/codex",
+        ):
+            if is_file(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+    return None

--- a/tools/tokenserver/test_codex_command.py
+++ b/tools/tokenserver/test_codex_command.py
@@ -1,0 +1,52 @@
+"""Tests for background-safe Codex CLI discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+try:
+    from .codex_command import resolve_codex_executable
+except ImportError:
+    from codex_command import resolve_codex_executable
+
+
+class CodexCommandTests(unittest.TestCase):
+    def test_windows_prefers_official_standalone_over_app_alias(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            expected = (Path(temp_dir) / "Programs" / "OpenAI" / "Codex" /
+                        "bin" / "codex.exe")
+            expected.parent.mkdir(parents=True)
+            expected.touch()
+
+            found = resolve_codex_executable(
+                platform="win32", environ={"LOCALAPPDATA": temp_dir},
+                which=lambda _name: (
+                    r"C:\Program Files\WindowsApps\OpenAI.Codex\codex.exe"))
+
+        self.assertEqual(found, str(expected))
+
+    def test_windows_rejects_store_managed_alias(self):
+        found = resolve_codex_executable(
+            platform="win32", environ={},
+            which=lambda _name: (
+                r"C:\Users\Tester\AppData\Local\Microsoft\WindowsApps\codex.exe"))
+        self.assertIsNone(found)
+
+    def test_windows_rejects_packaged_app_binary(self):
+        found = resolve_codex_executable(
+            platform="win32", environ={},
+            which=lambda _name: (
+                r"C:\Program Files\WindowsApps\OpenAI.Codex_1.0\codex.exe"))
+        self.assertIsNone(found)
+
+    def test_normal_path_command_is_accepted(self):
+        found = resolve_codex_executable(
+            platform="linux", environ={},
+            which=lambda _name: "/usr/local/bin/codex")
+        self.assertEqual(found, "/usr/local/bin/codex")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1130,6 +1130,14 @@ class CodexLimitLogTests(unittest.TestCase):
         self.assertEqual(reset_min, 60)
         self.assertEqual(window_min, 10080)
 
+    def test_app_server_uses_shared_codex_resolver(self):
+        expected = (
+            r"C:\Users\Tester\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe")
+        with mock.patch.object(
+                tokenserver, "resolve_codex_executable",
+                return_value=expected):
+            self.assertEqual(tokenserver._codex_app_server_command(), expected)
+
     def _fake_app_server(self, temp_dir, body):
         """Ett körbart som talar app-server-protokollet på stdin/stdout.
 

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -42,7 +42,6 @@ import os
 import queue
 import re
 import select
-import shutil
 import socket
 import stat
 import subprocess
@@ -69,6 +68,7 @@ except ImportError:  # macOS/Linux
 
 if __package__:
     from .agent_status import AgentStatusService
+    from .codex_command import resolve_codex_executable
     from .codex_interactions import (
         codex_permission_response,
         codex_question_result,
@@ -92,6 +92,7 @@ if __package__:
     from . import codex_usage, interactions, value_meter
 else:  # direktkörning: python3 tools/tokenserver/tokenserver.py
     from agent_status import AgentStatusService
+    from codex_command import resolve_codex_executable
     from codex_interactions import (
         codex_permission_response,
         codex_question_result,
@@ -1468,16 +1469,7 @@ def _parse_codex_rate_limits_response(body, observed_at, now_ts):
 
 
 def _codex_app_server_command():
-    executable = shutil.which("codex")
-    if executable:
-        return executable
-    for candidate in (
-        "/Applications/ChatGPT.app/Contents/Resources/codex",
-        "/Applications/Codex.app/Contents/Resources/codex",
-    ):
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return None
+    return resolve_codex_executable()
 
 
 def _pump_lines(stream):

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -13,7 +13,6 @@ import re
 import secrets
 import selectors
 import signal
-import shutil
 import stat
 import subprocess
 import sys
@@ -35,6 +34,7 @@ from tokenserver.vibepulse_config import (  # noqa: E402
     load_config,
     save_config,
 )
+from tokenserver.codex_command import resolve_codex_executable  # noqa: E402
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -1410,7 +1410,13 @@ def _doctor(
         print("OFF Codex executable: provider intentionally disabled",
               file=stdout)
     elif codex is None:
-        print("FIX Codex executable: install or expose codex on PATH", file=stdout)
+        if sys.platform == "win32":
+            print("FIX Codex executable: install the standalone Codex CLI; "
+                  "the Windows desktop app alias is not background-safe",
+                  file=stdout)
+        else:
+            print("FIX Codex executable: install or expose codex on PATH",
+                  file=stdout)
         fixes = True
     else:
         codex_ok = _codex_probe_ok(codex, run)
@@ -1565,7 +1571,7 @@ def _resolve_executables(python, codex):
     python_path = (Path(sys.executable) if python is _AUTO else
                    (None if python is None else Path(python)))
     if codex is _AUTO:
-        found = shutil.which("codex")
+        found = resolve_codex_executable()
         codex_path = Path(found) if found else None
     else:
         codex_path = None if codex is None else Path(codex)


### PR DESCRIPTION
## What changed

- prefer OpenAI's standalone per-user Codex CLI on Windows
- reject Store-managed `WindowsApps` aliases that can resolve but fail in background hosts
- share the resolver between setup doctor and tokenserver app-server reads
- document the official Windows installer and recovery check

## Verification

- `./test/run.sh` — PASS (783 Python tests plus C, simulator, relay, typecheck, and host gates)
- `test/test_vibepulse_codex_plugin.py` — PASS (108 tests)
- `git diff --check` — PASS

## Remaining physical gate

The real Windows PC must still approve the official standalone CLI installation and then pass `codex --version`, VibePulse doctor, live app-server quota, and the physical panel loop. Silence is not a pass.