### PR TITLE
VibePulse v1.0.0: Windows joins the shelf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Designsystemet: **spec/ui-spec.md**. Hårdvarusanningen routas under
 `Hardware-aware work` nedan; läs den kanoniska femfilslistan där före
 hårdvaruarbete.
 
-## Status (2026-08-27, v0.7.1)
+## Status (2026-08-28, v1.0.0)
 
 Plattformen bröts ut ur underhållarens tidigare solcells-firmware (den
 historiken ligger i ett privat repo och är inget du behöver) och stöptes om
@@ -39,6 +39,13 @@ Valfria och oberoende Cloudflare-reläer kan bära siffror respektive
 end-to-end-krypterade interaktioner/live-status över separata nät; allt är
 default-off. Appen ligger först i registret, så en färsk klon utifrån bygger
 en binär som startar i VibePulse och ingenting annat.
+
+Windows-kärnan och den fysiska svarsslingan passerade på en riktig PC mot
+exakt hostrevision `bee5d8c`: ren checkout, full tokenserversvit, Task
+Scheduler-start/watchdog, begränsad logg, friska källor, Private-LAN,
+panelpollning och `NEEDS YOU` → `APPROVE` → returnerat `Ja`. Det är inte samma
+sak som beständig livscykelcertifiering; sign-in, sleep/resume och reboot är
+fortfarande öppna i #28 och får inte ärvas som PASS från kärnprovet.
 
 Solelkollen och Vibbe/Buddy är egna produkter i egna repon och dras in som
 companion-inputs när de finns utcheckade — `TORGET_SOLELKOLLEN_DIR`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+## v1.0.0 — 2026-08-28
+
+Release notes:
+[v1.0.0 — Windows joins the shelf](docs/releases/2026-08-28-windows-joins-the-shelf.md).
+
 ### Added
 
 - Optional `_vibepulse._tcp.local` discovery lets one panel stay pinned to a
@@ -31,6 +36,24 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 - A sanitized post-v0.7.1 Windows checkpoint pins every real-host observation
   to its exact commit and keeps firewall, lifecycle, recent-panel, and physical
   rows explicitly failed or not tested instead of inheriting an older pass.
+- A real Windows host now advertises `_vibepulse._tcp.local`, allowing the same
+  panel to move between healthy Mac and Windows tokenservers without changing
+  a compiled address. Discovery remains LAN-only and publishes no credential,
+  prompt, account, or quota data.
+- A sanitized exact-revision Windows report records a clean checkout, the full
+  tokenserver suite, Task Scheduler start and watchdog recovery, bounded logs,
+  real Claude/Codex source health, Private-only LAN reachability, recent panel
+  polling, and the canonical physical `NEEDS YOU` → `APPROVE` answer loop.
+
+### Changed
+
+- VibePulse reaches `v1.0.0`: the core product promise—always-visible quota,
+  live agent state, and an explicit human answer from the physical panel—is
+  now exercised on both macOS and a real Windows host. Windows sign-in,
+  sleep/resume, and reboot persistence remain a separately named lifecycle
+  certification gate rather than being inferred from a successful panel tap.
+- The Windows support matrix now distinguishes the verified core/physical
+  answer loop from the still-open persistent lifecycle rows tracked in #28.
 
 ### Fixed
 
@@ -45,6 +68,11 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   but fail with Access Denied under Task Scheduler or other background hosts.
   The README and tokenserver guide include the official install and doctor
   verification commands.
+- The optional Codex MCP bridge now gives a panel question the complete
+  120-second human-answer window instead of allowing Codex's shorter default
+  tool deadline to turn a healthy physical flow into computer fallback.
+- The ESP-IDF mDNS component is locked in the dependency manifest so clean
+  firmware builds reproduce the Mac/Windows discovery code used by the panel.
 
 ## v0.7.1 — 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,26 @@ Both answers already exist, buried in a terminal you're not looking at.
 VibePulse moves them onto a screen you can't miss: one glance from across
 the room, no window to switch to, no menu bar to squint at.
 
