### PR TITLE
fix(windows): allow Codex app-server startup

### DIFF
--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1272,12 +1272,16 @@ class CodexLimitLogTests(unittest.TestCase):
             tokenserver._codex_refreshing = True
             with mock.patch.object(
                     tokenserver, "_read_codex_app_server_limits",
-                    return_value={"codexWeekPct": 62.0}), \
+                    return_value={"codexWeekPct": 62.0}) as app_server, \
                     mock.patch.object(
                         tokenserver, "_scan_codex_limits",
                         return_value={"codexWeekPct": 58.0}):
                 tokenserver._refresh_codex_limits()
 
+            app_server.assert_called_once_with(
+                timeout_s=tokenserver.CODEX_APP_SERVER_TIMEOUT_S)
+            self.assertGreaterEqual(
+                tokenserver.CODEX_APP_SERVER_TIMEOUT_S, 15)
             self.assertEqual(
                 tokenserver._last_codex_limits["codexWeekPct"], 62.0)
         finally:

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -1334,6 +1334,7 @@ def get_limits():
 
 CODEX_SESSIONS = Path(os.path.expanduser("~/.codex/sessions"))
 CODEX_LIMITS_EVERY_S = 30
+CODEX_APP_SERVER_TIMEOUT_S = 15
 CODEX_LIMIT_SCAN_BYTES = 1024 * 1024
 CODEX_WEEK_MINUTES = 10080
 _codex_limits_lock = threading.Lock()
@@ -1504,7 +1505,7 @@ def _pump_lines(stream):
     return lines
 
 
-def _read_codex_app_server_limits(timeout_s=5):
+def _read_codex_app_server_limits(timeout_s=CODEX_APP_SERVER_TIMEOUT_S):
     """Read Codex's current quota snapshot through its local app protocol."""
     executable = _codex_app_server_command()
     if executable is None:
@@ -1732,7 +1733,8 @@ def _scan_codex_limits():
 def _refresh_codex_limits():
     global _last_codex_limits, _last_codex_read, _codex_refreshing
     try:
-        refreshed = _read_codex_app_server_limits()
+        refreshed = _read_codex_app_server_limits(
+            timeout_s=CODEX_APP_SERVER_TIMEOUT_S)
         if not refreshed:
             refreshed = _scan_codex_limits()
     except Exception:


### PR DESCRIPTION
## Summary
- allow 15 seconds for the local Codex app-server quota probe
- assert the production refresh path uses the Windows-proven timeout

## Validation
- full tokenserver suite: 783 tests, 11 skipped, 0 failures
- real Windows default app-server probe: PASS