### PR TITLE
Keep Codex MCP alive for panel answers

### DIFF
--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -277,8 +277,10 @@ python3 tools/vibepulse_setup.py install
 Choose `off`, `claude`, `codex`, or `both`. Then choose whether bounded
 question/command detail may reach the local panel; the safe default is no.
 This saves the choices for the tokenserver and installs the optional Codex
-adapter. It does not start a cloud relay. A non-interactive install with no
-provider choice leaves both providers off.
+adapter. The installer also gives the VibePulse MCP tool a bounded 130-second
+deadline so Codex does not cancel the panel's 120-second answer window at its
+shorter default. It does not start a cloud relay. A non-interactive install
+with no provider choice leaves both providers off.
 
 Useful lifecycle commands:
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,19 @@ point at the backlog item.
 
 ---
 
+## 2026-08-28 · Codex cancelled the panel before the panel deadline
+
+**What happened:** the canonical physical question reached the VibePulse MCP
+but returned computer fallback after roughly thirty seconds. **Root cause:**
+the bridge and permission hook allowed 125 seconds for the panel's bounded
+120-second hold, while `codex mcp add` left `tool_timeout_sec` unset and the
+CLI's shorter default won. **The rule:** every nested timeout must exceed the
+deadline it encloses, and setup must verify the persisted external value rather
+than its own constant. **Guards:** setup now atomically pins the owned MCP row
+to 130 seconds, doctor rejects the legacy missing value, and the Windows
+release runbook checks the real CLI listing. **Watch for:** Codex changing the
+MCP listing schema or maximum timeout.
+
 ## 2026-08-28 · USB-värden var inte panelens datavärd
 
 **What happened:** panelen flyttades från Macens USB-port till Windows och

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -88,6 +88,9 @@ scheduled process must receive its verified bin directory without changing the
 user's global PATH. If the user already has a custom `CODEX_HOME`, the task
 must receive that verified directory process-locally without editing Codex
 settings or authentication.
+The installed VibePulse MCP row must report `tool_timeout_sec: 130`; a missing
+timeout lets Codex cancel the bridge before the panel's bounded 120-second
+answer window expires and is a failed interaction gate.
 
 ## 5. Exercise the real local sources on a temporary port
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -221,6 +221,15 @@ def load_setup():
     return module
 
 
+def load_timeout_helper():
+    path = ROOT / "tools/codex_mcp_timeout.py"
+    spec = importlib.util.spec_from_file_location(
+        "vibepulse_codex_mcp_timeout_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 class FakeRunner:
     def __init__(self, responses=()):
         self.responses = list(responses)
@@ -242,7 +251,7 @@ def result(returncode=0, stdout="", stderr=""):
 
 
 def owned_mcp(*, repo=ROOT, python=Path(sys.executable), enabled=True,
-              name="vibepulse", transport_extra=None):
+              name="vibepulse", transport_extra=None, tool_timeout=130):
     transport = {
         "type": "stdio",
         "command": str(Path(python).resolve()),
@@ -261,7 +270,7 @@ def owned_mcp(*, repo=ROOT, python=Path(sys.executable), enabled=True,
         "disabled_reason": None,
         "transport": transport,
         "startup_timeout_sec": None,
-        "tool_timeout_sec": None,
+        "tool_timeout_sec": tool_timeout,
         "auth_status": "unsupported",
     }
 
@@ -1385,7 +1394,84 @@ class PluginPackageTests(unittest.TestCase):
                           "unrelated Codex settings", prose)
 
 
