### PR TITLE
Fix and validate Windows host-service gates

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/permission_hook.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/permission_hook.py
@@ -80,8 +80,11 @@ def main():
             f"http://127.0.0.1:{port}/api/codex/permission", event,
             read_timeout=_read_timeout())
         if _valid_decision(result):
-            sys.stdout.write(json.dumps(
-                result, ensure_ascii=False, separators=(",", ":")) + "\n")
+            encoded = (json.dumps(
+                result, ensure_ascii=False, separators=(",", ":")) +
+                "\n").encode("utf-8")
+            sys.stdout.buffer.write(encoded)
+            sys.stdout.buffer.flush()
     except Exception:
         pass
     return 0

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -37,8 +37,11 @@ def main():
         }}
         if len(CONTEXT) > 1400:
             return 0
-        sys.stdout.write(json.dumps(
-            result, ensure_ascii=False, separators=(",", ":")) + "\n")
+        encoded = (json.dumps(
+            result, ensure_ascii=False, separators=(",", ":")) +
+            "\n").encode("utf-8")
+        sys.stdout.buffer.write(encoded)
+        sys.stdout.buffer.flush()
     except Exception:
         pass
     return 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,26 +117,29 @@ jobs:
           # now one list exists and run.sh guards its completeness.
           python -m unittest \
             $(tr -d '\r' < test/tokenserver-suite.txt | grep -v '^#') -v
+      - name: Run setup integration tests on Windows
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: python test/test_vibepulse_codex_plugin.py
       - name: Validate the Windows Task Scheduler installer without installing
         if: runner.os == 'Windows'
         shell: powershell
         run: |
