### PR TITLE
Fix real Windows Task Scheduler install and document recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- Windows Task Scheduler installation now uses the Windows 10-compatible
+  `IgnoreNew` instance policy and explicitly stops only its own running task
+  during an idempotent update; the previous `StopExisting` enum value parsed
+  but failed before registration on a real Windows 10 host.
+- Add a public Windows host installation, startup-health, troubleshooting,
+  recovery, and physical-validation runbook for developers and coding agents.
 - Windows Codex discovery now prefers OpenAI's standalone per-user CLI and
   rejects Store-managed `WindowsApps` aliases that can resolve successfully
   but fail with Access Denied under Task Scheduler or other background hosts.

--- a/README.md
+++ b/README.md
@@ -331,7 +331,9 @@ reported as current.
   that computer; the optional relays remove the same-WiFi requirement. The
   exact support/evidence boundary is maintained in
   **[Host platform support](docs/platform-support.md)**; Windows release
-  candidates use the reproducible
+  installation and recovery use the public
+  **[Windows host runbook](docs/windows-setup.md)**, while release candidates
+  use the reproducible
   **[Windows validation gate](docs/windows-validation.md)**.
 - **Claude Code and/or Codex.** Either alone is fine.
 - **2.4 GHz WiFi.** The ESP32-S3 can't see 5 GHz networks.
@@ -356,8 +358,9 @@ understand how the pieces fit together.
 ## Setup, the manual way
 
 The commands below show the macOS path. Windows is supported for the host
-service too; use the Windows ESP-IDF environment and the OS-specific host
-address/autostart steps in [the agent runbook](docs/agent-setup.md).
+service too; use the Windows ESP-IDF environment and the OS-specific
+[Windows host runbook](docs/windows-setup.md) for the standalone Codex CLI,
+host address, firewall, Task Scheduler, startup health, and recovery steps.
 
 1. Install [ESP-IDF 5.5](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/get-started/index.html)
    and `brew install cmake ninja`
