### PR TITLE
Document the current Windows validation boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 - A security policy, contribution guide, and pull-request evidence checklist
   document private reporting, secret handling, platform-claim discipline, and
   the difference between CI, real-host, and physical-panel validation.
+- A sanitized post-v0.7.1 Windows checkpoint pins every real-host observation
+  to its exact commit and keeps firewall, lifecycle, recent-panel, and physical
+  rows explicitly failed or not tested instead of inheriting an older pass.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,10 @@ reported as current.
   installation and recovery use the public
   **[Windows host runbook](docs/windows-setup.md)**, while release candidates
   use the reproducible
-  **[Windows validation gate](docs/windows-validation.md)**.
+  **[Windows validation gate](docs/windows-validation.md)**. “Host supported”
+  does not mean every later candidate has passed the physical Windows loop;
+  the latest sanitized checkpoint is explicitly
+  **[PARTIAL](docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md)**.
 - **Claude Code and/or Codex.** Either alone is fine.
 - **2.4 GHz WiFi.** The ESP32-S3 can't see 5 GHz networks.
 
@@ -658,6 +661,9 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   checkout and Python 3.11+ interpreter without changing Task Scheduler. The
   complete install, hook-review, firewall, startup-health, physical-test, and
   recovery procedure is the [Windows host runbook](docs/windows-setup.md).
+  The host implementation is supported, while a release-level physical claim
+  still requires every row in the [Windows validation gate](docs/windows-validation.md)
+  to pass on the same exact candidate.
 - **Linux for the tokenserver?** Not yet —
   [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2). The Ubuntu
   tokenserver CI lane is portability evidence, not a support claim: current

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,40 @@ point at the backlog item.
 
 ---
 
+## 2026-08-28 · A healthy scheduled Codex source failed in the interactive shell
+
+**What happened:** a direct Windows probe failed while the scheduled API
+returned a fresh numeric Codex observation. **Root cause:** the task prepended
+the verified standalone Codex bin directory, while the interactive shell did
+not; login and `CODEX_HOME` alone did not make the environments equivalent.
+**The rule:** diagnose a background source in the exact service environment
+before calling it stale. **Guards:** the installer pins the verified Codex bin
+and optional `CODEX_HOME`; the Windows runbook checks the scheduled API.
+**Watch for:** using `Get-Command` or an unpinned shell probe as task evidence.
+
+## 2026-08-28 · Real Windows startup outlived the optimistic Codex deadline
+
+**What happened:** the background Codex week could remain stale even though
+the standalone CLI and its task environment were valid. **Root cause:** a real
+Windows `codex app-server` startup could take longer than the original bounded
+probe allowance. **The rule:** keep the read bounded, but choose its deadline
+from the slow real-host boundary and verify the production refresh path uses
+that value. **Guards:** PR #37 raises the local allowance to 15 seconds and a
+regression test exercises the production caller. **Watch for:** shortening a
+provider deadline from fast unit-process timings or interactive warm starts.
+
+## 2026-08-28 · A disconnected validation host is NOT TESTED, not green
+
+**What happened:** the real-PC run stopped after useful host evidence but
+before the final merged commit, lifecycle transitions, and physical question.
+**Root cause:** remote-host reachability is independent of tokenserver health,
+and an in-progress task cannot leave new evidence after its PC disconnects.
+**The rule:** pin every PASS to its exact commit, persist only sanitized
+checkpoints, and keep every unfinished row FAIL or NOT TESTED. **Guards:** the
+current-main Windows checkpoint and support matrix link each claim to its
+evidence boundary. **Watch for:** treating repeated retries, old PASS results,
+or an active remote task as proof that the current candidate passed.
+
 ## 2026-08-27 · Codex CLI provenance changed shape without changing owner
 
 **What happened:** Windows setup registered the exact release checkout with

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -15,7 +15,7 @@ firmware from that operating system.
 | Host | Tokenserver | Autostart | Automated evidence | Real-host evidence | Public status |
 |---|---|---|---|---|---|
 | macOS | Yes | launchd | Tokenserver matrix + full host gate | Daily development and physical panel reviews | Supported |
-| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Windows host validation is required for each public support milestone | Supported; the new persistent-log path remains tracked in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) until it passes a real scheduled-task lifecycle |
+| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Host service, scheduled start, bounded log, and provider sources have partial real-PC evidence | Host supported; current post-v0.7.1 candidate is **PARTIAL**, not physical end to end. Persistent lifecycle completion remains tracked in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) |
 | Linux | Not on `main` | Not shipped | The Python suite runs on Ubuntu, but that alone does not exercise a supported Linux installation | No current-main release report | Not supported yet; tracked in [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2) |
 
 The v0.7.1 tokenserver matrix passed on Windows, macOS, and Ubuntu in the
@@ -29,6 +29,15 @@ source. It remained PARTIAL because that PC had no scheduled task, the
 app-owned Codex executable could not be invoked from the validation
 environment, external LAN reachability was not tested, and the panel never
 completed the physical loop.
+
+The newer
+[current-main checkpoint](superpowers/reviews/2026-08-28-windows-current-main-partial.md)
+records the fixes and additional real-PC evidence after v0.7.1. It confirms a
+running scheduled service with bounded logs and fresh Claude/Codex sources on
+an earlier merged candidate, plus a real-Windows Codex probe and green checks
+on current `main`. It remains PARTIAL because the exact final merge was not
+rerun through watchdog, firewall/LAN, session transitions, recent panel
+polling, and the physical answer loop.
 
 ## What “validated on Windows” means
 
@@ -89,4 +98,6 @@ parts rather than merging the stale branch wholesale.
   human touch → originating agent all completed with explicit evidence.
 
 Release notes and social posts should use the narrowest true claim. In
-particular, never turn “Ubuntu tests are green” into “Linux is supported.”
+particular, never turn “Ubuntu tests are green” into “Linux is supported,” or
+“the Windows host service is supported” into “this candidate passed the
+physical Windows loop.”

--- a/docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md
+++ b/docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md
@@ -1,0 +1,68 @@
+# Windows current-main validation checkpoint — 2026-08-28
+
+## Outcome
+
+**PARTIAL — not a Windows physical end-to-end GO.** Real Windows evidence now
+covers the host service, Task Scheduler installation and immediate start,
+bounded logging, and both quota sources on post-v0.7.1 code. The exact current
+`main` commit has green automated checks and a real-Windows Codex app-server
+probe, but it was not reinstalled for the complete lifecycle before the remote
+PC became unavailable.
+
+The unavailable PC is recorded as an evidence boundary, not as a product
+failure and never as a pass. Earlier observations remain valid only for the
+exact commits named below.
+
+## Sanitized checkpoints
+
+| Checkpoint | Exact revision | Evidence |
+|---|---|---|
+| Full real-PC baseline | `71ff7a98c8d763da05191edcc20f3ac889226e8f` | Clean checkout; 783 tests, 11 skips, 0 failures/errors; three PowerShell parsers; Windows PowerShell 5.1 and PowerShell 7 `-ValidateOnly`; temporary real-source endpoints; Task Scheduler install and immediate start; bounded log; fresh Claude and Codex sources |
+| Installed post-fix task | `e20e8a13f50e39292fdf365f774d32822aea7156` | Clean checkout matched `origin/main`; scheduled task was running the exact revision; pinned standalone Codex executable and `CODEX_HOME` were valid; scheduled API returned a numeric, fresh Codex weekly observation; bounded log remained healthy |
+| Current merged main | `7093aff7715fc2e0fbf941db70cdb507c0861c41` | All PR checks passed; the complete tokenserver suite passed with 783 tests and 11 skips; the default-timeout Codex app-server probe passed on real Windows. The complete scheduled-task and physical lifecycle was not rerun on this exact merge commit |
+
+No account identifier, credential, token, session content, prompt payload,
+private path, or LAN address is included here.
+
+## Gate status for current `main`
+
+| Gate | Status | Evidence boundary |
+|---|---|---|
+| Automated Windows suite | PASS | Green Windows matrix and setup-integration checks on the current merge |
+| Real Windows Codex app-server probe | PASS | Default production timeout passed on the PR #37 Windows host run |
+| Exact current-main clean checkout on the PC | NOT TESTED | The host became unavailable before the final clean clone and reinstall |
+| Installer parser and `-ValidateOnly` | PASS on earlier candidate | Real Windows PowerShell 5.1/7 evidence exists for `71ff7a98`; current-main coverage is automated |
+| Task install and immediate start | PASS on earlier merged candidate | Exact scheduled revision was observed after the Windows fixes merged |
+| Exact-process automatic watchdog restart | NOT TESTED on current main | The pre-fix baseline failed; the watchdog fix is merged and tested in CI, but the final real-process repetition is still required |
+| Bounded scheduled-task log | PASS on earlier merged candidate | Current and rotated tails stayed within their bounds with no recent traceback/error |
+| Claude source | PASS on earlier merged candidate | Safe probe status and fresh weekly/model observations were recorded |
+| Codex source | PASS on earlier merged candidate | Scheduled API was fresh with a numeric observation; task-pinned CLI environment was healthy |
+| Private-profile firewall | FAIL | No matching inbound Private TCP 8737 rule was present; the validation process was not elevated and did not change it |
+| Second-device LAN reachability | NOT TESTED | Private-address self-check passed; another LAN device was not used |
+| Recent panel polling | FAIL | Last safe state was `waiting`, not `ready` |
+| Canonical physical question and human answer | NOT TESTED | No visible **APPROVE**, human tap, and returned `answered / 0 / Ja` tuple on Windows |
+| Sign-out/sign-in | NOT TESTED | Requires a real user-session transition |
+| Sleep/resume | NOT TESTED | Requires the physical PC and panel |
+| Reboot | NOT TESTED | Requires the physical PC and panel |
+
+## What can proceed unattended
+
+When the PC is reachable, an agent may use a new clean checkout of the exact
+candidate to rerun the suite, installer validation, task install, immediate
+start, exact-process watchdog restart, bounded-log inspection, safe provider
+health, Private-profile inspection, and LAN self-check. It must preserve only
+sanitized evidence.
+
+## What still requires a person
+
+- Elevation for a missing Private-only firewall rule; never open the Public
+  profile and never silently grant elevation.
+- Review and trust of the exact VibePulse hooks in Codex.
+- A real sign-out/sign-in, sleep/resume, and reboot when those transitions
+  cannot be performed safely by the validation agent.
+- The physical smoke test: visible **APPROVE**, a human tap on `Ja`, and the
+  returned `status: answered`, `option_index: 0`, `answer: Ja` result.
+
+Until every required row passes on one exact candidate, Windows host support
+may be described as implemented and partially real-host validated. The current
+candidate must not be advertised as Windows physical end-to-end validated.

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -180,8 +180,9 @@ Verify all of these and record timestamps:
 4. it returns after sleep/resume;
 5. one full Windows reboot does not leave the panel stale.
 