-          $tokens = $null
-          $parseErrors = $null
           $allErrors = @()
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path 'tools\tokenserver\install-windows-task.ps1'),
-            [ref]$tokens,
-            [ref]$parseErrors
-          ) | Out-Null
-          $allErrors += $parseErrors
-          $parseErrors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path 'tools\tokenserver\run-windows-task.ps1'),
-            [ref]$tokens,
-            [ref]$parseErrors
-          ) | Out-Null
-          $allErrors += $parseErrors
+          foreach ($script in @(
+            'tools\tokenserver\install-windows-task.ps1',
+            'tools\tokenserver\run-windows-task.ps1',
+            'test\windows-task-runner.ps1'
+          )) {
+            $tokens = $null
+            $parseErrors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path $script),
+              [ref]$tokens,
+              [ref]$parseErrors
+            ) | Out-Null
+            $allErrors += $parseErrors
+          }
           if ($allErrors.Count -gt 0) {
             $allErrors | ForEach-Object { Write-Error $_.Message }
             exit 1

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,33 @@ point at the backlog item.
 
 ---
 
+## 2026-08-27 · Windows boundaries disagreed with portable-looking tests
+
+**What happened:** setup doctor rejected Python 3.12, Unicode hook JSON used
+the active Windows code page, and the task installer passed parser validation
+but failed before registration. **Root cause:** the production reader preserved
+`\r\n`, text-mode hook output inherited a code page, and the Task Scheduler
+XML value `StopExisting` was passed to a PowerShell cmdlet that only accepts
+`Parallel`, `Queue`, or `IgnoreNew`; its restart count was also 999
+although the schema limit is 255. **The rule:** test machine protocols through
+the production boundary on every claimed host OS, write explicit UTF-8, and
+keep scheduler values inside the XML schema even if a cmdlet accepts more.
+Execute non-mutating object construction in `-ValidateOnly`. **Guards:**
+Windows setup integration CI, strict LF/CRLF and Unicode tests, three-script
+parsing, runner tests, portable task settings, and a real forced-process
+restart. Native failures are normalized to exit 1 because Task Scheduler did
+not retry the long-lived action reliably even after PowerShell's forwarded
+`-1`/`0xFFFFFFFF` was normalized. A five-minute repeating trigger is the
+explicit watchdog; `IgnoreNew` prevents duplicates while healthy. **Watch
+for:** schema values PowerShell omits or fails to constrain, and assuming
+RestartOnFailure covers a successfully started long-lived action on every
+Windows release. Task Scheduler also has a smaller PATH than an interactive
+shell, so the installer verifies the optional Codex executable and passes only
+its bin directory to the wrapper. Its service can also retain a pre-login
+environment snapshot, so an existing custom `CODEX_HOME` is passed explicitly
+to the child without changing it. Never infer background CLI readiness from the
+installer's interactive environment alone.
+
 ## 2026-08-27 · A green build from an old tree hid the panel test
 
 **What happened:** the panel first showed **UPDATE READY**, then questions with

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -53,20 +53,35 @@ acceptable only when its reason is platform-specific and named in the output.
 ## 4. Validate the Task Scheduler installer without installing
 
 ```powershell
-$Tokens = $null
-$Errors = $null
-[System.Management.Automation.Language.Parser]::ParseFile(
-  (Resolve-Path tools\tokenserver\install-windows-task.ps1),
-  [ref]$Tokens,
-  [ref]$Errors
-) | Out-Null
-$Errors
+$AllErrors = @()
+foreach ($Script in @(
+  'tools\tokenserver\install-windows-task.ps1',
+  'tools\tokenserver\run-windows-task.ps1',
+  'test\windows-task-runner.ps1'
+)) {
+  $Tokens = $null
+  $Errors = $null
+  [System.Management.Automation.Language.Parser]::ParseFile(
+    (Resolve-Path $Script),
+    [ref]$Tokens,
+    [ref]$Errors
+  ) | Out-Null
+  $AllErrors += $Errors
+}
+$AllErrors
 .\tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+.\test\windows-task-runner.ps1
 ```
 
-The parser must return no errors. `-ValidateOnly` must report the exact checkout
-and a Python 3.11+ interpreter, and must say that it made no Task Scheduler
-changes.
+The parser must return no errors for all three scripts. `-ValidateOnly` must
+report the exact checkout, a Python 3.11+ interpreter, and a supported Task
+Scheduler settings object, and must say that it made no Task Scheduler changes.
+The runner test must pass stdout/stderr capture, log rotation, and paths
+containing spaces and non-ASCII characters. When Codex is installed, the
+scheduled process must receive its verified bin directory without changing the
+user's global PATH. If the user already has a custom `CODEX_HOME`, the task
+must receive that verified directory process-locally without editing Codex
+settings or authentication.
 
 ## 5. Exercise the real local sources on a temporary port
 
@@ -154,7 +169,8 @@ Verify all of these and record timestamps:
 
 1. the task starts immediately;
 2. it starts again after sign-out/sign-in;
-3. it restarts after the process is terminated once;
+3. after the tokenserver process is terminated once, the five-minute
+   watchdog starts a new process with the same release revision;
 4. it returns after sleep/resume;
 5. one full Windows reboot does not leave the panel stale.
 

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -214,13 +214,25 @@ assert "$LogCapBytes = 5MB" in windows_runner
 assert "$LogTailBytes = 256KB" in windows_runner
 assert "Write-VibePulseLogLine" in windows_runner
 assert "run-windows-task.ps1" in windows_service
-assert "-MultipleInstances StopExisting" in windows_service
+assert "-MultipleInstances IgnoreNew" in windows_service
+assert "Stop-ScheduledTask -TaskName $TaskName" in windows_service
+assert "$RestartCount = 255" in windows_service
+assert "$WatchdogTrigger = New-ScheduledTaskTrigger -Once" in windows_service
+assert "-RepetitionInterval (New-TimeSpan -Minutes 5)" in windows_service
 assert "Validate the Windows Task Scheduler installer without installing" in ci
 assert ".\\tools\\tokenserver\\install-windows-task.ps1 -ValidateOnly" in ci
 assert ".\\test\\windows-task-runner.ps1" in ci
+assert "'test\\windows-task-runner.ps1'" in ci
+assert "Run setup integration tests on Windows" in ci
+assert "python test/test_vibepulse_codex_plugin.py" in ci
 assert "VibePulse runner å" in windows_runner_test
 assert "stdout was not captured" in windows_runner_test
 assert "stderr was not captured" in windows_runner_test
+assert "negative child exit was not normalized to 1" in windows_runner_test
+assert "Codex bin directory was not prepended to PATH" in windows_runner_test
+assert "Codex home was not passed to the child process" in windows_runner_test
+assert "Resolve-VibePulseCodexBinDir" in windows_service
+assert "Resolve-VibePulseCodexHome" in windows_service
 assert "Ubuntu" in readme and "not a support claim" in readme
 assert "778 tests" in windows_host_report
 assert "Panel end to end | FAIL" in windows_host_report

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -66,6 +66,17 @@ def compact(value):
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
 
 
+def directory_symlink_or_skip(link, target):
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+            raise unittest.SkipTest(
+                "Windows directory symlinks require Developer Mode or "
+                "SeCreateSymbolicLinkPrivilege") from exc
+        raise
+
+
 class _Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -100,14 +111,20 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         first = behavior.get("first_bytes")
         if first is not None:
-            self.wfile.write(payload[:first])
-            self.wfile.flush()
-            time.sleep(behavior.get("delay_body", 0))
-            self.wfile.write(payload[first:])
+            try:
+                self.wfile.write(payload[:first])
+                self.wfile.flush()
+                time.sleep(behavior.get("delay_body", 0))
+                self.wfile.write(payload[first:])
+            except OSError:
+                return
         else:
             if behavior.get("delay_body"):
                 time.sleep(behavior["delay_body"])
-            self.wfile.write(payload)
+            try:
+                self.wfile.write(payload)
+            except OSError:
+                return
 
     def log_message(self, _format, *_args):
         pass
@@ -625,6 +642,26 @@ class PermissionHookTests(unittest.TestCase):
                 self.assertEqual(path, "/api/codex/permission")
                 self.assertEqual(headers["Content-Type"], "application/json")
                 self.assertEqual(json.loads(body), PERMISSION)
+
+    def test_unicode_decision_is_emitted_as_utf8(self):
+        decision = {
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {
+                    "behavior": "deny",
+                    "message": "Nekad från VibePulse – försök på datorn",
+                },
+            },
+        }
+        with LocalServer(body=compact(decision).encode("utf-8")) as server:
+            completed = run_script(
+                "permission_hook.py", compact(PERMISSION).encode("utf-8"),
+                port=server.port)
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(
+            json.loads(completed.stdout.decode("utf-8", errors="strict")),
+            decision)
+        self.assertEqual(completed.stderr, b"")
 
     def test_invalid_port_fails_silent_without_using_default(self):
         for port in ("", "0", "65536", "+8737", " 8737", "eight"):