@@ -652,7 +655,9 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   stdout/stderr to
   `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; the server's
   rotation guard keeps one `.old` tail. Use `-ValidateOnly` to verify the
-  checkout and Python 3.11+ interpreter without changing Task Scheduler.
+  checkout and Python 3.11+ interpreter without changing Task Scheduler. The
+  complete install, hook-review, firewall, startup-health, physical-test, and
+  recovery procedure is the [Windows host runbook](docs/windows-setup.md).
 - **Linux for the tokenserver?** Not yet —
   [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2). The Ubuntu
   tokenserver CI lane is portability evidence, not a support claim: current

--- a/README.sv.md
+++ b/README.sv.md
@@ -154,6 +154,13 @@ eftersom Claude Desktop kan fortsätta vara inloggad efter att den separata
 credential VibePulse får läsa har blivit för gammal; gammal Fable-data märks
 alltid som stale.
 
+På Windows finns en komplett publik
+[installations- och återställningsguide](docs/windows-setup.md) för den
+fristående Codex CLI:n, hookgranskning, Task Scheduler, Private-brandvägg,
+startup-hälsa och den fysiska slutgrinden. Den är skriven så att en ny
+utvecklare eller kodagent kan göra installationen utan underhållarens lokala
+historik.
+
 Efter firmware- eller Codex-bridgeändringar ska den fysiska rökkontrollen i
 [agent-setup](docs/agent-setup.md#post-flash-physical-codex-smoke-test) köras.
 Godkänt kräver synlig **APPROVE**, ett verkligt tryck på panelen och samma svar

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -8,6 +8,11 @@ deeper documentation is Swedish, which is fine to read as-is.
 Work through **Preflight** first — half of all setup failures are decided
 there.
 
+For a Windows host, keep
+[Windows host setup and recovery](windows-setup.md) open beside this hardware
+runbook. It covers the standalone Codex CLI, Task Scheduler, Private firewall,
+startup health, lifecycle proof, and the exact public evidence boundary.
+
 ## What is not part of this repo
 
 `AGENTS.md`, `README.sv.md` and some code comments refer to things the
@@ -209,6 +214,9 @@ Optional plan badges: `--claude-plan {pro,max5x,max20x}`, `--codex-plan
 {plus,pro}`. Cosmetic labels only, never used in any percentage maths.
 
 For autostart on login, see [../tools/tokenserver/README.md](../tools/tokenserver/README.md).
+Windows installers should follow the complete
+[Windows host runbook](windows-setup.md), not copy a Task Scheduler command in
+isolation.
 
 ## Step 5 — end-to-end
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,35 @@ point at the backlog item.
 
 ---
 
+## 2026-08-27 · CI parsed a Task Scheduler value the real PC rejected
+
+**What happened:** the installer parsed and `-ValidateOnly` passed in CI, but
+the first real installation stopped before task registration. **Root cause:**
+`-MultipleInstances StopExisting` is valid in the Task Scheduler schema but
+is not a member of Windows 10's ScheduledTasks PowerShell enum, which exposes
+only `Parallel`, `Queue`, and `IgnoreNew`. **The rule:** parser success proves
+syntax, not runtime compatibility; every service definition needs a real-host
+install/update/start cycle. **Guards:** the installer now explicitly stops its
+own running task during an update and uses the broadly supported `IgnoreNew`
+policy; the boundary test locks both behaviors and the Windows release gate
+requires the real lifecycle. **Watch for:** parameters that exist in XML or
+newer documentation but not in the target OS module.
+
+## 2026-08-27 · A visible Windows Codex command was not a runnable CLI
+
+**What happened:** Codex worked in the Windows desktop app and `Get-Command`
+could resolve `codex`, but the VibePulse background read failed and a local
+wrapper reported that the CLI was missing. **Root cause:** Windows exposed a
+Store-managed `WindowsApps` alias that was not executable from the scheduled
+background context; Task Scheduler also inherits a smaller `PATH` than an
+interactive shell. **The rule:** Windows provider validation must execute the
+standalone CLI from its stable per-user path and prove the app-server quota
+read, not merely resolve a command name. **Guards:** executable discovery now
+prefers `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin\codex.exe`, ignores
+`WindowsApps`, doctor tests execution, and the public Windows runbook separates
+desktop login, CLI execution, and fresh quota evidence. **Watch for:** wrappers
+or scheduled tasks that reintroduce interactive-`PATH` assumptions.
+
 ## 2026-08-27 · A green build from an old tree hid the panel test
 
 **What happened:** the panel first showed **UPDATE READY**, then questions with

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -1,0 +1,294 @@
+# Windows host setup and recovery
+
+This is the public installation runbook for the VibePulse **Windows host**.
+It is written so that a developer or coding agent can install, diagnose, and
+verify the service without access to the maintainer's computer or history.
+For release certification, continue with
+[Windows release validation](windows-validation.md); installation success is
+not the same as a physical end-to-end release pass.
+
+The commands below must run as the Windows user who actually uses Claude Code
+or Codex. Do not install the service as `SYSTEM`: VibePulse deliberately reads
+that user's local credentials, Codex sessions, configuration, and state.
+
+## 1. Install the host prerequisites
+
+Open PowerShell and verify:
+
+```powershell
+git --version
+py -3 -c "import sys; print(sys.version); raise SystemExit(0 if sys.version_info >= (3, 11) else 1)"
+```
+
+VibePulse requires Git and Python 3.11 or newer. Clone the repository into a
+stable path that will still exist after the next sign-in:
+
+```powershell
+git clone https://github.com/niclasvestlund-YT/vibepulse.git $HOME\vibepulse
+Set-Location $HOME\vibepulse
+git status --short
+```
+
+The last command should be empty. Task Scheduler records this checkout's
+absolute path, so moving or deleting it later breaks autostart until the
+installer is rerun from the new path.
+
+### Codex needs the standalone CLI
+
+The Codex desktop app and the background-safe Codex CLI are separate Windows
+installation surfaces. A Store-managed `WindowsApps` alias can appear in
+`Get-Command codex` and still fail with access denied from a background task.
+Install OpenAI's standalone CLI:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://chatgpt.com/codex/install.ps1 | iex"
+```
+
+Close PowerShell, open a new one, and verify both execution and login:
+
+```powershell
+codex --version
+codex login status
+```
+
+VibePulse prefers
+`%LOCALAPPDATA%\Programs\OpenAI\Codex\bin\codex.exe` and ignores
+`WindowsApps` aliases. Do not point `AVIARY_CODEX_BIN` at a Store alias; if a
+local wrapper reports `codex CLI not found on PATH`, fix the standalone CLI
+installation or set that variable to the real standalone executable.
+
+Claude users should also sign in with Claude Code on this Windows account.
+Windows stores the readable OAuth record under
+`%USERPROFILE%\.claude\.credentials.json`; never paste that file into an
+issue or validation report.
+
+## 2. Choose the interaction providers explicitly
+
+Quota display works independently of panel interactions. To install the
+optional Codex plugin/MCP bridge and enable Codex questions with bounded
+detail:
+
+```powershell
+Set-Location $HOME\vibepulse
+py -3 tools\vibepulse_setup.py install --providers codex --detail
+py -3 tools\vibepulse_setup.py status
+py -3 tools\vibepulse_setup.py doctor
+```
+
+Use `--providers claude`, `both`, or `off` when that is the intended scope.
+Installing the plugin does **not** enable the encrypted relay, agent-status
+relay, GitHub, or another provider.
+
+Open Codex, run `/hooks`, and review the exact VibePulse `SessionStart` and
+`PermissionRequest` commands before trusting them. Then start a **new Codex
+task** so the hook, skill, and MCP tool are loaded from a fresh session. Doctor
+can report that review is needed, but it never bypasses Codex trust.
+
+Expected healthy doctor lines for a Codex installation include:
+
+```text
+PASS Python executable
+PASS Codex executable
+PASS Codex plugin
+PASS Codex MCP
+PASS Tokenserver
+```
+
+Provider choices are saved under `%LOCALAPPDATA%\VibePulse\`; they do not
+belong in the Task Scheduler command, where an old choice could silently win
+after setup changes.
+
+## 3. Validate and install autostart
+
+First verify the exact interpreter, checkout, and runtime construction of the
+ScheduledTasks action, trigger, and settings without changing Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+```
+
+Then install the signed-in user's scheduled task:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1
+Get-ScheduledTask -TaskName "VibePulse tokenserver" |
+  Select-Object TaskName, State
+Get-ScheduledTaskInfo -TaskName "VibePulse tokenserver"
+```
+
+The installer resolves a real Python 3.11+ executable at install time because
+Task Scheduler has a smaller `PATH` than interactive PowerShell. It starts the
+service immediately, restarts it after failure, and writes a bounded log to:
+
+```text
+%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log
+```
+
+The wrapper and running service keep the log near 5 MB and preserve one `.old`
+tail. A missing log means the scheduled process did not reach its logging
+entry point. A traceback is a bug worth reporting; do not include credentials,
+prompts, commands, or raw session data in the report.
+
+Verify startup identity rather than merely seeing a Python process:
+
+```powershell
+$Health = Invoke-RestMethod http://127.0.0.1:8737/
+$Health | Select-Object service, rev, srcFingerprint, startedAt,
+  claudeProbe, claudeCredential,
+  @{Name='panel'; Expression={$_.interactions.panel}}
+py -3 tools\tokenserver\smoke.py
+```
+
+`smoke.py` exits `0` for healthy, `1` for warnings, and `2` for failures. The
+root endpoint exposes content-free health only. `rev` and `srcFingerprint`
+answer which checkout and source are actually running; they catch the common
+case where an old scheduled task serves code from another worktree.
+
+The startup panel state is evidence, not decoration:
+
+- `waiting`: no confirmed non-loopback panel poll yet;
+- `ready`: two recent panel polls from the same client were observed;
+- `stale`: the panel was confirmed earlier but is no longer polling recently.
+
+Never turn `waiting` or `stale` into a pass.
+
+## 4. Choose direct LAN or the optional encrypted relay
+
+For direct LAN, find the active Private-network IPv4 address:
+
+```powershell
+Get-NetConnectionProfile | Select-Object Name, NetworkCategory
+ipconfig
+```
+
+Reserve that IPv4 address in the router. Windows does not yet provide the
+stable `.local` discovery tracked in
+[#7](https://github.com/niclasvestlund-YT/vibepulse/issues/7), so firmware
+compiled with an old DHCP address eventually shows dashes.
+
+Inspect before changing the firewall:
+
+```powershell
+Get-NetFirewallRule -ErrorAction SilentlyContinue |
+  Where-Object DisplayName -Like "*VibePulse*" |
+  Select-Object DisplayName, Enabled, Direction, Action, Profile
+```
+
+If direct LAN is required and no rule exists, run elevated PowerShell and open
+only TCP 8737 on Private networks:
+
+```powershell
+New-NetFirewallRule -DisplayName "VibePulse tokenserver" -Direction Inbound `
+  -Protocol TCP -LocalPort 8737 -Action Allow -Profile Private
+```
+
+Never open the Public profile. From another device on the same LAN, test the
+PC's real address—not `localhost`:
+
+```powershell
+Test-NetConnection -ComputerName <PC-LAN-IP> -Port 8737
+```
+
+The optional interaction relay can bridge unrelated Wi-Fi using outbound
+HTTPS, but it is a separate, explicit, end-to-end encrypted setup. Follow
+[Interaction relay](interaction-relay.md); plugin installation alone never
+enables it.
+
+## 5. Verify the providers without exposing account data
+
+Run the read-only diagnostics:
+
+```powershell
+py -3 tools\vibepulse_setup.py doctor
+$Tokens = Invoke-RestMethod http://127.0.0.1:8737/api/tokens
+$Tokens | Select-Object v, claudeWeekStale, claudeModelWeekStale,
+  codexWeekStale
+```
+
+Do not paste the full endpoint into an issue. Report only presence/type,
+staleness, safe status, and revisions.
+
+Two failures that look similar are intentionally separate:
+
+- Claude can remain logged in while the exported usage credential readable by
+  VibePulse has expired. Check both `claudeCredential` and `claudeProbe`;
+  Fable/Opus remains honestly stale until a supported Claude client refreshes
+  the readable credential.
+- Codex can be logged in through the desktop app while the Store alias is not
+  executable by the background service. `PASS Codex executable` plus a fresh
+  `codexWeekStale: false` proves the standalone CLI/app-server path instead.
+
+## 6. Close the physical loop
+
+Before a panel test, compare the firmware build checkout's
+`git describe --tags --always --dirty` with the service's
+`otaAvailableVersion`. A valid build from an old worktree can immediately show
+**UPDATE READY** and invalidate the test.
+
+Use this exact Codex question:
+
+- header: `Test`
+- question: `Ser du APPROVE?`
+- `Ja` — `APPROVE syns` — recommended
+- `Nej` — `APPROVE saknas`
+
+Pass only when the panel visibly shows **APPROVE**, a human taps it, and the
+waiting call returns `status: answered`, `option_index: 0`, `answer: Ja`.
+Silence, timeout, panel absence, **LEAVE IT**, computer fallback, or
+**SOMETHING IS WAITING** without buttons is `FAIL` or `NOT TESTED`, never an
+implicit approval.
+
+## 7. Prove lifecycle recovery
+
+Before announcing Windows support, verify all of these against the exact
+candidate under test:
+
+1. the task starts immediately after installation;
+2. terminating only the tokenserver process produces an automatic restart;
+3. sign-out/sign-in starts it again;
+4. sleep/resume restores fresh endpoints and panel polling;
+5. one full Windows reboot restores the task, current provider sources, recent
+   panel polling, and the physical question path.
+
+Record each row as `PASS`, `FAIL`, or `NOT TESTED`. A green unit-test suite or
+`State: Ready` in Task Scheduler does not substitute for these lifecycle and
+physical checks.
+
+## Recovery and removal
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `codex_wrap: codex CLI not found on PATH` | A local wrapper cannot find the standalone CLI | Reopen PowerShell after installing the CLI; point `AVIARY_CODEX_BIN` only at the real standalone executable if the wrapper requires it |
+| `Get-Command codex` works but VibePulse gets access denied | WindowsApps/Store alias | Install the standalone CLI and rerun doctor |
+| `FIX Python executable` | Python is older than 3.11 or Task Scheduler cannot resolve it | Install current Python, reopen PowerShell, rerun `-ValidateOnly`, then reinstall the task |
+| `FIX Codex plugin` or `FIX Codex MCP` | Optional integration is absent or stale | Rerun setup install for the intended provider; review `/hooks`; start a new Codex task |
+| Hooks say `need review` | New or changed commands have not been trusted | Inspect exact commands in `/hooks`; never bypass trust automatically |
+| Root endpoint is healthy but panel is `waiting` | Wrong PC address, firewall, client isolation, relay off, or panel elsewhere | Test the real LAN IP from another device; verify saved relay state separately |
+| Only **LEAVE IT** appears | No single option was explicitly recommended | Use the canonical short smoke question with exactly one genuine recommendation |
+| **SOMETHING IS WAITING** has no buttons | The request failed the physical fit/privacy gate | Finish on the computer; do not count it as a panel pass |
+| Fable is stale while Claude still works | Login state and readable usage credential diverged | Inspect `claudeCredential`, `claudeProbe`, and `claudeLocalUsage`; refresh through a supported Claude client |
+| Task runs old code | Installer still points at an older checkout | Compare `rev`/`srcFingerprint`, rerun the installer from the intended stable checkout |
+| No scheduled-task log | Wrapper never started or its recorded path/interpreter disappeared | Inspect task action/result; rerun `-ValidateOnly` and reinstall from the stable checkout |
+
+Disable only a provider while preserving the package:
+
+```powershell
+py -3 tools\vibepulse_setup.py disable codex
+```
+
+Remove only the optional Codex integration:
+
+```powershell
+py -3 tools\vibepulse_setup.py uninstall codex
+```
+
+Remove autostart without deleting state, the repository, or a running process:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -Uninstall
+```
+
+Keep secrets and private state out of commits and reports. A useful public
+failure report contains Windows/Python/Codex versions, the exact VibePulse
+revision, safe doctor/smoke lines, scheduled-task state/result, filtered root
+health, and the narrow physical outcome—nothing from credentials or sessions.

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -4,6 +4,11 @@ This is the release gate for VibePulse's Windows **host service**. It does not
 flash the ESP32 and must not print credentials, session contents, prompts, or
 other secrets into the report.
 
+New installations should first complete
+[Windows host setup and recovery](windows-setup.md). This document is the
+stricter certification pass: it deliberately repeats critical checks against
+an exact clean candidate and adds lifecycle plus physical evidence.
+
 Run the procedure from PowerShell as the Windows user who actually runs Codex
 or Claude Code. The tokenserver reads that user's profile, so testing as
 Administrator or SYSTEM proves the wrong installation.
@@ -65,8 +70,9 @@ $Errors
 ```
 
 The parser must return no errors. `-ValidateOnly` must report the exact checkout
