### PR TITLE
docs: add final Windows v1 release ledger

### DIFF
--- a/docs/releases/2026-08-28-windows-joins-the-shelf.md
+++ b/docs/releases/2026-08-28-windows-joins-the-shelf.md
@@ -65,6 +65,27 @@ The resulting v1 claim is now **Windows core + physical answer loop +
 persistent lifecycle verified**. That claim remains pinned to the recorded
 v1 runtime and must not be inherited by a later untested runtime revision.
 
+### Final Windows v1 verification ledger
+
+| Gate | Result |
+|---|---|
+| Clean real Windows host and complete tokenserver suite | **PASS** — 788 tests, 11 named skips, 0 failures/errors |
+| Task Scheduler, immediate start, exact-PID watchdog and bounded logs | **PASS** |
+| Real Claude/Codex sources, Private-only firewall, LAN and discovery | **PASS** |
+| Recent panel polling and **NEEDS YOU → APPROVE → Ja** | **PASS** |
+| Sign-out/sign-in, sleep/resume and full reboot | **PASS** |
+| Post-transition source freshness | **PASS** — bounded convergence, then 12/12 fresh samples after sign-in and reboot |
+| Lifecycle PR CI and merged-main CI | **PASS** — 14/14 and 7/7 jobs |
+
+The host runtime under test was exact revision `bee5d8c`; the immutable
+`v1.0.0` tag resolves to `ab3ce92`, with documentation and tests only between
+them. The lifecycle evidence was merged at `4d1c47d` and its
+[merged-main CI passed all 7 jobs](https://github.com/niclasvestlund-YT/vibepulse/actions/runs/33214257872).
+The subsequent README publication was merged at `bc639eb` and its
+[merged-main CI also passed all 7 jobs](https://github.com/niclasvestlund-YT/vibepulse/actions/runs/33216669247).
+These are exact-revision claims; any later runtime change must pass the gate
+again.
+
 ## One panel, Mac or Windows
 
 The panel can now discover `_vibepulse._tcp.local` advertisements and stay

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1387,7 +1387,12 @@ class PluginPackageTests(unittest.TestCase):
                 "Ser du APPROVE?", "NEEDS YOU", "APPROVE",
                 "answered / option_index 0 / Ja", "788-test",
                 "Task Scheduler", "Private-profile-only", "source-only",
-                "Do not attach `torget.bin`", "v0.7.1...v1.0.0"):
+                "Do not attach `torget.bin`", "v0.7.1...v1.0.0",
+                "Final Windows v1 verification ledger",
+                "788 tests, 11 named skips, 0 failures/errors",
+                "14/14 and 7/7 jobs", "12/12 fresh samples",
+                "bee5d8c", "ab3ce92", "4d1c47d", "bc639eb",
+                "33214257872", "33216669247"):
             self.assertIn(required, release)
         for image in (
                 "vibepulse-codex-week.png",


### PR DESCRIPTION
## Summary
- add the final Windows v1 verification ledger to the checked-in v1.0.0 release notes
- pin real-host, lifecycle, tag, evidence, README, and merged-main CI boundaries
- guard the public claims with release-note assertions

## Verification
- `git diff --check`
- `python -m unittest discover -s test -p test_vibepulse_codex_plugin.py` (118 tests, 6 skips, PASS)

No product/runtime behavior changes.