@@ -1369,6 +1406,31 @@ class SetupPlanTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         self.assertEqual(completed.stdout, "vibepulse-python-3.11+\n")
         self.assertEqual(completed.stderr, "")
+        self.assertTrue(setup._python_probe_ok(
+            Path(sys.executable), setup._AUTO))
+
+    def test_python_probe_accepts_only_native_line_endings(self):
+        setup = load_setup()
+        sentinel = "vibepulse-python-3.11+"
+        for ending in ("\n", "\r\n"):
+            with self.subTest(ending=repr(ending)):
+                runner = FakeRunner([result(stdout=sentinel + ending)])
+                self.assertTrue(setup._python_probe_ok(
+                    Path(sys.executable), runner))
+
+        for stdout in (
+                sentinel + " \n", sentinel + "\nextra\n", sentinel, ""):
+            with self.subTest(stdout=repr(stdout)):
+                runner = FakeRunner([result(stdout=stdout)])
+                self.assertFalse(setup._python_probe_ok(
+                    Path(sys.executable), runner))
+
+        self.assertFalse(setup._python_probe_ok(
+            Path(sys.executable),
+            FakeRunner([result(returncode=1, stdout=sentinel + "\n")])))
+        self.assertFalse(setup._python_probe_ok(
+            Path(sys.executable),
+            FakeRunner([result(stdout=sentinel + "\n", stderr="warning")])))
 
     def test_disable_preserves_unrelated_switches_and_clears_legacy_with_claude(self):
         setup = load_setup()
@@ -1415,22 +1477,25 @@ class SetupPlanTests(unittest.TestCase):
 
     def test_install_plan_is_exact_and_paths_with_spaces_stay_one_argv(self):
         setup = load_setup()
+        repo = Path("/repo with spaces")
+        python = Path("/python with spaces")
+        codex = Path("/codex")
+        repo_path = str(repo.resolve())
+        python_path = str(python.resolve())
+        codex_path = str(codex.resolve())
         commands = setup.plan_codex_install(
-            repo_root=Path("/repo with spaces"),
-            python=Path("/python with spaces"), codex=Path("/codex"),
+            repo_root=repo, python=python, codex=codex,
             marketplace_name="torget")
         self.assertEqual(commands, [
-            ["/codex", "plugin", "marketplace", "add",
-             "/repo with spaces"],
-            ["/codex", "plugin", "add", "vibepulse@torget"],
-            ["/codex", "mcp", "remove", "vibepulse"],
-            ["/codex", "mcp", "add", "vibepulse", "--",
-             "/python with spaces",
-             "/repo with spaces/.agents/plugins/plugins/vibepulse/scripts/"
-             "mcp_server.py"],
+            [codex_path, "plugin", "marketplace", "add", repo_path],
+            [codex_path, "plugin", "add", "vibepulse@torget"],
+            [codex_path, "mcp", "remove", "vibepulse"],
+            [codex_path, "mcp", "add", "vibepulse", "--", python_path,
+             str(repo.resolve() /
+                 ".agents/plugins/plugins/vibepulse/scripts/mcp_server.py")],
         ])
         self.assertNotEqual(
-            commands[0][-1], "/repo with spaces/.agents/plugins")
+            commands[0][-1], str(repo.resolve() / ".agents/plugins"))
 
     def test_provider_choices_and_detail_are_separate_explicit_opt_ins(self):
         setup = load_setup()
