### PR TITLE
docs: harden runtime provenance checks

### DIFF
--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -214,6 +214,13 @@ Optional plan badges: `--claude-plan {pro,max5x,max20x}`, `--codex-plan
 {plus,pro}`. Cosmetic labels only, never used in any percentage maths.
 
 For autostart on login, see [../tools/tokenserver/README.md](../tools/tokenserver/README.md).
+Treat the launchd plist, Codex plugin, MCP registration, and marketplace as four
+separate absolute-path integrations: setup being enabled is not enough. They
+must resolve to one clean, durable checkout. After a move, reload launchd with
+`bootout` + `bootstrap`, run doctor and smoke against the configured port, and
+start a new Codex task. The smoke result must identify the expected live
+revision and source fingerprint; old log warnings are not new failures unless
+their timestamps are after the reload.
 Windows installers should follow the complete
 [Windows host runbook](windows-setup.md), not copy a Task Scheduler command in
 isolation.

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -331,6 +331,16 @@ version and reset reason (OBS-01, done). **Watch for:** the plist's
 hardcoded `WorkingDirectory` is still the root cause waiting to recur —
 the guards make it visible, not impossible.
 
+**2026-08-28 recurrence:** the live tokenserver, Codex plugin, MCP registration,
+and marketplace had independently retained absolute paths to older checkouts.
+All could look installed while executing different revisions. Moving the
+plist required `bootout` + `bootstrap`; `kickstart` would have reused launchd's
+cached paths. The repair rule is now stricter: install all four integrations
+from one clean, durable checkout, run setup doctor, verify live `rev` and
+`srcFingerprint` with smoke against the actual port, and start a new Codex task.
+Historical tracebacks remain in the bounded log, so a post-repair verdict must
+also prove that no new error appeared after the new timestamp.
+
 ## 2026-08-13 · Stale data replayed as breaking news
 
 **What happened:** after a tokenserver outage, the revived agent feed's

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -9,10 +9,9 @@
 > `--claude-plan {pro,max5x,max20x}` and/or `--codex-plan
 > {plus,pro}` to show a plan badge on the Max Tracker pages; both flags are
 > optional and purely cosmetic (a display label, never used in any
-> percentage math). Autostart on login: `cp se.torget.tokenserver.plist
-> ~/Library/LaunchAgents/ && launchctl load
-> ~/Library/LaunchAgents/se.torget.tokenserver.plist` (edit the path inside
-> if the repo isn't at `~/Torget`). Default privacy contract: only percentages
+> percentage math). For autostart on login, follow
+> [Autostart via launchd](#autostart-via-launchd) and verify the live revision;
+> do not copy an old plist between checkouts. Default privacy contract: only percentages
 > and counts are served. Optional local interactions can transiently serve
 > bounded detail, but prompts, commands and file contents are not stored.
 > Full details below in Swedish. Your agent translates.
@@ -467,9 +466,11 @@ Windows LAN-IP: `ipconfig`; reservera den valda IPv4-adressen i routern.
 
 ## Autostart via launchd
 
-```
+```sh
 cp se.torget.tokenserver.plist ~/Library/LaunchAgents/
-launchctl load ~/Library/LaunchAgents/se.torget.tokenserver.plist
+plutil -lint ~/Library/LaunchAgents/se.torget.tokenserver.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/se.torget.tokenserver.plist 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/se.torget.tokenserver.plist
 ```
 
 Plisten antar att repot bor i `~/Torget`, att repots Python 3.11+-miljö finns
@@ -480,6 +481,26 @@ annars. Med krypterat interaktionsrelä aktiverat ska den miljön även ha
 omstart; servern roterar den själv vid start om den vuxit förbi ~5 MB, med
 svansen bevarad i `.old`). Raderna har tidsstämplar och loggar övergångar,
 inte tillstånd: en frisk vecka är några rader, inte tusen.
+
+Använd en ren, beständig checkout som inte ska raderas när en PR är klar.
+`ProgramArguments[0]` (Python) och `WorkingDirectory` måste peka på samma
+checkout. Om någon plist-rad ändras räcker inte `kickstart`: launchd behåller
+den redan inlästa konfigurationen. Kör `bootout` + `bootstrap` enligt ovan.
+Bevara privata argument och reläinställningar när bara sökvägen flyttas.
+
+Efter installation eller flytt ska tre lager peka på samma källa:
+
+1. `python3 tools/vibepulse_setup.py doctor` ska godkänna Codex-plugin, MCP
+   och tokenserver. Hook-trust granskas fortfarande manuellt i `/hooks`.
+2. `python3 tools/tokenserver/smoke.py --base-url http://127.0.0.1:8737`
+   ska rapportera den väntade `rev`, matchande källfingeravtryck och noll fel.
+   Ange den faktiskt konfigurerade porten om den inte är 8737.
+3. Starta en ny Codex-task efter att plugin/MCP har flyttats, så att den nya
+   processen verkligen laddas. Tystnad eller en gammal task är inte bevis.
+
+Röktestets totalsiffror för tracebacks och starter omfattar bevarad historik.
+Efter en reparation ska även tidsstämplarna kontrolleras: exakt en ny start och
+inga nya traceback/error-rader efter omladdningen är det friska resultatet.
 
 Snabbaste hälsokollen är röktestet — kamrutinens steg 1–4 som ett kommando:
 


### PR DESCRIPTION
## Summary
- replace the legacy launchctl load example with lint plus bootout/bootstrap
- require plugin, MCP, marketplace and launchd to resolve to one durable clean checkout
- document revision/fingerprint verification, fresh-task loading and timestamp-scoped log review
- record the 2026-08-28 multi-checkout recurrence in lessons learned

## Verification
- git diff --check
- .venv/bin/python -m unittest tools.tokenserver.test_smoke (34 passed)
- live local service: exact d86accc revision, 10 checks OK, 0 current errors, one start since reload

No secrets, tokens, private relay credentials or raw payloads are included.