### PR TITLE
docs: certify Windows v1 lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,14 @@ end-to-end-krypterade interaktioner/live-status över separata nät; allt är
 default-off. Appen ligger först i registret, så en färsk klon utifrån bygger
 en binär som startar i VibePulse och ingenting annat.
 
-Windows-kärnan och den fysiska svarsslingan passerade på en riktig PC mot
-exakt hostrevision `bee5d8c`: ren checkout, full tokenserversvit, Task
-Scheduler-start/watchdog, begränsad logg, friska källor, Private-LAN,
-panelpollning och `NEEDS YOU` → `APPROVE` → returnerat `Ja`. Det är inte samma
-sak som beständig livscykelcertifiering; sign-in, sleep/resume och reboot är
-fortfarande öppna i #28 och får inte ärvas som PASS från kärnprovet.
+Windows-kärnan, den fysiska svarsslingan och den beständiga livscykeln
+passerade på en riktig PC mot exakt hostrevision `bee5d8c`: ren checkout, full
+tokenserversvit, Task Scheduler-start/watchdog, begränsad logg, friska källor,
+Private-LAN, panelpollning, `NEEDS YOU` → `APPROVE` → returnerat `Ja`, samt
+verklig sign-out/sign-in, sleep/resume och reboot. Release-taggen `v1.0.0`
+pekar på `ab3ce92`; de åtta filerna mellan hostrevisionen och taggen är endast
+dokumentation/test, inte runtime. Se den fullständiga sanerade rapporten och
+ärv aldrig denna PASS till en senare runtime-revision utan en ny körning.
 
 Solelkollen och Vibbe/Buddy är egna produkter i egna repon och dras in som
 companion-inputs när de finns utcheckade — `TORGET_SOLELKOLLEN_DIR`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,11 @@ Release notes:
 
 - VibePulse reaches `v1.0.0`: the core product promise—always-visible quota,
   live agent state, and an explicit human answer from the physical panel—is
-  now exercised on both macOS and a real Windows host. Windows sign-in,
-  sleep/resume, and reboot persistence remain a separately named lifecycle
-  certification gate rather than being inferred from a successful panel tap.
-- The Windows support matrix now distinguishes the verified core/physical
-  answer loop from the still-open persistent lifecycle rows tracked in #28.
+  now exercised on both macOS and a real Windows host. The same Windows
+  candidate subsequently passed real sign-out/sign-in, sleep/resume, and one
+  full reboot with the scheduled service and recent panel polling intact.
+- The Windows support matrix now records the completed core, physical, and
+  persistent-lifecycle gates while retaining their exact revision boundary.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ the real physical proof: clean source, full tests, Task Scheduler plus
 watchdog, bounded logs, real Claude/Codex sources, Private-LAN reachability,
 recent panel polling, and a human **NEEDS YOU → APPROVE → Ja** round trip.
 The same panel can discover and fail over between advertising Mac and Windows
-hosts. Silence and computer fallback are still never approval; persistent
-sign-in/sleep/reboot certification remains explicitly tracked rather than
-being guessed from one successful run.
+hosts. The real Windows host also passed sign-out/sign-in, sleep/resume, and a
+full reboot without losing the scheduled service or leaving the panel stale.
+Silence and computer fallback are still never approval.
 
 [Read the v1.0.0 notes](docs/releases/2026-08-28-windows-joins-the-shelf.md)
 · [Full changelog](CHANGELOG.md)
@@ -671,13 +671,12 @@ by default; set `PYTHON_BIN` to point at a different 3.11+ interpreter.
   checkout and Python 3.11+ interpreter without changing Task Scheduler. The
   complete install, hook-review, firewall, startup-health, physical-test, and
   recovery procedure is the [Windows host runbook](docs/windows-setup.md).