-The tagged v0.7.1 scheduler task has no persistent stdout/stderr log. The next
-candidate adds `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; keep
+The tagged v0.7.1 scheduler task has no persistent stdout/stderr log.
+Post-v0.7.1 `main` adds
+`%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; keep
 [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) open until the
 new wrapper, rotation, quoting, restart, and non-ASCII-profile path pass on a
 real scheduled task.
@@ -213,6 +214,13 @@ The first real-PC baseline for the tagged v0.7.1 release is recorded in
 [Windows v0.7.1 read-only validation](superpowers/reviews/2026-08-27-windows-v0.7.1-read-only.md).
 It is intentionally PARTIAL and must not be cited as a physical end-to-end
 pass.
+
+The later
+[current-main checkpoint](superpowers/reviews/2026-08-28-windows-current-main-partial.md)
+records post-v0.7.1 Task Scheduler, logging, provider, and Codex app-server
+evidence. It is also intentionally PARTIAL: an earlier commit's PASS does not
+automatically pass a later commit, and an unavailable PC turns unfinished rows
+into NOT TESTED rather than success.
 
 Record each row as PASS, FAIL, or NOT TESTED:
 


### PR DESCRIPTION
## Summary
- add a sanitized, commit-pinned post-v0.7.1 Windows validation checkpoint
- separate supported host implementation from current-candidate physical E2E status
- record the Windows PATH, app-server timeout, and offline-host lessons
- update README, support matrix, validation gate, and changelog

## Evidence
- full local host gate: PASS
- tokenserver suite: 783 tests, 11 skips, 0 failures
- numbers relay: 25 tests passed
- interaction relay: 29 tests passed + TypeScript typecheck
- : PASS

No credential, account identifier, private path, LAN address, prompt payload, or session content is included.