### PR TITLE
docs: record current-main Windows rerun

### DIFF
--- a/docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md
+++ b/docs/superpowers/reviews/2026-08-28-windows-current-main-partial.md
@@ -3,16 +3,17 @@
 ## Outcome
 
 **PARTIAL — not a Windows physical end-to-end GO.** Real Windows evidence now
-covers the host service, Task Scheduler installation and immediate start,
-bounded logging, and both quota sources on post-v0.7.1 code. The latest
-host-code revision at this checkpoint has green automated checks and a
-real-Windows Codex app-server probe, but it was not reinstalled for the
-complete lifecycle before the remote PC became unavailable. PR #38 published
-this report with another green CI run and did not change host code.
+covers the exact `7c204f9` current-main checkout, PowerShell 5.1/7 validation,
+the complete host suite, Task Scheduler installation and immediate task start,
+the live service, and fresh Claude/Codex quota sources after the asynchronous
+Codex refresh completed. The current rerun also found an unresolved Codex
+plugin/MCP registration discrepancy, no Windows interaction device key, no
+recent panel polling, and the existing Private-firewall gap. Those findings
+prevent a physical end-to-end claim.
 
-The unavailable PC is recorded as an evidence boundary, not as a product
-failure and never as a pass. Earlier observations remain valid only for the
-exact commits named below.
+The earlier unavailable-PC interval remains an evidence boundary, not a
+product failure and never a pass. Observations remain valid only for the exact
+commits named below.
 
 ## Sanitized checkpoints
 
