### PR TITLE
Discover local tokenservers across Mac and Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- Optional `_vibepulse._tcp.local` discovery lets one panel stay pinned to a
+  healthy tokenserver and move between advertising macOS/Windows hosts after
+  a bounded failure. The compiled URL remains the multicast-blocked fallback,
+  and the host advert carries only protocol version and port.
 - A versioned host-platform support matrix and reproducible Windows release
   gate now separate CI portability, real-host service evidence, and the
   physical panel loop. Linux remains explicitly unsupported until its XDG,

--- a/README.md
+++ b/README.md
@@ -378,12 +378,14 @@ host address, firewall, Task Scheduler, startup health, and recovery steps.
    ```
 
    **Don't miss this:** in `secrets.h`, point the `TK_VIBEPULSE_BASE_URL`
-   block at your Mac by replacing the `DIN-MAC` placeholder. Those URLs ship
+   fallback at a reachable host by replacing the `DIN-MAC` placeholder. Those URLs ship
    active on purpose — a wrong hostname is visible in the log, whereas an
    undefined URL compiles the fetch out entirely and the screen boots fine
    and shows dashes forever. Use your Mac's Bonjour name
    (`scutil --get LocalHostName`) rather than an IP, so the same firmware
-   works on your home network and on a phone hotspot.
+   works on your home network and on a phone hotspot. Current firmware also
+   discovers `_vibepulse._tcp.local`, so several Mac/Windows tokenservers can
+   be available without compiling their addresses into the panel.
 
    Board not showing up under `/dev/cu.usbmodem*`? Hold **BOOT**, tap
    **RESET**, release **BOOT** and it re-enumerates in download mode.
@@ -393,12 +395,16 @@ host address, firewall, Task Scheduler, startup health, and recovery steps.
    panel's draw makes the board bounce off the bus or hang, which looks
    like a flaky cable. After flashing, run the screen from its own USB
    power supply, not your computer.
-3. Start the core service on your computer. Pure Python stdlib, nothing to
-   install for local mode:
+3. Start the core service on your computer. Its core remains pure Python
+   stdlib. Install the small optional discovery dependency when the panel
+   should find this Mac/PC automatically:
 
    ```