-> **Status:** work in progress. This is an ongoing project for me and plenty
-> of tweaks are still on the list, but enough people asked about it that I'm
-> opening it up now rather than when it feels "done". Expect rough edges and
-> frequent commits.
+> **Status:** v1.0.0. The core shelf-screen loop is real and physically
+> exercised on macOS and Windows: see quota, see an agent waiting, and answer
+> a supported prompt on the glass. The project is still active, optional
+> integrations remain opt-in, and every platform claim stays tied to its
+> recorded evidence.
 
-## Latest release: v0.7.1
+## Latest release: v1.0.0
 
-The 27 August reliability release warns before the Claude credential readable
-by VibePulse expires, proves whether the physical panel is actually polling,
-keeps startup responsive while relay history is scanned, fixes mixed-case and
-localized project-name glyphs, and standardizes one strict Codex panel smoke
-test. Silence and computer fallback are never treated as approval.
+The first major release makes Windows a first-class VibePulse host and records
+the real physical proof: clean source, full tests, Task Scheduler plus
+watchdog, bounded logs, real Claude/Codex sources, Private-LAN reachability,
+recent panel polling, and a human **NEEDS YOU → APPROVE → Ja** round trip.
+The same panel can discover and fail over between advertising Mac and Windows
+hosts. Silence and computer fallback are still never approval; persistent
+sign-in/sleep/reboot certification remains explicitly tracked rather than
+being guessed from one successful run.
 
-[Read the v0.7.1 notes](docs/releases/2026-08-27-health-and-panel-reliability.md)
+[Read the v1.0.0 notes](docs/releases/2026-08-28-windows-joins-the-shelf.md)
 · [Full changelog](CHANGELOG.md)
-· [Compare v0.7.0...v0.7.1](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.7.0...v0.7.1)
+· [Compare v0.7.1...v1.0.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.7.1...v1.0.0)
 
 Contributing or validating another host? Read
 [CONTRIBUTING.md](CONTRIBUTING.md), the
@@ -667,9 +671,13 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   checkout and Python 3.11+ interpreter without changing Task Scheduler. The
   complete install, hook-review, firewall, startup-health, physical-test, and
   recovery procedure is the [Windows host runbook](docs/windows-setup.md).
-  The host implementation is supported, while a release-level physical claim
-  still requires every row in the [Windows validation gate](docs/windows-validation.md)
-  to pass on the same exact candidate.
+  The v1.0 core service and physical answer loop passed on a real Windows PC;
+  see the [sanitized evidence](docs/superpowers/reviews/2026-08-28-windows-v1-core-physical.md).
+  Persistent sign-in, sleep/resume, and reboot certification remains tracked
+  in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28), and a
+  complete release-level claim still requires every row in the
+  [Windows validation gate](docs/windows-validation.md) to pass on the same
+  exact candidate.
 - **Linux for the tokenserver?** Not yet —
   [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2). The Ubuntu
   tokenserver CI lane is portability evidence, not a support claim: current

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -15,7 +15,7 @@ firmware from that operating system.
 | Host | Tokenserver | Autostart | Automated evidence | Real-host evidence | Public status |
 |---|---|---|---|---|---|
 | macOS | Yes | launchd | Tokenserver matrix + full host gate | Daily development and physical panel reviews | Supported |
-| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Host service, scheduled start, bounded log, and provider sources have partial real-PC evidence | Host supported; current post-v0.7.1 candidate is **PARTIAL**, not physical end to end. Persistent lifecycle completion remains tracked in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) |
+| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Core service, watchdog, bounded log, providers, Private LAN, recent polling, and the physical answer loop passed on a real PC at `bee5d8c` | Host supported; v1 core + physical loop verified. Persistent sign-in/sleep/reboot certification remains tracked in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) |
 | Linux | Not on `main` | Not shipped | The Python suite runs on Ubuntu, but that alone does not exercise a supported Linux installation | No current-main release report | Not supported yet; tracked in [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2) |
 
 The v0.7.1 tokenserver matrix passed on Windows, macOS, and Ubuntu in the
