### PR TITLE
Anchor Windows evidence to the host-code revision

### DIFF
--- a/docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md
+++ b/docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md
@@ -4,10 +4,11 @@
 
 **PARTIAL — not a Windows physical end-to-end GO.** Real Windows evidence now
 covers the host service, Task Scheduler installation and immediate start,
-bounded logging, and both quota sources on post-v0.7.1 code. The exact current
-`main` commit has green automated checks and a real-Windows Codex app-server
-probe, but it was not reinstalled for the complete lifecycle before the remote
-PC became unavailable.
+bounded logging, and both quota sources on post-v0.7.1 code. The latest
+host-code revision at this checkpoint has green automated checks and a
+real-Windows Codex app-server probe, but it was not reinstalled for the
+complete lifecycle before the remote PC became unavailable. PR #38 published
+this report with another green CI run and did not change host code.
 
 The unavailable PC is recorded as an evidence boundary, not as a product
 failure and never as a pass. Earlier observations remain valid only for the
@@ -19,7 +20,8 @@ exact commits named below.
 |---|---|---|
 | Full real-PC baseline | `71ff7a98c8d763da05191edcc20f3ac889226e8f` | Clean checkout; 783 tests, 11 skips, 0 failures/errors; three PowerShell parsers; Windows PowerShell 5.1 and PowerShell 7 `-ValidateOnly`; temporary real-source endpoints; Task Scheduler install and immediate start; bounded log; fresh Claude and Codex sources |
 | Installed post-fix task | `e20e8a13f50e39292fdf365f774d32822aea7156` | Clean checkout matched `origin/main`; scheduled task was running the exact revision; pinned standalone Codex executable and `CODEX_HOME` were valid; scheduled API returned a numeric, fresh Codex weekly observation; bounded log remained healthy |
-| Current merged main | `7093aff7715fc2e0fbf941db70cdb507c0861c41` | All PR checks passed; the complete tokenserver suite passed with 783 tests and 11 skips; the default-timeout Codex app-server probe passed on real Windows. The complete scheduled-task and physical lifecycle was not rerun on this exact merge commit |
+| Latest host-code revision | `7093aff7715fc2e0fbf941db70cdb507c0861c41` | All PR #37 checks passed; the complete tokenserver suite passed with 783 tests and 11 skips; the default-timeout Codex app-server probe passed on real Windows. The complete scheduled-task and physical lifecycle was not rerun on this exact host-code revision |
+| Checkpoint publication | [PR #38](https://github.com/niclasvestlund-YT/vibepulse/pull/38) | Documentation-only change; both Windows jobs, both full host gates, both ESP32 builds, and all relay/macOS/Ubuntu jobs passed. This adds no new real-PC evidence |
 
 No account identifier, credential, token, session content, prompt payload,
 private path, or LAN address is included here.


### PR DESCRIPTION
## Summary
- call 7093aff the latest host-code revision at the checkpoint, not self-referential current main
- record PR #38 as the documentation-only publication with green CI
- keep real-PC evidence scoped to the exact code revisions that produced it

## Validation
- documentation-only follow-up
- : PASS
- PR #38 full CI: all 14 check rows passed