+   python3 -m pip install -r requirements-discovery.txt
    python3 tools/tokenserver/tokenserver.py
    ```
+
+   Without that package the configured URL path works exactly as before.
 
    Autostart on login: see [tools/tokenserver/README.md](tools/tokenserver/README.md).
 

--- a/components/app_tokens/agent_net.c
+++ b/components/app_tokens/agent_net.c
@@ -1,9 +1,12 @@
 /*
- * Agentstatus från VibePulse-tjänsten. En enda HTTP-klient återanvänds av
- * den långlivade tasken; fel lämnar alltid den senaste goda UI-statusen.
+ * Agentstatus från VibePulse-tjänsten. En HTTP-klient återanvänds så länge
+ * samma upptäckta/configurerade värd gäller; fel lämnar senaste goda UI-status.
  */
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+
+#include <stdio.h>
+#include <string.h>
 
 #include "esp_http_client.h"
 #include "esp_log.h"
@@ -13,6 +16,7 @@
 #include "app_tokens.h"
 #include "secrets.h"
 #include "torget.h"
+#include "service_discovery.h"
 
 static const char *TAG = "agent-net";
 
@@ -28,6 +32,43 @@ static const char *TAG = "agent-net";
 #ifdef TK_AGENT_STATUS_URL
 
 static tk_agent_http_response response;
+static portMUX_TYPE s_origin_lock = portMUX_INITIALIZER_UNLOCKED;
+static char s_direct_origin[64];
+
+static bool origin_from_url(const char *url, char *origin, size_t cap) {
+  if (!url || strncmp(url, "http://", 7) != 0 || !origin || cap == 0)
+    return false;
+  const char *path = strchr(url + 7, '/');
+  if (!path) return false;
+  size_t len = (size_t)(path - url);
+  if (len == 0 || len >= cap) return false;
+  memcpy(origin, url, len);
+  origin[len] = '\0';
+  return true;
+}
+
+static void remember_direct_origin(const char *url) {
+  char origin[sizeof s_direct_origin] = {0};
+  if (!origin_from_url(url, origin, sizeof origin)) return;
+  taskENTER_CRITICAL(&s_origin_lock);
+  memcpy(s_direct_origin, origin, sizeof s_direct_origin);
+  s_direct_origin[sizeof s_direct_origin - 1] = '\0';
+  taskEXIT_CRITICAL(&s_origin_lock);
+}
+
+bool tokens_agent_direct_origin(char *origin, size_t cap) {
+  if (!origin || cap == 0) return false;
+  char selected[sizeof s_direct_origin] = {0};
+  taskENTER_CRITICAL(&s_origin_lock);
+  memcpy(selected, s_direct_origin, sizeof selected);
+  taskEXIT_CRITICAL(&s_origin_lock);
+  if (!selected[0] &&
+      !origin_from_url(TK_AGENT_STATUS_URL, selected, sizeof selected)) {
+    return false;
+  }
+  int written = snprintf(origin, cap, "%s", selected);
+  return written >= 0 && (size_t)written < cap;
+}
 
 static esp_err_t status_http_event(esp_http_client_event_t *event) {
   /* ESP-IDF ignorerar callbackens returvärde för ON_DATA. Den bounded
@@ -102,25 +143,42 @@ static void agent_net_task(void *arg) {
   torget_net_wait();
   vTaskDelay(pdMS_TO_TICKS(3000));
 
-  esp_http_client_config_t cfg = {
-    .url = TK_AGENT_STATUS_URL,
-    .timeout_ms = 2500,
-    .keep_alive_enable = true,
-    .keep_alive_idle = 5,
-    .keep_alive_interval = 5,
-    .keep_alive_count = 3,
-    .event_handler = status_http_event,
-    .user_data = &response,
-  };
-  esp_http_client_handle_t client = esp_http_client_init(&cfg);
-  if (!client) {
-    ESP_LOGE(TAG, "agentstatus kunde inte skapa HTTP-klient");
-    vTaskDelete(NULL);
-    return;
-  }
+  esp_http_client_handle_t client = NULL;
+  char client_url[160] = {0};
+  tg_service_source client_source = TG_SERVICE_SOURCE_CONFIGURED;
 
   ESP_LOGI(TAG, "agentstatuspollning startad");
   for (;;) {
+    char selected_url[sizeof client_url];
+    tg_service_source selected_source = TG_SERVICE_SOURCE_CONFIGURED;
+    if (!torget_service_endpoint_url(
+            "/api/agent-status", TK_AGENT_STATUS_URL,
+            selected_url, sizeof selected_url, &selected_source)) {
+      vTaskDelay(pdMS_TO_TICKS(AGENT_POLL_MS));
+      continue;
+    }
+    if (!client || strcmp(client_url, selected_url) != 0) {
+      if (client) esp_http_client_cleanup(client);
+      snprintf(client_url, sizeof client_url, "%s", selected_url);
+      client_source = selected_source;
+      esp_http_client_config_t cfg = {
+        .url = client_url,
+        .timeout_ms = 2500,
+        .keep_alive_enable = true,
+        .keep_alive_idle = 5,
+        .keep_alive_interval = 5,
+        .keep_alive_count = 3,
+        .event_handler = status_http_event,
+        .user_data = &response,
+      };
+      client = esp_http_client_init(&cfg);
+      if (!client) {
+        ESP_LOGW(TAG, "agentstatus kunde inte skapa HTTP-klient");
+        client_url[0] = '\0';
+        vTaskDelay(pdMS_TO_TICKS(AGENT_POLL_MS));
+        continue;
+      }
+    }
     tk_agent_http_fetch_result fetch =
         tk_agent_http_fetch_bounded(client, &response, &status_http_io);
     esp_err_t err = fetch == TK_AGENT_HTTP_FETCH_OK ? ESP_OK : ESP_FAIL;
@@ -131,12 +189,23 @@ static void agent_net_task(void *arg) {
     if (transport_ok && response.status == 200 && !response.overflow) {
       parsed = tk_agent_status_parse(response.body, response.len, &snapshot);
     }
-    if (tk_agent_http_response_can_apply(&response, transport_ok, parsed)) {
+    bool accepted = tk_agent_http_response_can_apply(
+        &response, transport_ok, parsed);
+    bool host_ok = transport_ok && response.status == 200 &&
+                   !response.overflow;
+    torget_service_note_result(client_source, client_url, host_ok);
+    if (accepted) {
+      remember_direct_origin(client_url);
       torget_ui_lock();
       tokens_apply_agent_status(&snapshot);
       torget_ui_unlock();
     } else {
       log_rejection(err, parsed);
+      if (client_source == TG_SERVICE_SOURCE_DISCOVERED && !host_ok) {
+        esp_http_client_cleanup(client);
+        client = NULL;
+        client_url[0] = '\0';
+      }
     }
 
     vTaskDelay(pdMS_TO_TICKS(AGENT_POLL_MS));
@@ -151,6 +220,17 @@ void tokens_agent_net_start(void) {
 }
 
 #else
+
+bool tokens_agent_direct_origin(char *origin, size_t cap) {
+  if (!origin || cap == 0) return false;
+#ifdef TK_VIBEPULSE_BASE_URL
+  int written = snprintf(origin, cap, "%s", TK_VIBEPULSE_BASE_URL);
+  return written >= 0 && (size_t)written < cap;
+#else
+  origin[0] = '\0';
+  return false;
+#endif
+}
 
 void tokens_agent_net_start(void) {
   ESP_LOGW(TAG, "TK_AGENT_STATUS_URL saknas i secrets.h — agentstatus avstängd");

--- a/components/app_tokens/app_tokens.h
+++ b/components/app_tokens/app_tokens.h
@@ -2,6 +2,7 @@
 #define APP_TOKENS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "torget_app.h"
@@ -56,6 +57,9 @@ void tokens_apply_github(const tk_github_status *status);
 /* Targetets 1 Hz-hämtning. Utan TK_AGENT_STATUS_URL loggas avstängt läge
  * och ingen task eller HTTP-klient skapas. */
 void tokens_agent_net_start(void);
+/* Exact LAN origin that produced the latest accepted agent snapshot. Needs
+ * You uses it so a verdict returns to the same Mac/PC in a multi-host LAN. */
+bool tokens_agent_direct_origin(char *origin, size_t cap);
 void tokens_github_net_start(void);
 
 /* Hoppa till en VibePulse-vy utan animation — bänkens och BMP-dumparnas

--- a/components/app_tokens/github_net.c
+++ b/components/app_tokens/github_net.c
@@ -33,8 +33,9 @@ static void github_net_task(void *arg) {
 
   for (;;) {
     tk_github_status status;
-    if (torget_http_get_failover(TK_GITHUB_URL, TK_GITHUB_RELAY_URL,
-                                 body, sizeof body, &len) &&
+    if (torget_http_get_service("/api/github", TK_GITHUB_URL,
+                                TK_GITHUB_RELAY_URL,
+                                body, sizeof body, &len) &&
         tk_github_status_parse(body, len, &status)) {
       torget_ui_lock();
       tokens_apply_github(&status);

--- a/components/app_tokens/needs_you_net.c
+++ b/components/app_tokens/needs_you_net.c
@@ -23,6 +23,7 @@ static const char *TAG = "needs-you-net";
 #include "esp_http_client.h"
 
 #include "agent_monitor.h"
+#include "app_tokens.h"
 #include "agent_status.h"
 #include "needs_you_send_policy.h"
 #include "interaction_relay_policy.h"
@@ -97,8 +98,12 @@ static tk_ir_direct_result post_direct_verdict(const verdict_item *item) {
   char hmac_hex[TK_NEEDS_YOU_HMAC_HEX_CAP];
   char body[TK_NEEDS_YOU_BODY_CAP];
   char url[128];
+  char origin[64];
   const char *verdict_name = tk_needs_you_verdict_name(item->verdict);
-  if (!verdict_name) return TK_IR_DIRECT_HARD_REJECT;
+  if (!verdict_name ||
+      !tokens_agent_direct_origin(origin, sizeof origin)) {
+    return TK_IR_DIRECT_HARD_REJECT;
+  }
 
   if (item->panic) {
     if (tk_needs_you_canonical_message(message, sizeof message,
@@ -109,8 +114,7 @@ static tk_ir_direct_result post_direct_verdict(const verdict_item *item) {
     tk_needs_you_hmac_hex(hmac_hex, TK_VIBEPULSE_DEVICE_KEY, message);
     if (tk_needs_you_panic_body(body, sizeof body, item->ts, hmac_hex) < 0)
       return TK_IR_DIRECT_HARD_REJECT;
-    int written = snprintf(url, sizeof url, "%s/api/panic",
-                           TK_VIBEPULSE_BASE_URL);
+    int written = snprintf(url, sizeof url, "%s/api/panic", origin);
     if (written < 0 || (size_t)written >= sizeof url)
       return TK_IR_DIRECT_HARD_REJECT;
   } else {
@@ -144,7 +148,7 @@ static tk_ir_direct_result post_direct_verdict(const verdict_item *item) {
       }
     }
     int written = snprintf(url, sizeof url, "%s/api/interaction/%s",
-                           TK_VIBEPULSE_BASE_URL, item->context.request_id);
+                           origin, item->context.request_id);
     if (written < 0 || (size_t)written >= sizeof url)
       return TK_IR_DIRECT_HARD_REJECT;
   }

--- a/components/app_tokens/net.c
+++ b/components/app_tokens/net.c
@@ -47,7 +47,8 @@ static void net_task(void *arg) {
 
   for (;;) {
     tk_tokens t;
-    if (torget_http_get_failover(TK_TOKENS_URL, TK_TOKENS_RELAY_URL,
+    if (torget_http_get_service("/api/tokens", TK_TOKENS_URL,
+                                TK_TOKENS_RELAY_URL,
                                 body, sizeof body, &len)
         && tk_tokens_parse(body, len, &t)) {
       torget_ui_lock();
@@ -102,7 +103,8 @@ static void max_tracker_task(void *arg) {
 
   for (;;) {
     tk_max_tracker t;
-    if (torget_http_get_failover(TK_MAX_TRACKER_URL, TK_MAX_TRACKER_RELAY_URL,
+    if (torget_http_get_service("/api/max-tracker", TK_MAX_TRACKER_URL,
+                                TK_MAX_TRACKER_RELAY_URL,
                                 body, sizeof body, &len)
         && tk_max_tracker_parse(body, len, &t)) {
       torget_ui_lock();

--- a/components/torget_net/CMakeLists.txt
+++ b/components/torget_net/CMakeLists.txt
@@ -2,6 +2,7 @@
 # ingenting — nu med reläet som reservväg när LAN:et inte går att nå.
 # net_source_policy är den rena kärnan och värdtestas i test/run.sh.
 idf_component_register(
-  SRCS "torget_http.c" "net_source_policy.c"
+  SRCS "torget_http.c" "net_source_policy.c" "service_discovery.c"
+       "service_discovery_policy.c"
   INCLUDE_DIRS "."
-  PRIV_REQUIRES esp_http_client esp-tls esp_timer freertos)
+  PRIV_REQUIRES esp_http_client esp-tls esp_timer freertos mdns nvs_flash)

--- a/components/torget_net/service_discovery.c
+++ b/components/torget_net/service_discovery.c
@@ -111,7 +111,7 @@ static bool select_result(mdns_result_t *results, char *origin, size_t cap,
   for (mdns_result_t *result = results; result; result = result->next) {
     if (!version_one(result) || result->port == 0) continue;
     for (mdns_ip_addr_t *addr = result->addr; addr; addr = addr->next) {
-      if (addr->addr.type != IPADDR_TYPE_V4) continue;
+      if (addr->addr.type != ESP_IPADDR_TYPE_V4) continue;
       char candidate[TG_DISCOVERY_ORIGIN_CAP];
       int written = snprintf(candidate, sizeof candidate, "http://" IPSTR ":%u",
                              IP2STR(&addr->addr.u_addr.ip4),

--- a/components/torget_net/service_discovery.c
+++ b/components/torget_net/service_discovery.c
@@ -1,0 +1,216 @@
+#include "service_discovery.h"
+#include "service_discovery_policy.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "lwip/ip4_addr.h"
+#include "mdns.h"
+#include "nvs.h"
+
+#define TG_DISCOVERY_ORIGIN_CAP 64
+#define TG_DISCOVERY_QUERY_MS 1500
+#define TG_DISCOVERY_RESULTS 8
+#define TG_DISCOVERY_RETRY_US (10LL * 1000000LL)
+#define TG_DISCOVERY_FAILED_US (30LL * 1000000LL)
+#define TG_DISCOVERY_FAILED_CAP 4
+
+static const char *TAG = "service-discovery";
+static const char *NVS_NAMESPACE = "vibepulse";
+static const char *NVS_ORIGIN_KEY = "service_lkg";
+
+typedef struct {
+  char origin[TG_DISCOVERY_ORIGIN_CAP];
+  int64_t retry_after_us;
+} failed_origin;
+
+static StaticSemaphore_t s_lock_storage;
+static SemaphoreHandle_t s_lock;
+static portMUX_TYPE s_init_lock = portMUX_INITIALIZER_UNLOCKED;
+static bool s_loaded;
+static bool s_querying;
+static bool s_mdns_ready;
+static int64_t s_next_query_us;
+static char s_active_origin[TG_DISCOVERY_ORIGIN_CAP];
+static char s_persisted_origin[TG_DISCOVERY_ORIGIN_CAP];
+static failed_origin s_failed[TG_DISCOVERY_FAILED_CAP];
+static unsigned s_failed_next;
+
+static bool ensure_lock(void) {
+  if (s_lock != NULL) return true;
+  taskENTER_CRITICAL(&s_init_lock);
+  if (s_lock == NULL) s_lock = xSemaphoreCreateMutexStatic(&s_lock_storage);
+  taskEXIT_CRITICAL(&s_init_lock);
+  return s_lock != NULL;
+}
+
+static bool bounded_copy(char *dst, size_t cap, const char *src) {
+  if (!dst || cap == 0 || !src) return false;
+  int written = snprintf(dst, cap, "%s", src);
+  return written >= 0 && (size_t)written < cap;
+}
+
+static void load_lkg_locked(void) {
+  if (s_loaded) return;
+  s_loaded = true;
+  nvs_handle_t handle;
+  if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK) return;
+  size_t len = sizeof s_active_origin;
+  esp_err_t err = nvs_get_str(handle, NVS_ORIGIN_KEY, s_active_origin, &len);
+  nvs_close(handle);
+  if (err != ESP_OK || !tg_service_origin_valid(s_active_origin)) {
+    s_active_origin[0] = '\0';
+    s_persisted_origin[0] = '\0';
+  } else {
+    bounded_copy(s_persisted_origin, sizeof s_persisted_origin,
+                 s_active_origin);
+  }
+}
+
+static void save_lkg(const char *origin) {
+  nvs_handle_t handle;
+  if (!origin || nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle) != ESP_OK)
+    return;
+  esp_err_t err = nvs_set_str(handle, NVS_ORIGIN_KEY, origin);
+  if (err == ESP_OK) err = nvs_commit(handle);
+  nvs_close(handle);
+  if (err != ESP_OK) ESP_LOGW(TAG, "kunde inte spara senast fungerande värd");
+}
+
+static bool version_one(const mdns_result_t *result) {
+  if (!result) return false;
+  for (size_t i = 0; i < result->txt_count; ++i) {
+    if (result->txt[i].key && result->txt[i].value &&
+        strcmp(result->txt[i].key, "v") == 0 &&
+        strcmp(result->txt[i].value, "1") == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool failed_now_locked(const char *origin, int64_t now_us) {
+  for (size_t i = 0; i < TG_DISCOVERY_FAILED_CAP; ++i) {
+    if (s_failed[i].origin[0] &&
+        strcmp(s_failed[i].origin, origin) == 0 &&
+        now_us < s_failed[i].retry_after_us) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool select_result(mdns_result_t *results, char *origin, size_t cap,
+                          int64_t now_us) {
+  for (mdns_result_t *result = results; result; result = result->next) {
+    if (!version_one(result) || result->port == 0) continue;
+    for (mdns_ip_addr_t *addr = result->addr; addr; addr = addr->next) {
+      if (addr->addr.type != IPADDR_TYPE_V4) continue;
+      char candidate[TG_DISCOVERY_ORIGIN_CAP];
+      int written = snprintf(candidate, sizeof candidate, "http://" IPSTR ":%u",
+                             IP2STR(&addr->addr.u_addr.ip4),
+                             (unsigned)result->port);
+      if (written < 0 || (size_t)written >= sizeof candidate) continue;
+      if (xSemaphoreTake(s_lock, portMAX_DELAY) != pdTRUE) return false;
+      bool failed = failed_now_locked(candidate, now_us);
+      xSemaphoreGive(s_lock);
+      if (!failed) return bounded_copy(origin, cap, candidate);
+    }
+  }
+  return false;
+}
+
+static bool query_service(char *origin, size_t cap, int64_t now_us) {
+  if (!s_mdns_ready) {
+    esp_err_t err = mdns_init();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) return false;
+    s_mdns_ready = true;
+  }
+  mdns_result_t *results = NULL;
+  esp_err_t err = mdns_query_ptr("_vibepulse", "_tcp",
+                                 TG_DISCOVERY_QUERY_MS,
+                                 TG_DISCOVERY_RESULTS, &results);
+  bool found = err == ESP_OK && select_result(results, origin, cap, now_us);
+  if (results) mdns_query_results_free(results);
+  return found;
+}
+
+bool torget_service_endpoint_url(const char *path, const char *configured_url,
+                                 char *url, size_t cap,
+                                 tg_service_source *source) {
+  if (source) *source = TG_SERVICE_SOURCE_CONFIGURED;
+  if (!path || !configured_url || !url || cap == 0 || !ensure_lock())
+    return false;
+
+  const int64_t now_us = esp_timer_get_time();
+  bool should_query = false;
+  char active[TG_DISCOVERY_ORIGIN_CAP] = {0};
+  if (xSemaphoreTake(s_lock, portMAX_DELAY) != pdTRUE) return false;
+  load_lkg_locked();
+  if (s_active_origin[0]) {
+    bounded_copy(active, sizeof active, s_active_origin);
+  } else if (!s_querying && now_us >= s_next_query_us) {
+    s_querying = true;
+    should_query = true;
+  }
+  xSemaphoreGive(s_lock);
+
+  if (should_query) {
+    char discovered[TG_DISCOVERY_ORIGIN_CAP] = {0};
+    bool found = query_service(discovered, sizeof discovered, now_us);
+    if (xSemaphoreTake(s_lock, portMAX_DELAY) == pdTRUE) {
+      s_querying = false;
+      s_next_query_us = now_us + TG_DISCOVERY_RETRY_US;
+      if (found) {
+        bounded_copy(s_active_origin, sizeof s_active_origin, discovered);
+        bounded_copy(active, sizeof active, discovered);
+      }
+      xSemaphoreGive(s_lock);
+    }
+  }
+
+  if (active[0] && tg_service_build_endpoint(active, path, url, cap)) {
+    if (source) *source = TG_SERVICE_SOURCE_DISCOVERED;
+    return true;
+  }
+  return bounded_copy(url, cap, configured_url);
+}
+
+void torget_service_note_result(tg_service_source source, const char *url,
+                                bool ok) {
+  if (source != TG_SERVICE_SOURCE_DISCOVERED || !url || !ensure_lock()) return;
+  const char *path = strstr(url + 7, "/");
+  if (!path) return;
+  size_t len = (size_t)(path - url);
+  if (len == 0 || len >= TG_DISCOVERY_ORIGIN_CAP) return;
+  char origin[TG_DISCOVERY_ORIGIN_CAP];
+  memcpy(origin, url, len);
+  origin[len] = '\0';
+
+  bool persist = false;
+  const int64_t now_us = esp_timer_get_time();
+  if (xSemaphoreTake(s_lock, portMAX_DELAY) != pdTRUE) return;
+  load_lkg_locked();
+  if (ok) {
+    persist = strcmp(s_persisted_origin, origin) != 0;
+    bounded_copy(s_active_origin, sizeof s_active_origin, origin);
+    if (persist) {
+      bounded_copy(s_persisted_origin, sizeof s_persisted_origin, origin);
+    }
+  } else {
+    failed_origin *failed = &s_failed[s_failed_next];
+    s_failed_next = (s_failed_next + 1u) % TG_DISCOVERY_FAILED_CAP;
+    bounded_copy(failed->origin, sizeof failed->origin, origin);
+    failed->retry_after_us = now_us + TG_DISCOVERY_FAILED_US;
+    if (strcmp(s_active_origin, origin) == 0) s_active_origin[0] = '\0';
+    s_next_query_us = now_us;
+  }
+  xSemaphoreGive(s_lock);
+  if (ok && persist) save_lkg(origin);
+}

--- a/components/torget_net/service_discovery.h
+++ b/components/torget_net/service_discovery.h
@@ -1,0 +1,25 @@
+#ifndef TORGET_SERVICE_DISCOVERY_H
+#define TORGET_SERVICE_DISCOVERY_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef enum {
+  TG_SERVICE_SOURCE_CONFIGURED = 0,
+  TG_SERVICE_SOURCE_DISCOVERED = 1,
+} tg_service_source;
+
+/* Resolve the local _vibepulse._tcp service and append one fixed endpoint
+ * path.  Discovery is best-effort: multicast failure, missing records, or a
+ * bounded query timeout returns the configured full URL unchanged. */
+bool torget_service_endpoint_url(const char *path, const char *configured_url,
+                                 char *url, size_t cap,
+                                 tg_service_source *source);
+
+/* Feed the exact transport outcome back into the cache.  A successful
+ * discovered origin becomes the NVS last-known-good; a failed one is backed
+ * off and another advertised host may win the next query. */
+void torget_service_note_result(tg_service_source source, const char *url,
+                                bool ok);
+
+#endif

--- a/components/torget_net/service_discovery_policy.c
+++ b/components/torget_net/service_discovery_policy.c
@@ -1,0 +1,25 @@
+#include "service_discovery_policy.h"
+
+#include <stdio.h>
+
+bool tg_service_origin_valid(const char *origin) {
+  if (!origin) return false;
+  unsigned a, b, c, d, port;
+  int consumed = 0;
+  if (sscanf(origin, "http://%u.%u.%u.%u:%u%n",
+             &a, &b, &c, &d, &port, &consumed) != 5) {
+    return false;
+  }
+  return origin[consumed] == '\0' && a <= 255 && b <= 255 && c <= 255 &&
+         d <= 255 && port >= 1 && port <= 65535;
+}
+
+bool tg_service_build_endpoint(const char *origin, const char *path,
+                               char *url, size_t cap) {
+  if (!tg_service_origin_valid(origin) || !path || path[0] != '/' ||
+      !url || cap == 0) {
+    return false;
+  }
+  int written = snprintf(url, cap, "%s%s", origin, path);
+  return written >= 0 && (size_t)written < cap;
+}

--- a/components/torget_net/service_discovery_policy.h
+++ b/components/torget_net/service_discovery_policy.h
@@ -1,0 +1,13 @@
+#ifndef TORGET_SERVICE_DISCOVERY_POLICY_H
+#define TORGET_SERVICE_DISCOVERY_POLICY_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Discovered/LKG origins are deliberately narrower than general URLs:
+ * mDNS supplies one IPv4 address and one TCP port, never a path or userinfo. */
+bool tg_service_origin_valid(const char *origin);
+bool tg_service_build_endpoint(const char *origin, const char *path,
+                               char *url, size_t cap);
+
+#endif

--- a/components/torget_net/torget_http.c
+++ b/components/torget_net/torget_http.c
@@ -13,6 +13,7 @@
 #include "esp_timer.h"
 
 #include "net_source_policy.h"
+#include "service_discovery.h"
 
 static const char *TAG = "torget-http";
 
@@ -161,4 +162,44 @@ bool torget_http_get_failover(const char *lan_url, const char *relay_url,
   tg_net_source_note(&state, TG_NET_SOURCE_RELAY, ok, now);
   atomic_store(&s_relay_won, state.relay_won);
   return ok;
+}
+
+bool torget_http_get_service(const char *path, const char *configured_url,
+                             const char *relay_url, char *buf, size_t cap,
+                             size_t *len_out) {
+  char discovered[160];
+  tg_service_source source = TG_SERVICE_SOURCE_CONFIGURED;
+  if (!torget_service_endpoint_url(path, configured_url, discovered,
+                                   sizeof discovered, &source)) {
+    return false;
+  }
+  if (source == TG_SERVICE_SOURCE_CONFIGURED ||
+      strcmp(discovered, configured_url) == 0) {
+    return torget_http_get_failover(configured_url, relay_url,
+                                    buf, cap, len_out);
+  }
+
+  bool ok = http_get_timeout(discovered, buf, cap, len_out,
+                             TG_NET_REPROBE_TIMEOUT_MS, false);
+  torget_service_note_result(source, discovered, ok);
+  if (ok) return true;
+
+  /* The failed origin is now backed off. One immediate query may select a
+   * second advertising Mac/PC without waiting for the next poll interval. */
+  char alternate[160];
+  tg_service_source alternate_source = TG_SERVICE_SOURCE_CONFIGURED;
+  if (torget_service_endpoint_url(path, configured_url, alternate,
+                                  sizeof alternate, &alternate_source) &&
+      alternate_source == TG_SERVICE_SOURCE_DISCOVERED &&
+      strcmp(alternate, discovered) != 0 &&
+      strcmp(alternate, configured_url) != 0) {
+    ok = http_get_timeout(alternate, buf, cap, len_out,
+                          TG_NET_REPROBE_TIMEOUT_MS, false);
+    torget_service_note_result(alternate_source, alternate, ok);
+    if (ok) return true;
+  }
+
+  ESP_LOGI(TAG, "lokala VibePulse-värdar svarade inte, provar reservvägen");
+  return torget_http_get_failover(configured_url, relay_url,
+                                  buf, cap, len_out);
 }

--- a/components/torget_net/torget_http.h
+++ b/components/torget_net/torget_http.h
@@ -44,4 +44,11 @@ bool torget_http_get(const char *url, char *buf, size_t cap, size_t *len_out);
 bool torget_http_get_failover(const char *lan_url, const char *relay_url,
                               char *buf, size_t cap, size_t *len_out);
 
+/* Prefer a healthy _vibepulse._tcp service discovered on this LAN.  If mDNS
+ * is unavailable or every advertised host fails, preserve the exact existing
+ * configured-LAN then optional-relay behavior. */
+bool torget_http_get_service(const char *path, const char *configured_url,
+                             const char *relay_url, char *buf, size_t cap,
+                             size_t *len_out);
+
 #endif

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -73,10 +73,11 @@ Then edit `secrets.h`. Two separate things must be right:
   the only network it knows before it has ever been anywhere. Every network
   *after* the first is taught to the panel at the place itself, with no
   rebuild — see [wifi.md](wifi.md).
-- **Replace `DIN-MAC` in `TK_VIBEPULSE_BASE_URL`** with an address the panel
-  can reach. On macOS, use the Mac's Bonjour name. On Windows, use the active
-  LAN IPv4 address and reserve that address in the router; the tokenserver does
-  not advertise an mDNS name on Windows.
+- **Replace `DIN-MAC` in `TK_VIBEPULSE_BASE_URL`** with a reachable fallback.
+  On macOS, use the Mac's Bonjour name. On Windows, use an active LAN IPv4
+  address and reserve it in the router. Current firmware first discovers
+  `_vibepulse._tcp.local`; the compiled URL remains the fail-closed path when
+  multicast or the optional host advertiser is unavailable.
 
 Those `#define`s ship active on purpose, with an obvious placeholder. Do not
 comment them out or delete them: `components/app_tokens/net.c` guards every