@@ -1590,7 +1655,8 @@ class RelaySetupTests(unittest.TestCase):
         token = root / "home/.vibepulse-interaction-relay-token"
         secrets = root / "repo/secrets.h"
         service = root / "repo/tools/interaction-relay"
-        wrangler = service / "node_modules/.bin/wrangler"
+        wrangler = service / "node_modules/.bin" / (
+            "wrangler.cmd" if os.name == "nt" else "wrangler")
         wrangler.parent.mkdir(parents=True)
         wrangler.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
         wrangler.chmod(0o700)
@@ -2142,10 +2208,11 @@ class RelaySetupTests(unittest.TestCase):
                 ["uninstall", "codex"], config_path=config,
                 codex=Path("/codex"), run=runner,
                 stdout=io.StringIO()), 0)
+            codex_path = str(Path("/codex").resolve())
             self.assertEqual([call[0] for call in runner.calls[3:6]], [
-                ["/codex", "mcp", "remove", "vibepulse"],
-                ["/codex", "plugin", "remove", "vibepulse@torget"],
-                ["/codex", "plugin", "marketplace", "remove", "torget"],
+                [codex_path, "mcp", "remove", "vibepulse"],
+                [codex_path, "plugin", "remove", "vibepulse@torget"],
+                [codex_path, "plugin", "marketplace", "remove", "torget"],
             ])
             self.assertEqual(setup.load_config(config), setup.VibePulseConfig(
                 claude_interactions=True, codex_interactions=False,
@@ -2186,7 +2253,8 @@ class RelaySetupTests(unittest.TestCase):
                 codex=Path("/codex"), run=failed,
                 stdout=io.StringIO()), 1)
             self.assertIn(
-                ["/codex", "plugin", "marketplace", "remove", "torget"],
+                [str(Path("/codex").resolve()), "plugin", "marketplace",
+                 "remove", "torget"],
                 [call[0] for call in failed.calls])
             self.assertTrue(setup.load_config(path).codex_interactions)
 
@@ -2328,7 +2396,9 @@ class RelaySetupTests(unittest.TestCase):
             # but a symlink to dash on Debian-family CI runners.
             self.assertEqual(runner.calls[0][0][0:2],
                              [str(Path("/bin/sh").resolve()), "-c"])
-            self.assertEqual(runner.calls[1][0], ["/codex", "--version"])
+            self.assertEqual(
+                runner.calls[1][0],
+                [str(Path("/codex").resolve()), "--version"])
             self.assertTrue(all(call[1]["timeout"] <= 15
                                 and call[1]["shell"] is False
                                 for call in runner.calls))
@@ -2358,11 +2428,11 @@ class RelaySetupTests(unittest.TestCase):
             (plugin.parent / "spelling").mkdir()
 
             repo_alias = base / "repo-alias"
-            repo_alias.symlink_to(repo, target_is_directory=True)
+            directory_symlink_or_skip(repo_alias, repo)
             plugin_alias = base / "plugin-alias"
-            plugin_alias.symlink_to(plugin, target_is_directory=True)
+            directory_symlink_or_skip(plugin_alias, plugin)
             parent_alias = base / "parent-alias"
-            parent_alias.symlink_to(base, target_is_directory=True)
+            directory_symlink_or_skip(parent_alias, base)
             parent_repo = parent_alias / "repo"
             parent_plugin = (
                 parent_repo / ".agents/plugins/plugins/vibepulse")
@@ -2406,10 +2476,9 @@ class RelaySetupTests(unittest.TestCase):
             foreign_plugin = foreign / "plugin"
             foreign_plugin.mkdir(parents=True)
             foreign_link = Path(tmp) / "foreign-link"