@@ -38,6 +38,15 @@ an earlier merged candidate, plus a real-Windows Codex probe and green checks
 on current `main`. It remains PARTIAL because the exact final merge was not
 rerun through watchdog, firewall/LAN, session transitions, recent panel
 polling, and the physical answer loop.
+
+The final v1 host-code checkpoint at `bee5d8c` closes those core gaps: exact
+watchdog recovery, bounded live logs, the named Private-only firewall rule,
+real LAN reachability, fresh providers, recent panel polling, and the
+canonical human answer all passed. See the
+[sanitized v1 core and physical report](superpowers/reviews/2026-08-28-windows-v1-core-physical.md).
+Sign-out/sign-in, sleep/resume, and one reboot remain NOT TESTED; they are a
+persistent lifecycle boundary, not a reason to erase the physical PASS and
+not something the release may silently infer.
 
 ## What “validated on Windows” means
 

--- a/docs/releases/2026-08-28-windows-joins-the-shelf.md
+++ b/docs/releases/2026-08-28-windows-joins-the-shelf.md
@@ -1,0 +1,126 @@
+<!-- GitHub-ready v1.0.0 release body. Intentionally starts without an H1. -->
+
+VibePulse v1.0.0 is the moment the shelf screen becomes a two-host product.
+The core loop now runs on a real Windows PC as well as macOS: quota stays in
+view, live Claude/Codex activity reaches the glass, and a supported Codex
+question can travel from the computer to the physical panel and back through
+an explicit human tap.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.0.0/docs/img/vibepulse-codex-week.png" width="31%" alt="Codex weekly quota on VibePulse">
+  &nbsp;
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.0.0/docs/img/vibepulse-codex-needs-you.png" width="31%" alt="Codex Needs You alert on VibePulse">
+  &nbsp;
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.0.0/docs/img/vibepulse-needs-you-codex-question.png" width="31%" alt="Codex question with an explicit recommendation on VibePulse">
+</p>
+
+## Why 1.0
+
+VibePulse began with one promise: put the state of your coding agents
+somewhere you can see it without opening another window. The first major
+release now exercises that whole promise on both supported host families:
+
+- see the real Claude and Codex weekly windows without invented zeroes;
+- see which agent is working, waiting, done, or stale;
+- let the panel take the room with **NEEDS YOU** when the human is the blocker;
+- tap into the decision, read the recommended choice, and explicitly answer;
+- keep unsupported, ambiguous, oversized, private, or mutating work on the
+  computer where it belongs.
+
+The physical Windows proof ended with the exact canonical round trip:
+`Ser du APPROVE?` → visible **NEEDS YOU** → visible **APPROVE** → human tap on
+`Ja` → returned `answered / option_index 0 / Ja`. Silence, timeout, computer
+fallback, and a buttonless private screen remain failures—not consent.
+
+## Windows, for real
+
+This is not a CI-only portability claim. On a real Windows host, exact clean
+revision `bee5d8c9c9b47b761b5970c346cc0e641ac82485` passed:
+
+- the complete 788-test tokenserver suite with 11 named skips and no failure;
+- PowerShell parsing plus the non-mutating Task Scheduler `-ValidateOnly` gate;
+- user-scoped Task Scheduler installation and immediate service start;
+- exact-PID watchdog recovery back to the same revision;
+- bounded live stdout/stderr logging with one bounded rotated tail;
+- the standalone Codex CLI/app-server source and safe Claude source health;
+- Codex plugin/MCP setup with the full bounded human-answer window;
+- a Private-profile-only TCP 8737 rule and real non-loopback LAN reachability;
+- recent physical panel polling throughout the parked interaction;
+- the live payload through the same strict C parser shipped in the firmware;
+- the physical human answer, with the service still running afterward.
+
+The sanitized evidence is preserved in the
+[Windows v1 core and physical report](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.0.0/docs/superpowers/reviews/2026-08-28-windows-v1-core-physical.md).
+
+One boundary stays named: sign-out/sign-in, sleep/resume, and a full reboot
+were not performed in that pass. They remain the persistent lifecycle gate in
+[#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28). The truthful
+v1 claim is **Windows core + physical answer loop verified**, not that three
+unrun transitions somehow passed.
+
+## One panel, Mac or Windows
+
+The panel can now discover `_vibepulse._tcp.local` advertisements and stay
+pinned to a healthy tokenserver. If that host fails for a bounded interval, it
+can move to another advertising Mac or Windows PC and keep the compiled URL as
+the fallback for multicast-hostile networks. The advertisement carries only
+protocol version and port—never quota values, prompts, account identifiers,
+credentials, or a relay address.
+
+The mDNS dependency is locked in the ESP-IDF manifest so a clean firmware
+build reproduces the discovery behavior that was tested on the panel.
+
+## Windows hardening since v0.7.1
+
+- Task Scheduler uses Windows-compatible instance policy and updates only its
+  own task/process.
+- The runner preserves exact arguments, captures stdout/stderr, rotates within
+  hard bounds, and handles paths containing spaces and non-ASCII characters.
+- Codex discovery prefers OpenAI's standalone per-user CLI and rejects
+  `WindowsApps` aliases that fail in background contexts.
+- The app-server startup probe has a real bounded Windows deadline instead of
+  turning normal startup into stale quota.
+- Current Codex plugin provenance is accepted without weakening ownership or
+  path checks.
+- The MCP tool timeout covers the complete 120-second panel-answer window, so
+  Codex no longer abandons a healthy physical question early.
+- Setup doctor checks the actual Python 3.11+ probe consistently on Windows.
+- The public setup, recovery, and validation runbooks distinguish automated,
+  real-host, physical, and persistent-lifecycle evidence.
+
+## Privacy and failure behavior did not loosen
+
+Local mode still requires no VibePulse account. Agent activity and interaction
+detail stay on the LAN unless the separate encrypted relay is explicitly
+enabled. Installing the Codex plugin enables no provider or cloud transport.
+The numbers relay, interaction relay, live-status relay, GitHub page, Claude
+bridge, Codex bridge, and detail sharing remain independent choices.
+
+Panel answers are provider-bound, request-bound, view-digest-bound,
+short-lived, and authenticated with the paired device key. The device never
+receives an OAuth token, refresh token, account identifier, or full session.
+Unknown tools and uncertain payloads fail closed to the computer.
+
+## Upgrade
+
+Check out the release, rerun the host setup for the operating system that will
+serve the panel, then build/flash through the existing consent-gated path:
+
+```sh
+git fetch --tags origin
+git switch --detach v1.0.0
+python3 tools/vibepulse_setup.py status
+```
+
+Windows users should follow the
+[Windows host runbook](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.0.0/docs/windows-setup.md)
+and run the shipped Task Scheduler installer from the release checkout. The
+strict release procedure is in
+[Windows validation](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.0.0/docs/windows-validation.md).
+
+This release remains source-only. **Do not attach `torget.bin`**: every local
+firmware build contains that installation's Wi-Fi credentials and may contain
+its private device key.
+
+Full history:
+[v0.7.1...v1.0.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.7.1...v1.0.0).

--- a/docs/superpowers/reviews/2026-08-28-windows-v1-core-physical.md
+++ b/docs/superpowers/reviews/2026-08-28-windows-v1-core-physical.md
@@ -1,0 +1,48 @@
+# Windows v1 core and physical validation — 2026-08-28
+
+## Outcome
+
+**CORE + PHYSICAL PASS; PERSISTENT LIFECYCLE PARTIAL.** A clean Windows host
+checkout at exact revision `bee5d8c9c9b47b761b5970c346cc0e641ac82485`
+served the real panel and completed the canonical human Codex answer loop.
+Sign-out/sign-in, sleep/resume, and reboot were not performed and remain
+NOT TESTED. This report therefore supports the narrow claim “Windows core and
+physical answer loop verified,” not “every Windows lifecycle row passed.”
+
+No credential, account identifier, prompt payload, session content, quota
+value, private address, device key, or relay address is recorded here.
+
+## Sanitized evidence
+
+| Gate | Status | Evidence |
+|---|---|---|
+| Exact clean host checkout | PASS | Detached host code was exactly `bee5d8c9c9b47b761b5970c346cc0e641ac82485`; status was empty |
+| Complete Windows tokenserver suite | PASS | 788 tests, 11 skips, 0 failures/errors; exit 0 |
+| PowerShell parser and `-ValidateOnly` | PASS | All three Windows scripts parsed; validation resolved the real interpreter and checkout without installing |
+| Task Scheduler install and immediate start | PASS | The user-scoped task installed from the exact checkout and served the expected revision |
+| Exact-process watchdog recovery | PASS | Only the verified tokenserver PID was terminated; the task watchdog created a new exact-owned PID serving the same revision |
+| Bounded scheduled-task log | PASS | Live log and retained tail stayed inside their documented bounds without traceback or restart churn |
+| Claude source health | PASS | Safe probe state was healthy; both weekly observations were fresh and numeric |
+| Codex source health | PASS | Standalone CLI login succeeded and the app-server weekly observation was fresh and numeric; no value was printed |
+| Codex plugin/MCP | PASS | Setup, doctor, registration, initialize, and tool listing passed with the owned local bridge and the 130-second bounded tool window |
+| Private firewall and LAN | PASS | Inbound TCP 8737 was limited to the Private profile; a non-loopback LAN self-check reached the service |
+| Mac/Windows host discovery | PASS | The panel moved between advertising Mac and Windows tokenservers after a bounded failure without changing a compiled host address |
+| Recent physical panel polling | PASS | Root health reported recent polling on `/api/agent-status` throughout a parked question |
+| Firmware/parser contract | PASS | The live bounded status payload contained a valid v2 pending view and the shipped C parser accepted that exact payload |
+| Canonical physical answer | PASS | The panel showed the two-stage `NEEDS YOU` → `APPROVE` flow; a human tapped the recommended answer and the host returned `status: answered`, `option_index: 0`, `answer: Ja` |
+| Service after the physical check | PASS | The scheduled tokenserver continued serving the same exact revision |
+| Sign-out/sign-in | NOT TESTED | Disruptive user-session transition was not authorized during this pass |
+| Sleep/resume | NOT TESTED | Disruptive physical lifecycle transition was not authorized during this pass |
+| Reboot | NOT TESTED | Full Windows restart was not authorized during this pass |
+
+## Claim boundary
+
+The exact physical product path is proven: Windows source → scheduled local
+service → Private LAN → physical panel → visible explicit choice → human tap
+→ structured answer returned to the originating call. Silence, fallback, and
+the private buttonless screen were not counted as approval.
+
+Issue [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) remains
+open for persistent lifecycle completion. Those rows must be rerun against an
+exact clean release candidate before the broader claim “full Windows release
+certification” is used.

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -33,12 +33,12 @@ redder than the release:
 ```powershell
 $ValidationRoot = Join-Path $env:TEMP ("vibepulse-validation-" + [guid]::NewGuid())
 git clone https://github.com/niclasvestlund-YT/vibepulse.git $ValidationRoot
-git -C $ValidationRoot checkout --detach v0.7.1
+git -C $ValidationRoot checkout --detach v1.0.0
 git -C $ValidationRoot describe --tags --always --dirty
 git -C $ValidationRoot status --short
 ```
 
-The description must be `v0.7.1` and status output must be empty. For a future
+The description must be `v1.0.0` and status output must be empty. For a future
 release, substitute the exact candidate tag or commit everywhere in this
 document.
 
@@ -185,12 +185,11 @@ Verify all of these and record timestamps:
 4. it returns after sleep/resume;
 5. one full Windows reboot does not leave the panel stale.
 
-The tagged v0.7.1 scheduler task has no persistent stdout/stderr log.
-Post-v0.7.1 `main` adds
-`%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log`; keep
+The v1.0.0 scheduler wrapper writes bounded stdout/stderr to
+`%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log` and retains one bounded
+`.old` tail. The tagged v0.7.1 task predated that log. Keep
 [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) open until the
-new wrapper, rotation, quoting, restart, and non-ASCII-profile path pass on a
-real scheduled task.
+remaining sign-in, sleep/resume, and reboot rows pass on one exact candidate.
 
 ## 8. Close the physical loop
 
@@ -226,6 +225,12 @@ records post-v0.7.1 Task Scheduler, logging, provider, and Codex app-server
 evidence. It is also intentionally PARTIAL: an earlier commit's PASS does not
 automatically pass a later commit, and an unavailable PC turns unfinished rows
 into NOT TESTED rather than success.
+
+The subsequent
+[v1.0 core and physical checkpoint](superpowers/reviews/2026-08-28-windows-v1-core-physical.md)
+records the recovered real-host gates and the exact human panel answer on
+`bee5d8c`. It is the physical answer-loop proof, but not a substitute for the
+three still-unrun persistent lifecycle transitions.
 
 Record each row as PASS, FAIL, or NOT TESTED:
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1360,8 +1360,42 @@ class PluginPackageTests(unittest.TestCase):
         self.assertNotIn("eventual `v0.7.1` tag", release)
 
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("## Latest release: v0.7.1", readme)
-        self.assertIn("Compare v0.7.0...v0.7.1", readme)
+        self.assertIn("## Latest release: v1.0.0", readme)
+        self.assertIn("Compare v0.7.1...v1.0.0", readme)
+
+    def test_v100_release_is_major_windows_honest_and_source_only(self):
+        release = (ROOT / "docs/releases/"
+                   "2026-08-28-windows-joins-the-shelf.md").read_text(
+                       encoding="utf-8")
+        evidence = (ROOT / "docs/superpowers/reviews/"
+                    "2026-08-28-windows-v1-core-physical.md").read_text(
+                        encoding="utf-8")
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        self.assertFalse(release.lstrip().startswith("# "))
+        for required in (
+                "VibePulse v1.0.0", "Why 1.0", "Windows, for real",
+                "Ser du APPROVE?", "NEEDS YOU", "APPROVE",
+                "answered / option_index 0 / Ja", "788-test",
+                "Task Scheduler", "Private-profile-only", "source-only",
+                "Do not attach `torget.bin`", "v0.7.1...v1.0.0"):
+            self.assertIn(required, release)
+        for image in (
+                "vibepulse-codex-week.png",
+                "vibepulse-codex-needs-you.png",
+                "vibepulse-needs-you-codex-question.png"):
+            self.assertIn(
+                "https://raw.githubusercontent.com/"
+                "niclasvestlund-YT/vibepulse/v1.0.0/docs/img/" + image,
+                release)
+        for boundary in (
+                "PERSISTENT LIFECYCLE PARTIAL", "Sign-out/sign-in",
+                "Sleep/resume", "Reboot", "NOT TESTED"):
+            self.assertIn(boundary, evidence)
+        self.assertIn("## v1.0.0 — 2026-08-28", changelog)
+        self.assertIn("## Unreleased\n\n## v1.0.0", changelog)
+        for forbidden in ("oauth token:", "refresh token:",
+                          "account id:", "relay address:"):
+            self.assertNotIn(forbidden, release.lower())
 
     def test_default_runner_invokes_plugin_suite_once(self):
         runner = (ROOT / "test/run.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- publish the GitHub-ready, image-backed VibePulse v1.0.0 release story
- update README, changelog, Windows support matrix, validation runbook, and maintainer status
- record sanitized exact-revision Windows core + physical evidence
- add a regression test for the major-release claim, evidence links, lifecycle boundary, and source-only firmware rule

## Local verification

- `python test/test_vibepulse_codex_plugin.py`: 118 tests, 6 skips, exit 0
- complete `test/tokenserver-suite.txt`: 788 tests, 11 skips, exit 0
- three Windows PowerShell parsers: 0 errors
- `install-windows-task.ps1 -ValidateOnly`: exit 0, no task mutation
- `test/windows-task-runner.ps1`: exit 0
- `git diff --check`: exit 0

## Claim boundary

This release says **Windows core + physical answer loop verified**. It does not claim sign-out/sign-in, sleep/resume, or reboot persistence passed; those remain explicitly NOT TESTED and tracked in #28. No firmware binary is attached because local builds contain installation secrets.