@@ -92,10 +93,17 @@ home and on a phone hotspot:
 scutil --get LocalHostName     # e.g. "Niclas-MacBook" -> Niclas-MacBook.local
 ```
 
-On Windows, use `ipconfig` to find the IPv4 address of the active adapter. A
-DHCP reservation matters: if that address changes, direct-LAN mode shows
-dashes until the URL is rebuilt. The optional relays remove the same-LAN
-requirement but do not make a stale local URL correct.
+Install the optional discovery advertiser in the tokenserver's exact Python
+environment on every Mac/PC that may serve the panel:
+
+```sh
+python3 -m pip install -r requirements-discovery.txt
+```
+
+Without it, the tokenserver remains stdlib-only and the compiled URL behaves
+exactly as before. With it, several computers may advertise simultaneously;
+the panel pins one healthy origin and changes only after failure. On Windows,
+`ipconfig` plus a DHCP reservation still makes the compiled fallback durable.
 
 **Verify:** `secrets.h` has a non-empty SSID and no `DIN-MAC` placeholder:
 
@@ -104,11 +112,11 @@ grep -q 'DIN-MAC' secrets.h && echo "PLACEHOLDER STILL THERE" || echo "host set"
 ```
 
 It must print `host set`. If the placeholder is still there,
-the board will look for a host that does not exist and every page will stay
-on dashes. On macOS, a raw IP is a snapshot of a DHCP lease and should be
-replaced with the Bonjour name. On Windows, document the DHCP reservation
-that keeps the chosen IPv4 stable. A stale compiled address cost an entire
-evening of network debugging before anyone read the URL
+the board's fallback will name a host that does not exist. Discovery may still
+find an advertising service, but a release must not depend on hiding a broken
+fallback. On macOS, replace a raw IP with the Bonjour name. On Windows,
+document the DHCP reservation that keeps the fallback IPv4 stable. A stale
+compiled address cost an entire evening of network debugging before anyone read the URL
 (`docs/lessons.md` 2026-08-17).
 
 Ask the user for the WiFi password. Do not guess it, and do not commit

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,17 @@ point at the backlog item.
 
 ---
 