-  The v1.0 core service and physical answer loop passed on a real Windows PC;
-  see the [sanitized evidence](docs/superpowers/reviews/2026-08-28-windows-v1-core-physical.md).
-  Persistent sign-in, sleep/resume, and reboot certification remains tracked
-  in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28), and a
-  complete release-level claim still requires every row in the
-  [Windows validation gate](docs/windows-validation.md) to pass on the same
-  exact candidate.
+  The v1.0 core service, physical answer loop, sign-out/sign-in,
+  sleep/resume, and reboot all passed on a real Windows PC; see the
+  [full sanitized evidence](docs/superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md).
+  A later runtime revision still requires a fresh pass through the complete
+  [Windows validation gate](docs/windows-validation.md); release evidence is
+  never inherited across untested code.
 - **Linux for the tokenserver?** Not yet —
   [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2). The Ubuntu
   tokenserver CI lane is portability evidence, not a support claim: current

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -15,7 +15,7 @@ firmware from that operating system.
 | Host | Tokenserver | Autostart | Automated evidence | Real-host evidence | Public status |
 |---|---|---|---|---|---|
 | macOS | Yes | launchd | Tokenserver matrix + full host gate | Daily development and physical panel reviews | Supported |
-| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Core service, watchdog, bounded log, providers, Private LAN, recent polling, and the physical answer loop passed on a real PC at `bee5d8c` | Host supported; v1 core + physical loop verified. Persistent sign-in/sleep/reboot certification remains tracked in [#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) |
+| Windows | Yes | Task Scheduler | Tokenserver matrix on `windows-latest`; installer/runner parser and `-ValidateOnly` gate | Core service, watchdog, bounded log, providers, Private LAN, recent polling, physical answer, sign-out/sign-in, sleep/resume, and reboot passed on a real PC at `bee5d8c` | Supported; v1 core, physical loop, and persistent lifecycle verified |
 | Linux | Not on `main` | Not shipped | The Python suite runs on Ubuntu, but that alone does not exercise a supported Linux installation | No current-main release report | Not supported yet; tracked in [#2](https://github.com/niclasvestlund-YT/vibepulse/issues/2) |
 
 The v0.7.1 tokenserver matrix passed on Windows, macOS, and Ubuntu in the
@@ -42,11 +42,11 @@ polling, and the physical answer loop.
 The final v1 host-code checkpoint at `bee5d8c` closes those core gaps: exact
 watchdog recovery, bounded live logs, the named Private-only firewall rule,
 real LAN reachability, fresh providers, recent panel polling, and the
-canonical human answer all passed. See the
-[sanitized v1 core and physical report](superpowers/reviews/2026-08-28-windows-v1-core-physical.md).
-Sign-out/sign-in, sleep/resume, and one reboot remain NOT TESTED; they are a
-persistent lifecycle boundary, not a reason to erase the physical PASS and
-not something the release may silently infer.
+canonical human answer all passed. A continuation on the same installed
+runtime then passed sign-out/sign-in, sleep/resume, and one full reboot. See
+the [sanitized v1 core report](superpowers/reviews/2026-08-28-windows-v1-core-physical.md)
+and the subsequent
+[full lifecycle report](superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md).
 
 ## What “validated on Windows” means
 

--- a/docs/releases/2026-08-28-windows-joins-the-shelf.md
+++ b/docs/releases/2026-08-28-windows-joins-the-shelf.md
@@ -52,11 +52,18 @@ revision `bee5d8c9c9b47b761b5970c346cc0e641ac82485` passed:
 The sanitized evidence is preserved in the
 [Windows v1 core and physical report](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.0.0/docs/superpowers/reviews/2026-08-28-windows-v1-core-physical.md).
 
-One boundary stays named: sign-out/sign-in, sleep/resume, and a full reboot
-were not performed in that pass. They remain the persistent lifecycle gate in
-[#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28). The truthful
-v1 claim is **Windows core + physical answer loop verified**, not that three
-unrun transitions somehow passed.
+The first physical pass deliberately left sign-out/sign-in, sleep/resume, and
+a full reboot unclaimed. A subsequent continuation on the same installed
+runtime performed all three transitions for real. Task Scheduler ran after
+sign-in and boot, the service returned after sleep, Codex and Claude converged
+to fresh observations within the bounded readiness window, freshness then
+remained stable, and recent physical-panel polling survived the reboot. The
+sanitized continuation is the
+[Windows v1 full lifecycle report](https://github.com/niclasvestlund-YT/vibepulse/blob/main/docs/superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md).
+
+The resulting v1 claim is now **Windows core + physical answer loop +
+persistent lifecycle verified**. That claim remains pinned to the recorded
+v1 runtime and must not be inherited by a later untested runtime revision.
 
 ## One panel, Mac or Windows
 

--- a/docs/superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md
+++ b/docs/superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md
@@ -1,0 +1,53 @@
+# Windows v1 full lifecycle validation — 2026-08-28
+
+## Outcome
+
+**FULL WINDOWS v1 PASS.** The previously verified Windows v1 host completed
+the three deliberately deferred persistent transitions: real
+sign-out/sign-in, real sleep/resume, and one full Windows reboot. Task
+Scheduler, the local service, safe Claude/Codex source health, and recent
+physical-panel polling all recovered within a bounded readiness window.
+
+The installed runtime remained exact host revision
+`bee5d8c9c9b47b761b5970c346cc0e641ac82485`. Release tag `v1.0.0` resolves to
+`ab3ce92a069b4cc66312b6043e3715829d1bb763`; the eight changed files between
+those revisions are documentation/tests only, with zero runtime files. This
+continuation therefore validates the runtime shipped by v1.0.0 without
+pretending that a later runtime was exercised.
+
+No credential, account identifier, prompt payload, session content, quota
+value, private address, device key, relay address, or private route is recorded
+here.
+
+## Persistent lifecycle evidence
+
+| Gate | Result | Sanitized evidence |
+|---|---|---|
+| Pre-transition health | PASS | The scheduled task was running; the service revision was present; Claude and Codex weekly observations were numeric and fresh |
+| Sleep entered | PASS | Windows recorded a Kernel-Power sleep transition after the saved baseline |
+| Resume occurred | PASS | Windows recorded a Power-Troubleshooter resume event on the same boot |
+| Service after resume | PASS | The task remained running and the local service returned successfully |
+| Sources after resume | PASS | Claude returned immediately; Codex converged within the bounded three-minute readiness window and the final checkpoint was fresh |
+| Sign-out/sign-in | PASS | A real user sign-out and sign-in occurred; the logon trigger ran after the saved baseline and the service was healthy afterward |
+| Stable sources after sign-in | PASS | Claude and Codex were fresh for 12 of 12 consecutive five-second samples after initialization |
+| Full reboot occurred | PASS | The post-check boot identifier differed from the saved pre-reboot identifier |
+| Task Scheduler after reboot | PASS | The task ran after the new boot and remained in the running state |
+| Service after reboot | PASS | The local service returned successfully with a revision present |
+| Sources after reboot | PASS | Claude was fresh; Codex converged inside the bounded three-minute readiness window |
+| Stable sources after reboot | PASS | Codex was fresh for 12 of 12 consecutive five-second samples |
+| Physical panel after reboot | PASS | Panel status was `ready`, polling age was numeric and inside the 120-second recent window, and the service remained healthy |
+
+## Combined Windows v1 verdict
+
+This continuation completes the earlier
+[core and physical report](2026-08-28-windows-v1-core-physical.md). Together,
+the two reports cover the clean checkout, full suite, parser and
+`-ValidateOnly`, real Task Scheduler installation, immediate start, exact-PID
+watchdog recovery, bounded logs, real providers, Private-only firewall and LAN
+reachability, discovery, recent polling, the canonical visible human answer,
+sign-out/sign-in, sleep/resume, and reboot.
+
+Every required row in [Windows release validation](../../windows-validation.md)
+is PASS for the recorded v1 runtime. Silence, fallback, and a buttonless screen
+were never counted as approval. This evidence is exact-revision evidence, not
+a permanent waiver for future releases.

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -187,9 +187,9 @@ Verify all of these and record timestamps:
 
 The v1.0.0 scheduler wrapper writes bounded stdout/stderr to
 `%LOCALAPPDATA%\VibePulse\Logs\torget-tokenserver.log` and retains one bounded
-`.old` tail. The tagged v0.7.1 task predated that log. Keep
-[#28](https://github.com/niclasvestlund-YT/vibepulse/issues/28) open until the
-remaining sign-in, sleep/resume, and reboot rows pass on one exact candidate.
+`.old` tail. The tagged v0.7.1 task predated that log. Allow a bounded source
+warm-up after a session or power transition, then require a continuous fresh
+window; a single transient success is not enough.
 
 ## 8. Close the physical loop
 
@@ -229,8 +229,11 @@ into NOT TESTED rather than success.
 The subsequent
 [v1.0 core and physical checkpoint](superpowers/reviews/2026-08-28-windows-v1-core-physical.md)
 records the recovered real-host gates and the exact human panel answer on
-`bee5d8c`. It is the physical answer-loop proof, but not a substitute for the
-three still-unrun persistent lifecycle transitions.
+`bee5d8c`. The later
+[v1.0 full lifecycle continuation](superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md)
+records real sign-out/sign-in, sleep/resume, and reboot against that same
+installed runtime. Together they close every required Windows row for v1.0.0;
+neither report is evidence for a later untested runtime revision.
 
 Record each row as PASS, FAIL, or NOT TESTED:
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1370,6 +1370,9 @@ class PluginPackageTests(unittest.TestCase):
         evidence = (ROOT / "docs/superpowers/reviews/"
                     "2026-08-28-windows-v1-core-physical.md").read_text(
                         encoding="utf-8")
+        lifecycle = (ROOT / "docs/superpowers/reviews/"
+                     "2026-08-28-windows-v1-full-lifecycle.md").read_text(
+                         encoding="utf-8")
         changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertFalse(release.lstrip().startswith("# "))
         for required in (
@@ -1391,11 +1394,19 @@ class PluginPackageTests(unittest.TestCase):
                 "PERSISTENT LIFECYCLE PARTIAL", "Sign-out/sign-in",
                 "Sleep/resume", "Reboot", "NOT TESTED"):
             self.assertIn(boundary, evidence)
+        for completed in (
+                "FULL WINDOWS v1 PASS", "Sign-out/sign-in", "Sleep entered",
+                "Full reboot occurred", "12 of 12", "Physical panel after reboot",
+                "bee5d8c9c9b47b761b5970c346cc0e641ac82485",
+                "ab3ce92a069b4cc66312b6043e3715829d1bb763"):
+            self.assertIn(completed, lifecycle)
+        self.assertIn("persistent lifecycle verified", release)
         self.assertIn("## v1.0.0 — 2026-08-28", changelog)
         self.assertIn("## Unreleased\n\n## v1.0.0", changelog)
         for forbidden in ("oauth token:", "refresh token:",
                           "account id:", "relay address:"):
             self.assertNotIn(forbidden, release.lower())
+            self.assertNotIn(forbidden, lifecycle.lower())
 
     def test_default_runner_invokes_plugin_suite_once(self):
         runner = (ROOT / "test/run.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## Outcome

Completes the deferred real-Windows lifecycle certification for v1.0.0 without rewriting the earlier historical PARTIAL report.

## Real-host evidence

- real sleep/resume: PASS; Windows sleep and resume events observed, service returned
- real sign-out/sign-in: PASS; logon trigger ran and service remained healthy
- full reboot: PASS; new boot observed, task ran after boot, service and recent panel polling returned
- Claude/Codex safe source health: PASS after bounded warm-up
- post-sign-in stability: 12/12 fresh samples
- post-reboot stability: 12/12 fresh samples
- no secrets, quota values, private routes, account identifiers, or payloads recorded

Runtime under test was exact `bee5d8c9c9b47b761b5970c346cc0e641ac82485`. Tag `v1.0.0` is `ab3ce92a069b4cc66312b6043e3715829d1bb763`; the intervening release changes are docs/tests only (zero runtime files).

## Local checks

- release/plugin regression: 118 tests, 6 skips, 0 failures
- full tokenserver suite: 788 tests, 11 skips, 0 failures
- `git diff --check`: PASS

Closes #28