@@ -22,6 +23,7 @@ exact commits named below.
 | Installed post-fix task | `e20e8a13f50e39292fdf365f774d32822aea7156` | Clean checkout matched `origin/main`; scheduled task was running the exact revision; pinned standalone Codex executable and `CODEX_HOME` were valid; scheduled API returned a numeric, fresh Codex weekly observation; bounded log remained healthy |
 | Latest host-code revision | `7093aff7715fc2e0fbf941db70cdb507c0861c41` | All PR #37 checks passed; the complete tokenserver suite passed with 783 tests and 11 skips; the default-timeout Codex app-server probe passed on real Windows. The complete scheduled-task and physical lifecycle was not rerun on this exact host-code revision |
 | Checkpoint publication | [PR #38](https://github.com/niclasvestlund-YT/vibepulse/pull/38) | Documentation-only change; both Windows jobs, both full host gates, both ESP32 builds, and all relay/macOS/Ubuntu jobs passed. This adds no new real-PC evidence |
+| Exact current-main rerun | `7c204f915ee41744c8a8cac7dbbe1082ff5fd77b` | New clean clone matched `origin/main`; the complete tokenserver suite exited 0; parser and `-ValidateOnly` passed in PowerShell 7.6 and Windows PowerShell 5.1; the runner passed; Task Scheduler installed and entered `Running` with the exact checkout plus pinned Codex bin/home; the live API eventually reported the exact revision and fresh Claude/Codex observations. The Codex refresh was asynchronous and temporarily stale before its app-server child completed |
 
 No account identifier, credential, token, session content, prompt payload,
 private path, or LAN address is included here.
@@ -32,16 +34,18 @@ private path, or LAN address is included here.
 |---|---|---|
 | Automated Windows suite | PASS | Green Windows matrix and setup-integration checks on the current merge |
 | Real Windows Codex app-server probe | PASS | Default production timeout passed on the PR #37 Windows host run |
-| Exact current-main clean checkout on the PC | NOT TESTED | The host became unavailable before the final clean clone and reinstall |
-| Installer parser and `-ValidateOnly` | PASS on earlier candidate | Real Windows PowerShell 5.1/7 evidence exists for `71ff7a98`; current-main coverage is automated |
-| Task install and immediate start | PASS on earlier merged candidate | Exact scheduled revision was observed after the Windows fixes merged |
+| Exact current-main clean checkout on the PC | PASS | Fresh clone was clean, exactly `7c204f9`, and contained the required merge |
+| Installer parser and `-ValidateOnly` | PASS | Three scripts parsed with zero errors; `-ValidateOnly` exited 0 in PowerShell 7.6 and Windows PowerShell 5.1 |
+| Task install and immediate start | PASS | Installer exited 0; task entered `Running` and pinned the exact checkout, Codex bin, and Codex home. API readiness took longer than the first 45-second observation window but recovered without a change |
 | Exact-process automatic watchdog restart | NOT TESTED on current main | The pre-fix baseline failed; the watchdog fix is merged and tested in CI, but the final real-process repetition is still required |
-| Bounded scheduled-task log | PASS on earlier merged candidate | Current and rotated tails stayed within their bounds with no recent traceback/error |
-| Claude source | PASS on earlier merged candidate | Safe probe status and fresh weekly/model observations were recorded |
-| Codex source | PASS on earlier merged candidate | Scheduled API was fresh with a numeric observation; task-pinned CLI environment was healthy |
+| Bounded scheduled-task log | PARTIAL on current main | The runner's capture/rotation checks passed and the real task created its log; the live file/rotation bounds were not re-measured in the final rerun |
+| Claude source | PASS | Safe probe status and fresh weekly/model observations were recorded on the exact current-main service |
+| Codex source | PASS | The task-pinned direct probe passed; the scheduled source became fresh with a numeric observation after its asynchronous app-server cycle completed |
+| Codex plugin/MCP registration | FAIL / unresolved | Final doctor reported both missing after the setup command had returned success; a later read-only CLI provenance query timed out. Neither state is called PASS |
+| Windows interaction device key | FAIL | The exact-current-main service reported that no device key was available, so Windows cannot accept a panel verdict |
 | Private-profile firewall | FAIL | No matching inbound Private TCP 8737 rule was present; the validation process was not elevated and did not change it |
 | Second-device LAN reachability | NOT TESTED | Private-address self-check passed; another LAN device was not used |
-| Recent panel polling | FAIL | Last safe state was `waiting`, not `ready` |
+| Recent panel polling | FAIL | Exact-current-main root health reported `waiting`, not `ready` |
 | Canonical physical question and human answer | NOT TESTED | No visible **APPROVE**, human tap, and returned `answered / 0 / Ja` tuple on Windows |
 | Sign-out/sign-in | NOT TESTED | Requires a real user-session transition |
 | Sleep/resume | NOT TESTED | Requires the physical PC and panel |
@@ -49,17 +53,18 @@ private path, or LAN address is included here.
 
 ## What can proceed unattended
 
-When the PC is reachable, an agent may use a new clean checkout of the exact
-candidate to rerun the suite, installer validation, task install, immediate
-start, exact-process watchdog restart, bounded-log inspection, safe provider
-health, Private-profile inspection, and LAN self-check. It must preserve only
-sanitized evidence.
+When the PC is reachable, an agent may continue with the unresolved
+plugin/MCP provenance, exact-process watchdog restart, live log-bound check,
+Private-profile inspection, and LAN self-check. It must use bounded CLI probes,
+kill only diagnostic children it started, and preserve only sanitized evidence.
 
 ## What still requires a person
 
 - Elevation for a missing Private-only firewall rule; never open the Public
   profile and never silently grant elevation.
 - Review and trust of the exact VibePulse hooks in Codex.
+- Provisioning the same private interaction device key on Windows and the
+  panel; the key must never be pasted into an issue, report, or commit.
 - A real sign-out/sign-in, sleep/resume, and reboot when those transitions
   cannot be performed safely by the validation agent.
 - The physical smoke test: visible **APPROVE**, a human tap on `Ja`, and the


### PR DESCRIPTION
## Summary
- record the exact clean Windows rerun of merge 7c204f9
- promote the PowerShell, suite, Task Scheduler and quota-source gates supported by sanitized real-host evidence
- keep watchdog/log bounds/LAN/physical lifecycle unpromoted where the current run did not prove them
- record plugin/MCP provenance, missing interaction key, firewall and panel-polling failures explicitly

## Verification
- git diff --check
- real Windows full tokenserver suite exited 0 on exact 7c204f9
- PowerShell 7.6 and Windows PowerShell 5.1 parser/ValidateOnly gates exited 0

No credentials, tokens, private paths, account data, prompt payloads or LAN addresses are included.