### PR TITLE
Fix Codex 0.150 plugin provenance on Windows

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,21 @@ point at the backlog item.
 
 ---
 
+## 2026-08-27 · Codex CLI provenance changed shape without changing owner
+
+**What happened:** Windows setup registered the exact release checkout with
+Codex CLI 0.150.1, then rolled back because its own post-install verification
+classified the plugin and marketplace as foreign. **Root cause:** the newer CLI
+omits `marketplaceSource` from marketplace-list rows and reports the plugin's
+local marketplace cache as its source, while the executable plugin path and
+marketplace root still identify the requested checkout exactly. **The rule:**
+version external JSON contracts by observed shape and keep ownership checks on
+the fields that still name executable code and the registered root. **Guards:**
+both strict legacy and 0.150 schemas have provenance tests; unexpected fields,
+foreign roots, and foreign plugin paths remain fail-closed. **Watch for:** a
+future Codex CLI schema adding another shape without a fixture from the real
+Windows boundary.
+
 ## 2026-08-27 · Windows boundaries disagreed with portable-looking tests
 
 **What happened:** setup doctor rejected Python 3.12, Unicode hook JSON used

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -2484,7 +2484,10 @@ class RelaySetupTests(unittest.TestCase):
             plugin.mkdir(parents=True)
             cache = base / "codex-marketplace-cache"
             cache.mkdir()
-            listing = plugin_listing(repo=repo, marketplace_root=cache)
+            # Hosted Windows runners may spell TEMP through an 8.3 alias;
+            # model the CLI's canonical emitted path, not tempfile's input.
+            listing = plugin_listing(
+                repo=repo, marketplace_root=cache.resolve())
             listing["installed"][0].update({
                 "version": "1.0.0",
                 "installPolicy": "project",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -2475,6 +2475,53 @@ class RelaySetupTests(unittest.TestCase):
                     self.assertFalse(setup._plugin_installed(
                         json.dumps(listing), repo))
 
+    def test_plugin_provenance_accepts_codex_0150_cached_marketplace(self):
+        setup = load_setup()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            repo = base / "repo"
+            plugin = repo / ".agents/plugins/plugins/vibepulse"
+            plugin.mkdir(parents=True)
+            cache = base / "codex-marketplace-cache"
+            cache.mkdir()
+            listing = plugin_listing(repo=repo, marketplace_root=cache)
+            listing["installed"][0].update({
+                "version": "1.0.0",
+                "installPolicy": "project",
+                "authPolicy": "none",
+            })
+
+            self.assertTrue(setup._plugin_installed(
+                json.dumps(listing), repo))
+
+            listing["installed"][0]["source"]["path"] = str(
+                base / "foreign-plugin")
+            self.assertFalse(setup._plugin_installed(
+                json.dumps(listing), repo))
+
+    def test_marketplace_state_accepts_codex_0150_root_only_schema(self):
+        setup = load_setup()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            current = {"marketplaces": [{
+                "name": "torget", "root": str(repo.resolve()),
+            }]}
+            foreign = {"marketplaces": [{
+                "name": "torget", "root": str(repo.parent.resolve()),
+            }]}
+            extra = {"marketplaces": [{
+                "name": "torget", "root": str(repo.resolve()),
+                "unexpected": True,
+            }]}
+
+            self.assertIs(setup._marketplace_state(
+                json.dumps(current), repo), True)
+            self.assertFalse(setup._marketplace_state(
+                json.dumps(foreign), repo))
+            self.assertIsNone(setup._marketplace_state(
+                json.dumps(extra), repo))
+
     def test_doctor_rejects_every_plugin_false_green_transcript(self):
         setup = load_setup()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1243,16 +1243,47 @@ def _is_exact_existing_directory(value, expected: Path) -> bool:
         return False
 
 
+def _is_canonical_existing_directory(value) -> bool:
+    """Accept only an absolute, unaliased spelling of an existing directory."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        candidate = Path(value)
+        canonical = candidate.resolve(strict=True)
+        return all((
+            candidate.is_absolute(),
+            value == str(candidate),
+            value == str(canonical),
+            candidate.is_dir(),
+            not _has_symlink_component(candidate),
+        ))
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
 def _owned_plugin_item(item, repo_root: Path) -> bool:
     if not isinstance(item, dict):
         return False
+    legacy_keys = {
+        "pluginId", "name", "marketplaceName", "installed", "enabled",
+        "source", "marketplaceSource",
+    }
+    cached_marketplace_keys = legacy_keys | {
+        "version", "installPolicy", "authPolicy",
+    }
+    item_keys = set(item)
+    cached_marketplace = item_keys == cached_marketplace_keys
     source = item.get("source")
     marketplace_source = item.get("marketplaceSource")
-    if (item.get("pluginId") != "vibepulse@torget" or
+    if (item_keys not in (legacy_keys, cached_marketplace_keys) or
+            item.get("pluginId") != "vibepulse@torget" or
             item.get("name") != "vibepulse" or
             item.get("marketplaceName") != "torget" or
             item.get("installed") is not True or
             item.get("enabled") is not True or
+            (cached_marketplace and any(
+                not isinstance(item.get(key), str) or not item.get(key)
+                for key in ("version", "installPolicy", "authPolicy"))) or
             not isinstance(source, dict) or
             set(source) != {"source", "path"} or
             source.get("source") != "local" or
@@ -1271,8 +1302,10 @@ def _owned_plugin_item(item, repo_root: Path) -> bool:
     return all((
         expected_root.is_dir(),
         expected_plugin.is_dir(),
-        _is_exact_existing_directory(
-            marketplace_source.get("source"), expected_root),
+        (_is_canonical_existing_directory(marketplace_source.get("source"))
+         if cached_marketplace else
+         _is_exact_existing_directory(
+             marketplace_source.get("source"), expected_root)),
         _is_exact_existing_directory(source.get("path"), expected_plugin),
     ))
 
@@ -1322,6 +1355,12 @@ def _marketplace_state(text: str, repo_root: Path) -> bool | None:
     if len(matches) != 1:
         return None
     item = matches[0]
+    if set(item) == {"name", "root"}:
+        try:
+            expected = Path(repo_root).resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            return None
+        return _is_exact_existing_directory(item.get("root"), expected)
     source = item.get("marketplaceSource")
     if (set(item) != {"name", "root", "marketplaceSource"} or
             not isinstance(source, dict) or


### PR DESCRIPTION
## What changed
- accept the exact legacy and Codex CLI 0.150 plugin-list provenance shapes
- verify the executable plugin path and marketplace root still belong to the requested checkout
- keep malformed, unexpected, symlinked, and foreign paths fail-closed
- record the real Windows boundary lesson

## Windows evidence
- real Codex CLI 0.150.1 parser: MCP/plugin/marketplace all owned
- setup/plugin suite: 112 tests, 5 skips, 0 failures/errors
- tokenserver suite: 783 tests, 11 skips, 0 failures/errors
- `vibepulse_setup.py install --providers codex --detail`: exit 0 on the Windows host

No credentials, quota values, prompts, or private payloads are included.