+class CodexMcpTimeoutConfigTests(unittest.TestCase):
+    def test_adds_timeout_and_preserves_unrelated_toml(self):
+        helper = load_timeout_helper()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.toml"
+            original = (
+                "model = \"gpt-test\"\n\n"
+                "[mcp_servers.peer]\ncommand = \"peer\"\n\n"
+                "[mcp_servers.vibepulse]\n"
+                "command = \"python\"\nargs = [\"mcp.py\"]\n")
+            path.write_text(original, encoding="utf-8")
+
+            helper.configure(path)
+
+            updated = path.read_text(encoding="utf-8")
+            self.assertIn("tool_timeout_sec = 130\n", updated)
+            self.assertIn("[mcp_servers.peer]\ncommand = \"peer\"", updated)
+            self.assertIn("model = \"gpt-test\"", updated)
+
+    def test_replaces_legacy_timeout_and_is_idempotent(self):
+        helper = load_timeout_helper()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.toml"
+            path.write_text(
+                "[mcp_servers.vibepulse]\ncommand = \"python\"\n"
+                "tool_timeout_sec = 20\n",
+                encoding="utf-8")
+
+            helper.configure(path)
+            once = path.read_bytes()
+            helper.configure(path)
+
+            self.assertEqual(path.read_bytes(), once)
+            self.assertEqual(once.count(b"tool_timeout_sec = 130"), 1)
+
+    def test_missing_owned_section_fails_closed(self):
+        helper = load_timeout_helper()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.toml"
+            path.write_text(
+                "[mcp_servers.peer]\ncommand = \"peer\"\n",
+                encoding="utf-8")
+            before = path.read_bytes()
+
+            with self.assertRaises(helper.TimeoutConfigError):
+                helper.configure(path)
+
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_config_symlink_is_refused(self):
+        helper = load_timeout_helper()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "target.toml"
+            target.write_text(
+                "[mcp_servers.vibepulse]\ncommand = \"python\"\n",
+                encoding="utf-8")
+            link = root / "config.toml"
+            try:
+                link.symlink_to(target)
+            except OSError as exc:
+                if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+                    self.skipTest("Windows symlinks require Developer Mode")
+                raise
+
+            with self.assertRaises(helper.TimeoutConfigError):
+                helper.configure(link)
+
+
 class SetupPlanTests(unittest.TestCase):
+    def test_legacy_missing_timeout_is_migratable_but_not_doctor_pass(self):
+        setup = load_setup()
+        legacy = compact([owned_mcp(tool_timeout=None)])
+        self.assertIsNone(setup._owned_mcp_state(
+            legacy, ROOT, Path(sys.executable)))
+        self.assertTrue(setup._owned_mcp_state(
+            legacy, ROOT, Path(sys.executable), allow_legacy_timeout=True))
+
     def test_auto_executable_resolution_uses_shared_codex_resolver(self):
         setup = load_setup()
         expected = Path(
@@ -1496,6 +1582,8 @@ class SetupPlanTests(unittest.TestCase):
             [codex_path, "mcp", "add", "vibepulse", "--", python_path,
              str(repo.resolve() /
                  ".agents/plugins/plugins/vibepulse/scripts/mcp_server.py")],
+            [python_path, str(repo.resolve() /
+                              "tools/codex_mcp_timeout.py")],
         ])
         self.assertNotEqual(
             commands[0][-1], str(repo.resolve() / ".agents/plugins"))
@@ -1523,9 +1611,9 @@ class SetupPlanTests(unittest.TestCase):
                 self.assertEqual((saved.claude_interactions,
                                   saved.codex_interactions), pair)
                 self.assertFalse(saved.interaction_detail)
-                self.assertEqual(len(runner.calls), 12)
+                self.assertEqual(len(runner.calls), 13)
                 self.assertEqual(
-                    [call[0] for call in runner.calls[5:9]],
+                    [call[0] for call in runner.calls[5:10]],
                     setup.plan_codex_install(
                         ROOT, Path(sys.executable), Path("/codex")))
                 self.assertTrue(all(isinstance(call[0], list)
@@ -2300,11 +2388,11 @@ class RelaySetupTests(unittest.TestCase):
                 repo_root=ROOT, config_path=path,
                 python=Path(sys.executable), codex=Path("/codex"),
                 run=runner, stdout=io.StringIO(), stdin_isatty=False), 0)
-            self.assertEqual(len(seen), 12)
+            self.assertEqual(len(seen), 13)
             self.assertTrue(all(saved == original for _, saved, _ in seen))
             self.assertEqual(setup.load_config(path), setup.VibePulseConfig(
                 codex_interactions=True))