+## 2026-08-28 · USB-värden var inte panelens datavärd
+
+**What happened:** panelen flyttades från Macens USB-port till Windows och
+fortsatte visa Macens gamla kvot. **Root cause:** USB gav bara ström; firmware
+pollade fortfarande en ensam kompilerad tokenserveradress. **The rule:** lokal
+värdidentitet ska upptäckas som en tjänst, hållas sticky medan den är frisk och
+falla tillbaka till den explicita URL:en när multicast saknas. **Guards:**
+valfri innehållsfri DNS-SD-annons, strikt IPv4/port-policy, bounded mDNS-query,
+NVS last-known-good och Mac/Windows-failoverprov. **Watch for:** att kalla en
+strömförflyttning för ett källbyte eller att blanda endpoints från två värdar.
+
 ## 2026-08-28 · A healthy scheduled Codex source failed in the interactive shell
 
 **What happened:** a direct Windows probe failed while the scheduled API

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -161,10 +161,18 @@ Get-NetConnectionProfile | Select-Object Name, NetworkCategory
 ipconfig
 ```
 
-Reserve that IPv4 address in the router. Windows does not yet provide the
-stable `.local` discovery tracked in
-[#7](https://github.com/niclasvestlund-YT/vibepulse/issues/7), so firmware
-compiled with an old DHCP address eventually shows dashes.
+Install the optional advertiser in the exact Python environment used by the
+scheduled task, then restart the task through the normal installer flow:
+
+```powershell
+py -3 -m pip install -r requirements-discovery.txt
+```
+
+`GET /` must then report `discovery.status: ready`. Current firmware browses
+`_vibepulse._tcp.local`, caches the last healthy origin in NVS, and can choose
+another advertising Mac/PC after a bounded failure. Reserve the fallback IPv4
+in the router anyway: multicast can be blocked and discovery must never make
+direct LAN less reliable than the configured path.
 
 Inspect before changing the firewall:
 

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -154,10 +154,12 @@ same LAN, verify the PC's real address rather than localhost:
 Test-NetConnection -ComputerName <PC-LAN-IP> -Port 8737
 ```
 