-            foreign_link.symlink_to(foreign, target_is_directory=True)
+            directory_symlink_or_skip(foreign_link, foreign)
             foreign_plugin_link = Path(tmp) / "foreign-plugin-link"
-            foreign_plugin_link.symlink_to(
-                foreign_plugin, target_is_directory=True)
+            directory_symlink_or_skip(foreign_plugin_link, foreign_plugin)
 
             missing_source = plugin_listing()
             missing_source["installed"][0].pop("source")
@@ -2588,10 +2657,11 @@ class RelaySetupTests(unittest.TestCase):
                           result(stdout="not-json\n"),
                           json_result(marketplace_listing())],
         }
+        codex_path = str(Path("/codex").resolve())
         expected_preflight = [
-            ["/codex", "mcp", "list", "--json"],
-            ["/codex", "plugin", "list", "--json"],
-            ["/codex", "plugin", "marketplace", "list", "--json"],
+            [codex_path, "mcp", "list", "--json"],
+            [codex_path, "plugin", "list", "--json"],
+            [codex_path, "plugin", "marketplace", "list", "--json"],
         ]
         with tempfile.TemporaryDirectory() as tmp:
             for label, responses in cases.items():
@@ -2843,7 +2913,7 @@ class RelaySetupTests(unittest.TestCase):
         self.assertIsNone(setup._invoke(invalid, setup._AUTO))
         completed = setup._invoke(valid, setup._AUTO)
         self.assertIsNotNone(completed)
-        self.assertEqual(completed.stdout, "ok\n")
+        self.assertEqual(completed.stdout, "ok" + os.linesep)
         self.assertFalse(any(thread.name.startswith("vibepulse-drain-")
                              for thread in threading.enumerate()))
 
@@ -3273,7 +3343,7 @@ class RelaySetupTests(unittest.TestCase):
         completed = setup._invoke(
             [sys.executable, "-c", "print('recovered')"], setup._AUTO)
         self.assertIsNotNone(completed)
-        self.assertEqual(completed.stdout, "recovered\n")
+        self.assertEqual(completed.stdout, "recovered" + os.linesep)
         self.assertFalse(any(thread.name.startswith("vibepulse-drain-")
                              for thread in threading.enumerate()))
 
@@ -3303,7 +3373,7 @@ class RelaySetupTests(unittest.TestCase):
             stderr = io.BytesIO()
 
             def wait(self, timeout=None):
-                return 1
+                raise KeyboardInterrupt()
 
             def poll(self):
                 raise KeyboardInterrupt()

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -576,7 +576,10 @@ class LoopbackTests(unittest.TestCase):
                     read_timeout=0.12)
                 elapsed = time.monotonic() - started
             self.assertIsNone(result)
-            self.assertLess(elapsed, 0.25)
+            # The result assertion proves the absolute deadline won instead of
+            # accepting the complete drip-fed response.  Keep the wall-clock
+            # guard generous enough for contended Windows CI runners.
+            self.assertLess(elapsed, 0.75)
 
     def test_read_timeout_and_bad_responses_return_none(self):
         loopback = load_loopback()
@@ -2455,10 +2458,13 @@ class RelaySetupTests(unittest.TestCase):
                     repo=repo,
                     plugin_path=plugin.parent / "spelling" / ".." /
                     "vibepulse"),
+                # Do not use relpath here: Windows CI can put TEMP and the
+                # checkout on different drive letters, where relpath raises.
                 "marketplace relative": plugin_listing(
-                    repo=repo, marketplace_root=os.path.relpath(repo, ROOT)),
+                    repo=repo, marketplace_root=Path("repo")),
                 "plugin relative": plugin_listing(
-                    repo=repo, plugin_path=os.path.relpath(plugin, ROOT)),
+                    repo=repo,
+                    plugin_path=Path(".agents/plugins/plugins/vibepulse")),
                 "marketplace trailing separator": plugin_listing(
                     repo=repo, marketplace_root=str(repo) + os.sep),
                 "plugin trailing separator": plugin_listing(

--- a/test/windows-task-runner.ps1
+++ b/test/windows-task-runner.ps1
@@ -8,6 +8,7 @@ $TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
     "VibePulse runner å " + [guid]::NewGuid().ToString("N")
 )
 $PreviousLocalAppData = $env:LOCALAPPDATA