-and a Python 3.11+ interpreter, and must say that it made no Task Scheduler
-changes.
+and a Python 3.11+ interpreter, construct the action, trigger, and settings
+through the host's real ScheduledTasks module, and say that it made no Task
+Scheduler changes.
 
 ## 5. Exercise the real local sources on a temporary port
 

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -214,7 +214,11 @@ assert "$LogCapBytes = 5MB" in windows_runner
 assert "$LogTailBytes = 256KB" in windows_runner
 assert "Write-VibePulseLogLine" in windows_runner
 assert "run-windows-task.ps1" in windows_service
-assert "-MultipleInstances StopExisting" in windows_service
+assert "-MultipleInstances IgnoreNew" in windows_service
+assert "Stop-ScheduledTask -TaskName $TaskName" in windows_service
+assert windows_service.index("New-ScheduledTaskSettingsSet") < \
+    windows_service.index("if ($ValidateOnly) {")
+assert "task objects: runtime construction passed" in windows_service
 assert "Validate the Windows Task Scheduler installer without installing" in ci
 assert ".\\tools\\tokenserver\\install-windows-task.ps1 -ValidateOnly" in ci
 assert ".\\test\\windows-task-runner.ps1" in ci

--- a/tools/tokenserver/install-windows-task.ps1
+++ b/tools/tokenserver/install-windows-task.ps1
@@ -103,18 +103,6 @@ $PythonConsole = Resolve-VibePulsePython
 # than pythonw.exe so stdout/stderr can be captured in the durable log.
 $PowerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
 