-The panel's direct-LAN URL must use that reachable address. Reserve it in the
-router or use the optional relays; Windows does not currently provide the
-stable `.local` discovery tracked in
-[#7](https://github.com/niclasvestlund-YT/vibepulse/issues/7).
+Install `requirements-discovery.txt` in the scheduled task's exact Python
+environment. Require `GET /` → `discovery.status: ready`, then prove a real
+panel poll. The firmware caches one healthy `_vibepulse._tcp.local` origin and
+may select another advertising Mac/PC after failure. Keep a DHCP-reserved
+compiled URL as the multicast-blocked fallback; discovery is additive, never
+a reason to accept an unstable fallback.
 
 ## 7. Verify the real service lifecycle
 
@@ -167,7 +169,7 @@ Only after the release checkout and installer validation pass:
 .\tools\tokenserver\install-windows-task.ps1
 Get-ScheduledTaskInfo -TaskName "VibePulse tokenserver"
 Invoke-RestMethod http://127.0.0.1:8737/ |
-  Select-Object service, rev, srcFingerprint, claudeProbe, claudeCredential,
+  Select-Object service, rev, srcFingerprint, discovery, claudeProbe, claudeCredential,
     @{Name='panel'; Expression={$_.interactions.panel}}
 ```
 

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -11,3 +11,5 @@ dependencies:
   ## ChatGPT Voice + wake word-motorn. tinyusb följer med usb_device_uac.
   espressif/usb_device_uac: "^1.3.1"
   espressif/esp-tflite-micro: "^1.3.0"
+  ## Stable local tokenserver discovery on macOS, Windows, and Linux.
+  espressif/mdns: "1.11.3"

--- a/requirements-discovery.txt
+++ b/requirements-discovery.txt
@@ -1,0 +1,3 @@
+# Optional local DNS-SD advertisement. The tokenserver stays stdlib-only and
+# falls back silently to the configured firmware URL when this is absent.
+zeroconf==0.150.0

--- a/secrets.h.example
+++ b/secrets.h.example
@@ -33,11 +33,18 @@
 #define TG_WIFI2_SSID  ""
 #define TG_WIFI2_PASS  ""
 
-/* VibePulse: Mac-tjänsten på LAN:et (tools/tokenserver).
+/* VibePulse: tjänsten på LAN:et (tools/tokenserver, macOS/Windows/Linux).
  *
- * Byt DIN-MAC mot Macens Bonjour-namn — inte en IP-adress, så fungerar samma
- * firmware på både hemnät och telefon-hotspot. Namnet visas av:
+ * Ny firmware hittar automatiskt friska tokenservrar som annonserar
+ * _vibepulse._tcp.local. Adressen nedan är den oförändrade reservvägen när
+ * multicast eller den valfria värdannonsen saknas. Byt DIN-MAC mot Macens
+ * Bonjour-namn — inte en IP-adress. Namnet visas av:
  *   scutil --get LocalHostName
+ *
+ * På Windows kan reservvägen vara en DHCP-reserverad LAN-adress; den normala
+ * stabila vägen är `requirements-discovery.txt` på varje tokenservervärd.
+ * Flera Mac/PC får annonsera samtidigt: panelen håller sig till en frisk värd
+ * och byter först när den slutar svara.
  *
  * URL:erna är AVSIKTLIGT aktiva här: en odefinierad URL kompilerar bort
  * hämttasken helt, och då bootar skärmen glatt och visar streck för evigt

--- a/spec/hardware-capabilities.yaml
+++ b/spec/hardware-capabilities.yaml
@@ -165,6 +165,7 @@ capabilities:
       - torget-main-1fad449
       - waveshare-board-docs-2026-08-10
       - esp32s3-datasheet-2026-08-10
+      - espressif-mdns-1.11.3
     evidence:
       - {field: soc_capable, value: "yes", source: esp32s3-datasheet-2026-08-10}
       - {field: board_wired, value: "yes", source: waveshare-schematic-2026-08-10}

--- a/spec/hardware-sources.yaml
+++ b/spec/hardware-sources.yaml
@@ -108,3 +108,12 @@ sources:
     locator: https://docs.espressif.com/projects/esp-idf/en/v5.5/esp32s3/api-reference/peripherals/usb_device.html
     revision: ESP-IDF-v5.5
     accessed: "2026-08-10"
+
+  - id: espressif-mdns-1.11.3
+    kind: source-code
+    rank: 3
+    title: espressif/mdns
+    publisher: Espressif Systems
+    locator: https://components.espressif.com/components/espressif/mdns
+    revision: 1.11.3
+    accessed: "2026-08-28"

--- a/test/run.sh
+++ b/test/run.sh
@@ -234,6 +234,12 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 /tmp/torget-net-source-test
 
 cc -std=c11 -Wall -Wextra -Werror -O1 \
+  ../components/torget_net/service_discovery_policy.c \
+  test_service_discovery_policy.c \
+  -o /tmp/torget-service-discovery-policy-test
+/tmp/torget-service-discovery-policy-test
+
+cc -std=c11 -Wall -Wextra -Werror -O1 \
   ../components/torget_wifi/wifi_slots.c \
   test_wifi_slots.c \
   -lm \
@@ -277,6 +283,7 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_ota_sender_gates.py
 "$PYTHON_BIN" test_wifi_setup_wiring.py
 "$PYTHON_BIN" test_relay_boundary.py
+"$PYTHON_BIN" test_service_discovery_wiring.py
 "$PYTHON_BIN" test_numbers_relay_docs.py
 "$PYTHON_BIN" test_numbers_relay_js_wiring.py
 "$PYTHON_BIN" test_interaction_relay_boundary.py

--- a/test/test_agent_net_wiring.py
+++ b/test/test_agent_net_wiring.py
@@ -58,7 +58,7 @@ assert re.search(
 ), "agent task start must sit next to the existing VibePulse task start"
 
 required_config = (
-    ".url = TK_AGENT_STATUS_URL",
+    ".url = client_url",
     ".timeout_ms = 2500",
     ".keep_alive_enable = true",
     ".keep_alive_idle = 5",
@@ -83,9 +83,12 @@ for operation in (
     "esp_http_client_close(",
 ):
     assert operation in source, f"bounded adapter must use {operation}"
-assert "esp_http_client_cleanup(" not in source, (
-    "the long-lived polling task must not destroy its client per poll"
+assert "strcmp(client_url, selected_url) != 0" in source
+assert "if (client) esp_http_client_cleanup(client);" in source, (
+    "the long-lived client must be replaced only when discovery changes host"
 )
+assert "torget_service_note_result(client_source, client_url, host_ok);" in source
+assert "remember_direct_origin(client_url);" in source
 assert re.search(
     r"tk_agent_source_note_lan\([^;]+;\s*"
     r"usage_screen_apply_agent\(snapshot, now_us\);", app, re.DOTALL
@@ -155,6 +158,7 @@ for binding_copy in (
     assert binding_copy in needs_you_net, f"missing queued binding: {binding_copy}"
 assert "tk_needs_you_canonical_message_v2(" in needs_you_net
 assert "tk_needs_you_answer_body_v2(" in needs_you_net
+assert "tokens_agent_direct_origin(origin, sizeof origin)" in needs_you_net
 assert re.search(
     r"context->provider\s*==\s*TK_AGENT_PROVIDER_CODEX\s*&&\s*"
     r"!context->has_view_sha256",

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -45,9 +45,9 @@ for name in ("TK_TOKENS_RELAY_URL", "TK_MAX_TRACKER_RELAY_URL",
 assert "#else" in config and "TK_TOKENS_RELAY_URL      NULL" in config, (
     "without TK_VIBEPULSE_RELAY_URL every relay address must be NULL"
 )
-assert "torget_http_get_failover(TK_TOKENS_URL, TK_TOKENS_RELAY_URL" in net
-assert "torget_http_get_failover(TK_MAX_TRACKER_URL" in net
-assert "torget_http_get_failover(TK_GITHUB_URL" in github
+assert 'torget_http_get_service("/api/tokens", TK_TOKENS_URL' in net
+assert 'torget_http_get_service("/api/max-tracker", TK_MAX_TRACKER_URL' in net
+assert 'torget_http_get_service("/api/github", TK_GITHUB_URL' in github
 
 # --- What may not cross the numbers transport: anything naming your work --
 assert "RELAY" not in agent.upper()
@@ -63,8 +63,8 @@ assert "tk_interaction_relay_queue_verdict" in needs_you, (
 
 # The direct verdict route stays on LAN; remote delivery belongs only to the
 # separate encrypted client and must not enter the numbers failover helper.
-assert "TK_VIBEPULSE_BASE_URL" in needs_you, (
-    "the Needs You verdict must post to the LAN base URL"
+assert "tokens_agent_direct_origin" in needs_you, (
+    "the Needs You verdict must return to the LAN host that supplied it"
 )
 
 # --- The failover helper itself -----------------------------------------

--- a/test/test_service_discovery_policy.c
+++ b/test/test_service_discovery_policy.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../components/torget_net/service_discovery_policy.h"
+
+static int failures;
+
+static void check(const char *name, int condition) {
+  if (!condition) {
+    printf("FAIL %s\n", name);
+    ++failures;
+  }
+}
+
+int main(void) {
+  check("valid private IPv4 origin",
+        tg_service_origin_valid("http://192.168.1.8:8737"));
+  check("valid edge octets",
+        tg_service_origin_valid("http://0.255.1.2:65535"));
+  check("rejects path",
+        !tg_service_origin_valid("http://192.168.1.8:8737/api/tokens"));
+  check("rejects userinfo",
+        !tg_service_origin_valid("http://user@192.168.1.8:8737"));
+  check("rejects bad octet",
+        !tg_service_origin_valid("http://256.1.1.1:8737"));
+  check("rejects zero port",
+        !tg_service_origin_valid("http://192.168.1.8:0"));
+  check("rejects overflow port",
+        !tg_service_origin_valid("http://192.168.1.8:65536"));
+  check("rejects https",
+        !tg_service_origin_valid("https://192.168.1.8:8737"));
+
+  char url[64];
+  check("builds bounded endpoint",
+        tg_service_build_endpoint("http://192.168.1.8:8737", "/api/tokens",
+                                  url, sizeof url) &&
+        strcmp(url, "http://192.168.1.8:8737/api/tokens") == 0);
+  check("rejects relative path",
+        !tg_service_build_endpoint("http://192.168.1.8:8737", "api/tokens",
+                                   url, sizeof url));
+  check("rejects truncation",
+        !tg_service_build_endpoint("http://192.168.1.8:8737", "/api/tokens",
+                                   url, 8));
+
+  if (failures == 0) {
+    puts("OK: discovered origins and endpoint URLs are strict and bounded");
+    return 0;
+  }
+  return 1;
+}

--- a/test/test_service_discovery_wiring.py
+++ b/test/test_service_discovery_wiring.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Guard the optional host advert and fail-closed firmware fallback."""
+
+from pathlib import Path
+
+
+root = Path(__file__).resolve().parents[1]
+read = lambda path: (root / path).read_text(encoding="utf-8")
+
+manifest = read("main/idf_component.yml")
+cmake = read("components/torget_net/CMakeLists.txt")
+discovery = read("components/torget_net/service_discovery.c")
+http = read("components/torget_net/torget_http.c")
+tokenserver = read("tools/tokenserver/tokenserver.py")
+host_discovery = read("tools/tokenserver/discovery.py")
+
+assert 'espressif/mdns: "1.11.3"' in manifest
+assert '"service_discovery.c"' in cmake and " mdns " in cmake
+assert 'mdns_query_ptr("_vibepulse", "_tcp"' in discovery
+assert "TG_DISCOVERY_QUERY_MS 1500" in discovery
+assert "NVS_ORIGIN_KEY" in discovery and "service_lkg" in discovery
+assert "failed_now_locked" in discovery
+assert "TG_SERVICE_SOURCE_CONFIGURED" in discovery
+assert "torget_http_get_failover(configured_url, relay_url" in http
+assert "torget_service_note_result" in http
+
+assert "DiscoveryAdvertiser(log)" in tokenserver
+assert "discovery.start(args.port)" in tokenserver
+assert "discovery.stop()" in tokenserver
+assert 'SERVICE_TYPE = "_vibepulse._tcp.local."' in host_discovery
+assert "except ImportError:" in host_discovery
+for forbidden in ("token", "quota", "account", "prompt", "project"):
+    properties = host_discovery.split("properties={", 1)[1].split("}", 1)[0]
+    assert forbidden not in properties.lower()
+
+print("OK: mDNS discovery is bounded, optional, cached, and falls back closed")

--- a/test/tokenserver-suite.txt
+++ b/test/tokenserver-suite.txt
@@ -20,4 +20,5 @@ tools.tokenserver.test_interaction_relay
 tools.tokenserver.test_interaction_relay_integration
 tools.tokenserver.test_interaction_relay_crypto
 tools.tokenserver.test_publisher
+tools.tokenserver.test_discovery
 tools.tokenserver.test_smoke

--- a/tools/test_hardware_registry.py
+++ b/tools/test_hardware_registry.py
@@ -1028,7 +1028,7 @@ class RepositoryRegistryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
             result.stdout,
-            "OK: 30 capabilities, 10 sources, 1 units\n",
+            "OK: 30 capabilities, 11 sources, 1 units\n",
         )
 
     def test_repository_registry_loads(self):
@@ -1112,6 +1112,7 @@ class RepositoryRegistryTests(unittest.TestCase):
             "waveshare-cst9217-driver-1.0.0": (
                 "source-code", 3, "2.0.0",
             ),
+            "espressif-mdns-1.11.3": ("source-code", 3, "1.11.3"),
             "torget-main-1fad449": ("source-code", 3, "1fad449"),
             "waveshare-board-docs-2026-08-10": (
                 "vendor-doc", 4, "accessed-2026-08-10",

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -453,9 +453,19 @@ timmarna i den aktuella veckocykeln. Resultatet är antingen `collecting`,
 `unavailable`, beräknad procent vid reset (`at_reset`) eller beräknad tid då
 quotan tar slut (`exhausts`).
 
-Peka skärmen hit i reporotens `secrets.h`. På macOS är Bonjour-namnet bäst;
-på Windows används den aktiva LAN-adressen med en DHCP-reservation eftersom
-tjänsten inte annonserar mDNS där:
+Installera den valfria lokala upptäckten i samma Pythonmiljö som tjänsten:
+
+```sh
+python3 -m pip install -r requirements-discovery.txt
+```
+
+Tjänsten annonserar då `_vibepulse._tcp.local` utan kvoter, projektdata eller
+hemligheter. Aktuell firmware cachar en frisk Mac/PC och byter först efter ett
+begränsat fel. Utan paketet startar samma stdlib-tjänst och använder den
+kompilerade reservadressen exakt som tidigare.
+
+Peka därför fortfarande skärmens fallback hit i reporotens `secrets.h`. På
+macOS är Bonjour-namnet bäst; på Windows används en DHCP-reserverad LAN-adress:
 
 ```c
 #define TK_TOKENS_URL "http://<datorns-host-eller-lan-ip>:8737/api/tokens"

--- a/tools/tokenserver/discovery.py
+++ b/tools/tokenserver/discovery.py
@@ -1,0 +1,138 @@
+"""Best-effort DNS-SD advertisement for the local VibePulse service.
+
+The tokenserver deliberately remains runnable with the Python standard
+library only.  When ``zeroconf`` is installed we advertise the already-bound
+HTTP listener; otherwise startup continues with the configured-address path.
+No account data, credentials, repository names, or quota values enter mDNS.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from dataclasses import dataclass
+
+
+SERVICE_TYPE = "_vibepulse._tcp.local."
+PROTOCOL_VERSION = "1"
+
+
+def _safe_dns_label(value: str) -> str:
+    label = "".join(
+        char.lower() if char.isascii() and char.isalnum() else "-"
+        for char in value
+    ).strip("-")
+    while "--" in label:
+        label = label.replace("--", "-")
+    return (label or "host")[:48]
+
+
+def _local_ipv4_addresses() -> tuple[bytes, ...]:
+    """Return distinct routable local IPv4 addresses in packed form."""
+    found: set[str] = set()
+    try:
+        rows = socket.getaddrinfo(
+            socket.gethostname(), None, socket.AF_INET, socket.SOCK_DGRAM
+        )
+    except OSError:
+        rows = []
+    for row in rows:
+        try:
+            address = ipaddress.ip_address(row[4][0])
+        except (IndexError, ValueError):
+            continue
+        if not isinstance(address, ipaddress.IPv4Address):
+            continue
+        if address.is_loopback or address.is_link_local or address.is_unspecified:
+            continue
+        found.add(str(address))
+    return tuple(socket.inet_aton(value) for value in sorted(found))
+
+
+@dataclass
+class DiscoveryAdvertiser:
+    """Own one optional zeroconf registration and close it deterministically."""
+
+    logger: logging.Logger
+    status: str = "off"
+    reason: str | None = None
+    _zeroconf: object | None = None
+    _service_info: object | None = None
+
+    def start(self, port: int) -> bool:
+        if not 1 <= port <= 65535:
+            self.status = "error"
+            self.reason = "invalid-port"
+            return False
+        try:
+            from zeroconf import ServiceInfo, Zeroconf
+        except ImportError:
+            self.status = "unavailable"
+            self.reason = "dependency-missing"
+            self.logger.info(
+                "lokal VibePulse-upptäckt ej annonserad (zeroconf saknas)"
+            )
+            return False
+
+        addresses = _local_ipv4_addresses()
+        if not addresses:
+            self.status = "unavailable"
+            self.reason = "no-lan-address"
+            self.logger.info(
+                "lokal VibePulse-upptäckt väntar (ingen LAN-adress hittad)"
+            )
+            return False
+
+        host_label = _safe_dns_label(socket.gethostname())
+        service_name = f"VibePulse-{host_label}.{SERVICE_TYPE}"
+        server_name = f"vibepulse-{host_label}.local."
+        info = ServiceInfo(
+            SERVICE_TYPE,
+            service_name,
+            addresses=list(addresses),
+            port=port,
+            properties={b"v": PROTOCOL_VERSION.encode("ascii")},
+            server=server_name,
+        )
+        zc = None
+        try:
+            zc = Zeroconf()
+            zc.register_service(info, allow_name_change=True)
+        except Exception as exc:  # optional transport must never kill service
+            if zc is not None:
+                try:
+                    zc.close()
+                except Exception:
+                    pass
+            self.status = "error"
+            self.reason = type(exc).__name__
+            self.logger.warning(
+                "lokal VibePulse-upptäckt kunde inte annonseras (%s)",
+                type(exc).__name__,
+            )
+            return False
+
+        self._zeroconf = zc
+        self._service_info = info
+        self.status = "ready"
+        self.reason = None
+        self.logger.info("lokal VibePulse-upptäckt annonserad via mDNS")
+        return True
+
+    def stop(self) -> None:
+        zc, info = self._zeroconf, self._service_info
+        self._zeroconf = None
+        self._service_info = None
+        if zc is None:
+            return
+        try:
+            if info is not None:
+                zc.unregister_service(info)
+        except Exception:
+            self.logger.warning("kunde inte avregistrera VibePulse mDNS rent")
+        finally:
+            try:
+                zc.close()
+            except Exception:
+                self.logger.warning("kunde inte stänga VibePulse mDNS rent")

--- a/tools/tokenserver/test_discovery.py
+++ b/tools/tokenserver/test_discovery.py
@@ -1,0 +1,94 @@
+import logging
+import socket
+import sys
+import types
+import unittest
+from unittest import mock
+
+from . import discovery
+
+
+class _FakeZeroconf:
+    instances = []
+
+    def __init__(self):
+        self.registered = []
+        self.unregistered = []
+        self.closed = False
+        self.instances.append(self)
+
+    def register_service(self, info, allow_name_change=False):
+        self.registered.append((info, allow_name_change))
+
+    def unregister_service(self, info):
+        self.unregistered.append(info)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeServiceInfo:
+    def __init__(self, type_, name, **kwargs):
+        self.type = type_
+        self.name = name
+        self.kwargs = kwargs
+
+
+class DiscoveryTests(unittest.TestCase):
+    def setUp(self):
+        _FakeZeroconf.instances.clear()
+        self.logger = logging.getLogger("test-discovery")
+
+    def test_safe_label_is_bounded_and_dns_compatible(self):
+        self.assertEqual(discovery._safe_dns_label("PC å Ä / Test"),
+                         "pc-test")
+        self.assertLessEqual(len(discovery._safe_dns_label("x" * 100)), 48)
+        self.assertEqual(discovery._safe_dns_label("---"), "host")
+
+    def test_addresses_exclude_loopback_and_link_local(self):
+        rows = [
+            (socket.AF_INET, socket.SOCK_DGRAM, 0, "", ("127.0.0.1", 0)),
+            (socket.AF_INET, socket.SOCK_DGRAM, 0, "", ("169.254.1.2", 0)),
+            (socket.AF_INET, socket.SOCK_DGRAM, 0, "", ("192.168.1.8", 0)),
+            (socket.AF_INET, socket.SOCK_DGRAM, 0, "", ("192.168.1.8", 0)),
+        ]
+        with mock.patch.object(socket, "getaddrinfo", return_value=rows):
+            self.assertEqual(discovery._local_ipv4_addresses(),
+                             (socket.inet_aton("192.168.1.8"),))
+
+    def test_missing_dependency_is_nonfatal(self):
+        advertiser = discovery.DiscoveryAdvertiser(self.logger)
+        with mock.patch.dict(sys.modules, {"zeroconf": None}):
+            self.assertFalse(advertiser.start(8737))
+        self.assertEqual(advertiser.status, "unavailable")
+        self.assertEqual(advertiser.reason, "dependency-missing")
+
+    def test_registers_only_protocol_and_port_then_closes(self):
+        fake_module = types.SimpleNamespace(
+            Zeroconf=_FakeZeroconf, ServiceInfo=_FakeServiceInfo)
+        advertiser = discovery.DiscoveryAdvertiser(self.logger)
+        with mock.patch.dict(sys.modules, {"zeroconf": fake_module}), \
+                mock.patch.object(discovery, "_local_ipv4_addresses",
+                                  return_value=(socket.inet_aton("10.0.0.2"),)), \
+                mock.patch.object(socket, "gethostname", return_value="My PC"):
+            self.assertTrue(advertiser.start(8737))
+        self.assertEqual(advertiser.status, "ready")
+        zc = _FakeZeroconf.instances[-1]
+        info, allow_change = zc.registered[0]
+        self.assertTrue(allow_change)
+        self.assertEqual(info.type, discovery.SERVICE_TYPE)
+        self.assertEqual(info.kwargs["port"], 8737)
+        self.assertEqual(info.kwargs["properties"], {b"v": b"1"})
+        self.assertNotIn("rev", info.kwargs["properties"])
+        advertiser.stop()
+        self.assertEqual(zc.unregistered, [info])
+        self.assertTrue(zc.closed)
+
+    def test_invalid_port_fails_closed(self):
+        advertiser = discovery.DiscoveryAdvertiser(self.logger)
+        self.assertFalse(advertiser.start(0))
+        self.assertEqual(advertiser.status, "error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -67,6 +67,7 @@ except ImportError:  # macOS/Linux
     msvcrt = None
 
 if __package__:
+    from .discovery import DiscoveryAdvertiser
     from .agent_status import AgentStatusService
     from .codex_command import resolve_codex_executable
     from .codex_interactions import (
@@ -91,6 +92,7 @@ if __package__:
     )
     from . import codex_usage, interactions, value_meter
 else:  # direktkörning: python3 tools/tokenserver/tokenserver.py
+    from discovery import DiscoveryAdvertiser
     from agent_status import AgentStatusService
     from codex_command import resolve_codex_executable
     from codex_interactions import (
@@ -2263,6 +2265,8 @@ class Handler(BaseHTTPRequestHandler):
     interaction_relay_reason = None
     agent_status_relay_status = "off"
     agent_status_relay_reason = None
+    discovery_status = "off"
+    discovery_reason = None
     # Innehållsfritt närvarobevis för startup-hälsan. Den befintliga panelen
     # pollar /api/agent-status varje sekund. Två kända panel-GET från samma
     # icke-loopback-klient inom ett kort fönster är starkare evidens än en
@@ -2792,6 +2796,11 @@ class Handler(BaseHTTPRequestHandler):
                 "usageComputeFailingForS":
                     (int(time.monotonic() - failing_since)
                      if failing_since is not None else None),
+                "discovery": {
+                    "status": self.discovery_status,
+                    **({"reason": self.discovery_reason}
+                       if self.discovery_reason is not None else {}),
+                },
                 "interactions": {
                     "claude": bool(self.claude_interactions),
                     "codex": bool(self.codex_interactions),
@@ -3427,8 +3436,12 @@ def main():
     backfill_thread.start()
 
     srv = None
+    discovery = DiscoveryAdvertiser(log)
     try:
         srv = BoundedThreadingHTTPServer(("0.0.0.0", args.port), Handler)
+        discovery.start(args.port)
+        Handler.discovery_status = discovery.status
+        Handler.discovery_reason = discovery.reason
         log.info("serverar http://0.0.0.0:%d/api/tokens, "
                  "/api/agent-status, /api/max-tracker och /api/github "
                  "(LAN — exponera inte utåt)", args.port)
@@ -3436,6 +3449,7 @@ def main():
     except KeyboardInterrupt:
         pass
     finally:
+        discovery.stop()
         if interaction_relay_adapter is not None:
             interaction_relay_adapter.stop()
         if relay_publisher is not None:


### PR DESCRIPTION
Closes #7.

## Outcome
- optionally advertises the bound tokenserver as `_vibepulse._tcp.local` on macOS/Windows/Linux
- discovers one healthy local service on the panel, caches last-known-good in NVS, and keeps the existing configured URL plus optional relay as fail-closed fallback
- keeps Needs You verdicts on the exact LAN host that supplied the accepted agent snapshot
- advertises only protocol version and port; no quotas, account data, prompts, projects, or credentials

## Evidence
- Windows real runtime: temporary server reachable, `discovery.status=ready`, separate DNS-SD browse found port 8738, exact process stopped and port closed
- tokenserver suite: 788 tests, 11 skips, 0 failures/errors
- focused discovery/agent/relay/hardware registry checks: PASS
- ESP-IDF build and physical failover: required before merge/flash; intentionally not claimed here