+$PreviousPath = $env:Path
 
 try {
     New-Item -ItemType Directory -Path $TempRoot -Force | Out-Null
@@ -15,9 +16,22 @@ try {
     $Fixture = Join-Path $TempRoot "fixture med å.py"
     @'
 import sys
+import os
 print("stdout-ok")
 print("stderr-ok", file=sys.stderr)
+print("codex-path-ok" if os.environ["PATH"].split(os.pathsep)[0] ==
+      os.environ["VIBEPULSE_TEST_CODEX_DIR"] else "codex-path-bad")
+print("codex-home-ok" if os.environ.get("CODEX_HOME") ==
+      os.environ["VIBEPULSE_TEST_CODEX_HOME"] else "codex-home-bad")
 '@ | Set-Content -LiteralPath $Fixture -Encoding UTF8
+    $CodexDir = Join-Path $TempRoot "Codex bin å"
+    New-Item -ItemType Directory -Path $CodexDir -Force | Out-Null
+    New-Item -ItemType File -Path (Join-Path $CodexDir "codex.exe") `
+        -Force | Out-Null
+    $env:VIBEPULSE_TEST_CODEX_DIR = $CodexDir
+    $CodexHome = Join-Path $TempRoot "Codex home å"
+    New-Item -ItemType Directory -Path $CodexHome -Force | Out-Null
+    $env:VIBEPULSE_TEST_CODEX_HOME = $CodexHome
 
     $LogDir = Join-Path $TempRoot "VibePulse\Logs"
     $LogPath = Join-Path $LogDir "torget-tokenserver.log"
@@ -27,7 +41,8 @@ print("stderr-ok", file=sys.stderr)
     [System.IO.File]::WriteAllBytes($LogPath, $Filler)
     [System.IO.File]::AppendAllText($LogPath, "rotation-sentinel")
 
-    & $Runner -Python $Python -Server $Fixture
+    & $Runner -Python $Python -Server $Fixture -CodexBinDir $CodexDir `
+        -CodexHome $CodexHome
     if ($LASTEXITCODE -ne 0) {
         throw "runner returned $LASTEXITCODE"
     }
@@ -49,9 +64,30 @@ print("stderr-ok", file=sys.stderr)
     if (-not $CurrentText.Contains("stderr-ok")) {
         throw "stderr was not captured"
     }
+    if (-not $CurrentText.Contains("codex-path-ok")) {
+        throw "Codex bin directory was not prepended to PATH"
+    }
+    if (-not $CurrentText.Contains("codex-home-ok")) {
+        throw "Codex home was not passed to the child process"
+    }
+
+    $FailingFixture = Join-Path $TempRoot "fixture failure å.py"
+    @'
+import sys
+sys.exit(-1)
+'@ | Set-Content -LiteralPath $FailingFixture -Encoding UTF8
+    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File $Runner -Python $Python -Server $FailingFixture *> $null
+    if ($LASTEXITCODE -ne 1) {
+        throw "negative child exit was not normalized to 1"
+    }
     Write-Host "VibePulse Windows task runner: OK"
+    exit 0
 } finally {
+    Remove-Item Env:VIBEPULSE_TEST_CODEX_DIR -ErrorAction SilentlyContinue
+    Remove-Item Env:VIBEPULSE_TEST_CODEX_HOME -ErrorAction SilentlyContinue
     $env:LOCALAPPDATA = $PreviousLocalAppData
+    $env:Path = $PreviousPath
     if (Test-Path -LiteralPath $TempRoot) {
         Remove-Item -LiteralPath $TempRoot -Recurse -Force
     }

--- a/tools/tokenserver/install-windows-task.ps1
+++ b/tools/tokenserver/install-windows-task.ps1
@@ -29,8 +29,9 @@ Designval, i linje med resten av repot:
   not interaction-provider choices.
 - Ingen hemlighet i den registrerade kommandoraden utom relä-URL:en, som
   användaren själv valt att ge — samma exponeringsnivå som secrets.h.
-- Starta om vid fel, var 5:e minut, utan tak — en hyllservice ska resa
-  sig själv, precis som launchd-plisten gör på macOS.
+- En logon-trigger startar tjänsten och en femminuters-watchdog startar den
+  igen om processen har dött. `IgnoreNew` gör watchdoggen ofarlig när den
+  redan kör — en hyllservice ska resa sig själv, precis som launchd-plisten.
 #>
 param(
     [string]$PublishUrl = "",
@@ -82,6 +83,62 @@ function Resolve-VibePulsePython {
     throw "VibePulse requires Python 3.11 or newer. Install it, reopen PowerShell, and rerun this installer."
 }
 
+function Resolve-VibePulseCodexBinDir {
+    $Candidates = @()
+    if ($env:LOCALAPPDATA) {
+        $Standalone = Join-Path $env:LOCALAPPDATA `
+            "Programs\OpenAI\Codex\bin\codex.exe"
+        if (Test-Path -LiteralPath $Standalone -PathType Leaf) {
+            $Candidates += $Standalone
+        }
+    }
+    foreach ($Name in @("codex.exe", "codex.cmd")) {
+        $Command = Get-Command $Name -ErrorAction SilentlyContinue
+        if ($Command -and $Command.Source) {
+            $Candidates += $Command.Source
+        }
+    }
+    foreach ($Candidate in $Candidates | Select-Object -Unique) {
+        try {
+            & $Candidate --version *> $null
+            if ($LASTEXITCODE -eq 0) {
+                return Split-Path -Parent $Candidate
+            }
+        } catch {
+            # Codex is optional; keep checking candidates.
+        }
+    }
+    return ""
+}
+
+function Resolve-VibePulseCodexHome {
+    $Candidate = $env:CODEX_HOME
+    if (-not $Candidate) {
+        $Candidate = [Environment]::GetEnvironmentVariable(
+            "CODEX_HOME", "User")
+    }
+    if ($Candidate -and
+            (Test-Path -LiteralPath $Candidate -PathType Container)) {
+        return (Resolve-Path -LiteralPath $Candidate).Path
+    }
+    return ""
+}
+
+function New-VibePulseTaskSettings {
+    # The Task Scheduler XML schema supports StopExisting, but Microsoft's
+    # ScheduledTasks PowerShell cmdlet exposes only Parallel, Queue, and
+    # IgnoreNew. Stop the one owned task explicitly before replacement and
+    # use the portable IgnoreNew policy for later duplicate starts.
+    # RestartOnFailure/Count is an unsigned byte in the Task Scheduler
+    # schema. Values above 255 can register but are not executed reliably.
+    $RestartCount = 255
+    return New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -RestartCount $RestartCount -RestartInterval (New-TimeSpan -Minutes 5) `
+        -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
+        -MultipleInstances IgnoreNew
+}
+
 if ($Uninstall) {
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
     Write-Host "Uppgiften '$TaskName' borttagen. Processen som redan kör påverkas inte;"
@@ -99,9 +156,16 @@ $Runner = Join-Path $RepoRoot "tools\tokenserver\run-windows-task.ps1"
 if (-not (Test-Path $Runner)) { throw "hittar inte $Runner" }
 
 $PythonConsole = Resolve-VibePulsePython
+$CodexBinDir = Resolve-VibePulseCodexBinDir
+$CodexHome = Resolve-VibePulseCodexHome
 # Task Scheduler starts a hidden PowerShell wrapper. Keep python.exe rather
 # than pythonw.exe so stdout/stderr can be captured in the durable log.
 $PowerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
+$Settings = New-VibePulseTaskSettings
+$LogonTrigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$WatchdogTrigger = New-ScheduledTaskTrigger -Once `
+    -At (Get-Date).AddMinutes(1) `
+    -RepetitionInterval (New-TimeSpan -Minutes 5)
 
 if ($ValidateOnly) {
     $Version = & $PythonConsole -c `
@@ -117,6 +181,12 @@ if ($ValidateOnly) {
 
 $RunnerArgs = "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass" +
     " -File `"$Runner`" -Python `"$PythonConsole`" -Server `"$Server`""
+if ($CodexBinDir) {
+    $RunnerArgs += " -CodexBinDir `"$CodexBinDir`""
+}
+if ($CodexHome) {
+    $RunnerArgs += " -CodexHome `"$CodexHome`""
+}
 if ($PublishUrl) {
     $RunnerArgs += " -PublishUrl `"$PublishUrl`""
     if ($PublishName) { $RunnerArgs += " -PublishName `"$PublishName`"" }
@@ -124,15 +194,23 @@ if ($PublishUrl) {
 
 $Action = New-ScheduledTaskAction -Execute $PowerShell -Argument $RunnerArgs `
     -WorkingDirectory $RepoRoot
-$Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
-$Settings = New-ScheduledTaskSettingsSet `
-    -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
-    -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 5) `
-    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
-    -MultipleInstances StopExisting
+
+$ExistingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($ExistingTask -and $ExistingTask.State -eq "Running") {
+    Stop-ScheduledTask -TaskName $TaskName
+    $Deadline = (Get-Date).AddSeconds(15)
+    do {
+        Start-Sleep -Milliseconds 100
+        $ExistingTask = Get-ScheduledTask -TaskName $TaskName
+    } while ($ExistingTask.State -eq "Running" -and (Get-Date) -lt $Deadline)
+    if ($ExistingTask.State -eq "Running") {
+        throw "The existing VibePulse tokenserver task did not stop safely"
+    }
+}
 
 Register-ScheduledTask -TaskName $TaskName -Action $Action `
-    -Trigger $Trigger -Settings $Settings -Force | Out-Null
+    -Trigger @($LogonTrigger, $WatchdogTrigger) `
+    -Settings $Settings -Force | Out-Null
 Start-ScheduledTask -TaskName $TaskName
 
 Write-Host "Uppgiften '$TaskName' registrerad och startad."

--- a/tools/tokenserver/run-windows-task.ps1
+++ b/tools/tokenserver/run-windows-task.ps1
@@ -10,6 +10,8 @@ param(
     [string]$Python,
     [Parameter(Mandatory = $true)]
     [string]$Server,
+    [string]$CodexBinDir = "",
+    [string]$CodexHome = "",
     [string]$PublishUrl = "",
     [string]$PublishName = ""
 )
@@ -23,6 +25,21 @@ if (-not (Test-Path -LiteralPath $Python -PathType Leaf)) {
 }
 if (-not (Test-Path -LiteralPath $Server -PathType Leaf)) {
     throw "VibePulse tokenserver is missing: $Server"
+}
+if ($CodexBinDir) {
+    $Codex = Join-Path $CodexBinDir "codex.exe"
+    $CodexCmd = Join-Path $CodexBinDir "codex.cmd"
+    if (-not (Test-Path -LiteralPath $Codex -PathType Leaf) -and
+            -not (Test-Path -LiteralPath $CodexCmd -PathType Leaf)) {
+        throw "VibePulse Codex bin directory is invalid"
+    }
+    $env:Path = $CodexBinDir + [IO.Path]::PathSeparator + $env:Path
+}
+if ($CodexHome) {
+    if (-not (Test-Path -LiteralPath $CodexHome -PathType Container)) {
+        throw "VibePulse Codex home directory is invalid"
+    }
+    $env:CODEX_HOME = $CodexHome
 }
 
 $LocalAppData = $env:LOCALAPPDATA
@@ -95,7 +112,12 @@ try {
     $ExitCode = $LASTEXITCODE
     $ErrorActionPreference = $PreviousErrorActionPreference
     if ($null -eq $ExitCode) { $ExitCode = 1 }
-    exit $ExitCode
+    # A force-stopped Windows child commonly reports -1, which PowerShell
+    # forwards as 0xFFFFFFFF. Task Scheduler does not reliably apply
+    # RestartOnFailure to that sentinel. Normalize every native failure to
+    # the conventional process exit code 1.
+    if ($ExitCode -ne 0) { exit 1 }
+    exit 0
 } catch {
     $ErrorActionPreference = "Stop"
     $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1342,8 +1342,9 @@ def _python_probe_ok(python: Path | None, run) -> bool:
     if python is None:
         return False
     probe = _invoke([str(Path(python).resolve()), "-c", _PYTHON_PROBE], run)
+    sentinel = "vibepulse-python-3.11+"
     return (probe is not None and probe.returncode == 0 and
-            probe.stdout == "vibepulse-python-3.11+\n" and
+            probe.stdout in (sentinel + "\n", sentinel + "\r\n") and
             probe.stderr == "")
 
 


### PR DESCRIPTION
## Summary
- make the Python doctor probe accept strict LF and CRLF output
- emit hook protocol JSON as explicit UTF-8 on Windows
- make the Task Scheduler installer portable and ValidateOnly exercise settings/triggers
- add an IgnoreNew watchdog trigger and normalize native failures
- preserve the verified Codex bin and existing CODEX_HOME only inside the task process
- run the complete setup integration suite on Windows CI

## Windows evidence
- 783 tokenserver tests: PASS (11 skips, 0 failures/errors)
- 110 setup integration tests: PASS (5 named platform skips)
- three PowerShell parsers: PASS
- installer ValidateOnly in PowerShell 7 and Windows PowerShell 5.1: PASS, task unchanged
- runner stdout/stderr, rotation, spaces/non-ASCII, Codex env and exit normalization: PASS
- scheduled immediate start and forced-process watchdog restart: PASS
- Claude and Codex weekly sources fresh after restart: PASS

No credentials, quota values, prompts, or private payloads are included.