-if ($ValidateOnly) {
-    $Version = & $PythonConsole -c `
-        "import sys; print('.'.join(map(str, sys.version_info[:3])))"
-    Write-Host "VibePulse Windows installer validation: OK"
-    Write-Host "  repo:    $RepoRoot"
-    Write-Host "  server:  $Server"
-    Write-Host "  runner:  $Runner"
-    Write-Host "  python:  $PythonConsole ($Version)"
-    Write-Host "  action:  no Task Scheduler changes were made"
-    exit 0
-}
-
 $RunnerArgs = "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass" +
     " -File `"$Runner`" -Python `"$PythonConsole`" -Server `"$Server`""
 if ($PublishUrl) {
@@ -129,7 +117,35 @@ $Settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
     -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 5) `
     -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
-    -MultipleInstances StopExisting
+    -MultipleInstances IgnoreNew
+
+# ValidateOnly deliberately constructs every ScheduledTasks object before it
+# exits. PowerShell parser success did not catch a real-host enum mismatch;
+# this dry run now exercises the module's runtime parameter conversion while
+# still avoiding task lookup, registration, start, stop, or removal.
+if ($ValidateOnly) {
+    $Version = & $PythonConsole -c `
+        "import sys; print('.'.join(map(str, sys.version_info[:3])))"
+    Write-Host "VibePulse Windows installer validation: OK"
+    Write-Host "  repo:    $RepoRoot"
+    Write-Host "  server:  $Server"
+    Write-Host "  runner:  $Runner"
+    Write-Host "  python:  $PythonConsole ($Version)"
+    Write-Host "  task objects: runtime construction passed"
+    Write-Host "  action:  no Task Scheduler changes were made"
+    exit 0
+}
+
+# Windows 10's ScheduledTasks PowerShell module does not expose the task
+# schema's StopExisting policy; its enum contains only Parallel, Queue and
+# IgnoreNew. Stop the exact old task explicitly during an idempotent update,
+# then use the broadly supported IgnoreNew policy to prevent duplicate
+# long-running tokenservers during ordinary triggers.
+$ExistingTask = Get-ScheduledTask -TaskName $TaskName `
+    -ErrorAction SilentlyContinue
+if ($ExistingTask -and $ExistingTask.State -eq "Running") {
+    Stop-ScheduledTask -TaskName $TaskName
+}
 
 Register-ScheduledTask -TaskName $TaskName -Action $Action `
     -Trigger $Trigger -Settings $Settings -Force | Out-Null


### PR DESCRIPTION
## Summary

- replace the Windows 10-incompatible `StopExisting` ScheduledTasks enum with `IgnoreNew`
- explicitly stop only the running VibePulse task during an idempotent update
- make `-ValidateOnly` construct the real action, trigger, and settings so Windows CI covers runtime parameter conversion without mutating Task Scheduler
- add a public Windows installation/recovery runbook for developers and coding agents
- record the Codex CLI alias, Task Scheduler, credential-staleness, panel-fit, and fail-closed lessons

## Why

The first real Windows lifecycle run passed the clean checkout, host suite, endpoints, and standalone Codex app-server source, but the actual task installation failed before registration. Windows 10's ScheduledTasks PowerShell module accepts only `Parallel`, `Queue`, or `IgnoreNew`; parser-only CI had allowed `StopExisting` through.

## Evidence

- `PYTHON_BIN=<Python 3.12 venv> ./test/run.sh --skip-js`: 783 tests, 1 platform skip, 0 failures/errors
- `python test/test_relay_boundary.py`: PASS
- `python test/test_vibepulse_codex_plugin.py`: 108 tests, PASS
- real Windows 10 pre-fix install: reproducible FAIL before registration on `StopExisting`
- post-fix real-host install/lifecycle/physical validation will be attached before the support verdict is upgraded

No credential, token, prompt, session content, or private panel payload is included.