-            self.assertEqual([entry[0] for entry in seen[5:9]],
+            self.assertEqual([entry[0] for entry in seen[5:10]],
                              setup.plan_codex_install(
                                  ROOT, Path(sys.executable), Path("/codex")))
             self.assertTrue(all(entry[2].get("shell") is False for entry in seen))
@@ -3226,7 +3314,8 @@ class RelaySetupTests(unittest.TestCase):
             ROOT, Path(sys.executable), Path("/codex"))
         self.assertEqual(setup._state_reconciliation_commands(
             absent, present, repo_root=ROOT, python=Path(sys.executable),
-            codex=Path("/codex")), [install[0], install[1], install[3]])
+            codex=Path("/codex")),
+            [install[0], install[1], install[3], install[4]])
 
     def test_success_requires_strict_observed_desired_external_state(self):
         setup = load_setup()

--- a/tools/codex_mcp_timeout.py
+++ b/tools/codex_mcp_timeout.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Set VibePulse's bounded Codex MCP tool timeout without touching peers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import stat
+import tempfile
+import tomllib
+
+
+TOOL_TIMEOUT_SECONDS = 130
+MAX_CONFIG_BYTES = 1024 * 1024
+_SECTION = re.compile(
+    r"(?m)^\[mcp_servers\.vibepulse\][ \t]*(?:#[^\r\n]*)?(?:\r?\n|$)")
+_NEXT_SECTION = re.compile(r"(?m)^\[")
+_TIMEOUT = re.compile(
+    r"(?m)^[ \t]*tool_timeout_sec[ \t]*=[^\r\n]*(?P<cr>\r?)$")
+
+
+class TimeoutConfigError(ValueError):
+    pass
+
+
+def default_config_path() -> Path:
+    root = os.environ.get("CODEX_HOME")
+    return ((Path(root) if root else Path.home() / ".codex") /
+            "config.toml")
+
+
+def _read_regular(path: Path) -> tuple[bytes, int, os.stat_result]:
+    try:
+        before = os.lstat(path)
+        if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+            raise TimeoutConfigError("config must be a regular file")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | \
+            getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        fd = os.open(path, flags)
+        try:
+            opened = os.fstat(fd)
+            after = os.lstat(path)
+            if (not stat.S_ISREG(opened.st_mode) or
+                    stat.S_ISLNK(after.st_mode) or
+                    not os.path.samestat(before, opened) or
+                    not os.path.samestat(opened, after)):
+                raise TimeoutConfigError("config changed while opening")
+            raw = os.read(fd, MAX_CONFIG_BYTES + 1)
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        raise TimeoutConfigError("cannot read Codex config") from exc
+    if len(raw) > MAX_CONFIG_BYTES:
+        raise TimeoutConfigError("Codex config is too large")
+    return raw, stat.S_IMODE(before.st_mode), before
+
+
+def _updated_text(text: str) -> str:
+    try:
+        before = tomllib.loads(text)
+    except (tomllib.TOMLDecodeError, ValueError) as exc:
+        raise TimeoutConfigError("Codex config is invalid TOML") from exc
+    server = before.get("mcp_servers", {}).get("vibepulse")
+    if not isinstance(server, dict):
+        raise TimeoutConfigError("VibePulse MCP section is missing")
+
+    sections = list(_SECTION.finditer(text))
+    if len(sections) != 1:
+        raise TimeoutConfigError("VibePulse MCP section is ambiguous")
+    section = sections[0]
+    next_section = _NEXT_SECTION.search(text, section.end())
+    end = next_section.start() if next_section else len(text)
+    body = text[section.end():end]
+    timeouts = list(_TIMEOUT.finditer(body))
+    if len(timeouts) > 1:
+        raise TimeoutConfigError("VibePulse MCP timeout is ambiguous")
+
+    line = f"tool_timeout_sec = {TOOL_TIMEOUT_SECONDS}"
+    if timeouts:
+        match = timeouts[0]
+        start = section.end() + match.start()
+        finish = section.end() + match.end()
+        updated = (text[:start] + line + match.group("cr") +
+                   text[finish:])
+    else:
+        newline = "\r\n" if "\r\n" in section.group(0) else "\n"
+        if not section.group(0).endswith(("\n", "\r")):
+            line = newline + line
+        updated = text[:section.end()] + line + newline + text[section.end():]
+
+    try:
+        after = tomllib.loads(updated)
+    except (tomllib.TOMLDecodeError, ValueError) as exc:
+        raise TimeoutConfigError("updated Codex config is invalid") from exc
+    configured = after.get("mcp_servers", {}).get("vibepulse", {})
+    if configured.get("tool_timeout_sec") != TOOL_TIMEOUT_SECONDS:
+        raise TimeoutConfigError("VibePulse MCP timeout did not persist")
+    return updated
+
+
+def configure(path: Path) -> None:
+    path = Path(path)
+    raw, mode, original = _read_regular(path)
+    try:
+        text = raw.decode("utf-8", "strict")
+    except UnicodeError as exc:
+        raise TimeoutConfigError("Codex config is not UTF-8") from exc
+    updated = _updated_text(text)
+    if updated == text:
+        return
+
+    temporary = None
+    try:
+        fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        temporary = Path(name)
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, mode)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(updated.encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        current = os.lstat(path)
+        if (stat.S_ISLNK(current.st_mode) or
+                not os.path.samestat(original, current)):
+            raise TimeoutConfigError("Codex config changed during update")
+        os.replace(temporary, path)
+        temporary = None
+    except OSError as exc:
+        raise TimeoutConfigError("cannot save Codex config") from exc
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+
+
+def main() -> int:
+    try:
+        configure(default_config_path())
+    except TimeoutConfigError:
+        print("FIX Codex MCP tool timeout could not be configured")
+        return 1
+    print("PASS Codex MCP tool timeout")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -27,6 +27,9 @@ TOOLS_DIR = Path(__file__).resolve().parent
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
 
+from codex_mcp_timeout import (  # noqa: E402
+    TOOL_TIMEOUT_SECONDS as CODEX_MCP_TOOL_TIMEOUT_SECONDS,
+)
 from tokenserver.vibepulse_config import (  # noqa: E402
     ConfigError,
     VibePulseConfig,
@@ -103,6 +106,7 @@ def plan_codex_install(
     marketplace_root = root / ".agents" / "plugins"
     mcp_server = (marketplace_root / "plugins" / "vibepulse" / "scripts" /
                   "mcp_server.py")
+    timeout_helper = root / "tools" / "codex_mcp_timeout.py"
     return [
         [codex_path, "plugin", "marketplace", "add",
          str(root)],
@@ -111,6 +115,7 @@ def plan_codex_install(
         [codex_path, "mcp", "remove", "vibepulse"],
         [codex_path, "mcp", "add", "vibepulse", "--", python_path,
          str(mcp_server)],
+        [python_path, str(timeout_helper)],
     ]
 
 
@@ -1171,7 +1176,8 @@ def _strict_json(text: str):
         raise ValueError("invalid strict JSON") from exc
 
 
-def _expected_mcp_item(repo_root: Path, python: Path) -> dict:
+def _expected_mcp_item(
+        repo_root: Path, python: Path, *, legacy_timeout: bool = False) -> dict:
     script = (Path(repo_root).resolve() / ".agents" / "plugins" / "plugins" /
               "vibepulse" / "scripts" / "mcp_server.py")
     return {
@@ -1187,7 +1193,8 @@ def _expected_mcp_item(repo_root: Path, python: Path) -> dict:
             "cwd": None,
         },
         "startup_timeout_sec": None,
-        "tool_timeout_sec": None,
+        "tool_timeout_sec": (None if legacy_timeout else
+                             CODEX_MCP_TOOL_TIMEOUT_SECONDS),
         "auth_status": "unsupported",
     }
 
@@ -1204,14 +1211,19 @@ def _mcp_listing(text: str) -> list[dict] | None:
 
 
 def _owned_mcp_state(
-        text: str, repo_root: Path, python: Path) -> bool | None:
+        text: str, repo_root: Path, python: Path, *,
+        allow_legacy_timeout: bool = False) -> bool | None:
     listing = _mcp_listing(text)
     if listing is None:
         return None
     named = [item for item in listing if item.get("name") == "vibepulse"]
     if not named:
         return False
-    if len(named) != 1 or named[0] != _expected_mcp_item(repo_root, python):
+    expected = _expected_mcp_item(repo_root, python)
+    legacy = _expected_mcp_item(repo_root, python, legacy_timeout=True)
+    if (len(named) != 1 or
+            (named[0] != expected and
+             not (allow_legacy_timeout and named[0] == legacy))):
         return None
     return True
 
@@ -1493,7 +1505,8 @@ def _doctor(
         if mcp_ok:
             print("PASS Codex MCP", file=stdout)
         else:
-            print("FIX Codex MCP: register the local bridge", file=stdout)
+            print("FIX Codex MCP: register the local bridge with its "
+                  "130-second tool timeout", file=stdout)
             fixes = True
 
     if config.codex_interactions:
@@ -1625,7 +1638,8 @@ def _setup_transaction_path(path: Path) -> Path:
 
 def _inspect_external(
         *, repo_root: Path, python: Path, codex: Path, run,
-        stdout, report_failure: bool = True) -> _ExternalState | None:
+        stdout, report_failure: bool = True,
+        allow_legacy_mcp_timeout: bool = False) -> _ExternalState | None:
     codex_text = str(Path(codex).resolve())
     commands = [
         [codex_text, "mcp", "list", "--json"],
@@ -1636,7 +1650,8 @@ def _inspect_external(
     states: list[bool | None] = [None, None, None]
     if results[0] is not None and results[0].returncode == 0:
         states[0] = _owned_mcp_state(
-            results[0].stdout, repo_root, python)
+            results[0].stdout, repo_root, python,
+            allow_legacy_timeout=allow_legacy_mcp_timeout)
     if results[1] is not None and results[1].returncode == 0:
         states[1] = _plugin_state(results[1].stdout, repo_root)
     if results[2] is not None and results[2].returncode == 0:
@@ -1676,7 +1691,7 @@ def _state_reconciliation_commands(
     if not current.plugin and target.plugin:
         commands.append(install[1])
     if not current.mcp and target.mcp:
-        commands.append(install[3])
+        commands.extend(install[3:5])
     return commands
 
 
@@ -1687,7 +1702,8 @@ def _reconcile_external(
     try:
         current = _inspect_external(
             repo_root=repo_root, python=python, codex=codex, run=run,
-            stdout=stdout, report_failure=False)
+            stdout=stdout, report_failure=False,
+            allow_legacy_mcp_timeout=True)
     except BaseException:
         return False
     if current is None:
@@ -1706,7 +1722,8 @@ def _reconcile_external(
         try:
             observed = _inspect_external(
                 repo_root=repo_root, python=python, codex=codex, run=run,
-                stdout=stdout, report_failure=False)
+                stdout=stdout, report_failure=False,
+                allow_legacy_mcp_timeout=True)
         except BaseException:
             return False
         if observed is None:
@@ -1796,7 +1813,7 @@ def _install_transaction(
             failed_step = "resource ownership preflight"
             before = _inspect_external(
                 repo_root=repo_root, python=python, codex=codex, run=run,
-                stdout=stdout)
+                stdout=stdout, allow_legacy_mcp_timeout=True)
             if before is None:
                 return False
 
@@ -1806,6 +1823,7 @@ def _install_transaction(
                 ("plugin add", install[1]),
                 ("MCP remove", install[2]),
                 ("MCP add", install[3]),
+                ("MCP timeout", install[4]),
             )
             for failed_step, argv in steps:
                 completed = _invoke(argv, run)
@@ -1855,7 +1873,7 @@ def _uninstall_transaction(
         try:
             before = _inspect_external(
                 repo_root=repo_root, python=python, codex=codex, run=run,
-                stdout=stdout)
+                stdout=stdout, allow_legacy_mcp_timeout=True)
             if before is None:
                 return False
             uninstall = plan_codex_uninstall(codex)


### PR DESCRIPTION
## Summary
- pin the owned VibePulse Codex MCP tool timeout to 130 seconds
- fail closed and preserve unrelated Codex TOML while migrating legacy installs
- make setup, doctor, tests, and the Windows release runbook verify the persisted timeout

## Root cause
Codex's default MCP tool deadline could cancel the bridge before VibePulse's bounded 120-second panel answer window completed.

## Verification
- `py -3 test/test_vibepulse_codex_plugin.py -v`: 117 tests, 6 skips, 0 failures/errors
- full `test/tokenserver-suite.txt`: 788 tests, 11 skips, 0 failures/errors
- isolated real Codex config integration: MCP registration and persisted timeout verified