### PR TITLE
fix(windows): preserve GitHub and plan display inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,10 @@ jobs:
             $allErrors | ForEach-Object { Write-Error $_.Message }
             exit 1
           }
-          .\tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+          .\tools\tokenserver\install-windows-task.ps1 -ValidateOnly `
+            -GithubRepo "owner/repository" -ClaudePlan max5x `
+            -CodexPlan pro -ClaudePlanCostUsd "100" `
+            -CodexPlanCostUsd "20"
           .\test\windows-task-runner.ps1
 
   firmware:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+### Fixed
+
+- Windows Task Scheduler installations can now persist the optional public
+  GitHub source, named Claude/Codex plan labels, and explicit per-provider
+  subscription costs. The background service no longer drops the GitHub Stars
+  or API-versus-subscription inputs that work in a foreground launch.
+
 ## v1.0.0 — 2026-08-28
 
 Release notes:

--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ limit cannot stall the Claude/Codex endpoints. Configure it with:
 python3 tools/tokenserver/tokenserver.py --github-repo owner/repository
 ```
 
+On Windows, persist the same source in Task Scheduler instead of relying on a
+foreground shell:
+
+```powershell
+.\tools\tokenserver\install-windows-task.ps1 `
+  -GithubRepo "owner/repository"
+```
+
 Then opt into `TK_GITHUB_SCREEN_ENABLED` and/or
 `TK_GITHUB_NOTIFICATIONS_ENABLED` in your gitignored `secrets.h`. Both are
 off by default. No GitHub token is required for a public repository.
@@ -304,6 +312,15 @@ swipeable strip, alongside GitHub — neither replaces the other.
 
 ```
 python3 tools/tokenserver/tokenserver.py --claude-plan max5x --plan claude=100
+```
+
+The equivalent persistent Windows setup is explicit per provider and never
+guesses what you pay:
+
+```powershell
+.\tools\tokenserver\install-windows-task.ps1 `
+  -ClaudePlan max5x -ClaudePlanCostUsd "100" `
+  -CodexPlan pro -CodexPlanCostUsd "20"
 ```
 
 It counts cache tokens, which is the whole point — a real record here reads

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -100,17 +100,38 @@ after setup changes.
 
 ## 3. Validate and install autostart
 
+Choose any optional host-display inputs once and reuse the exact same values
+for validation and installation. Omit providers you do not pay for; VibePulse
+never guesses a subscription cost:
+
+```powershell
+$VibePulseHost = @{
+  GithubRepo = "owner/repository"
+  ClaudePlan = "max5x"
+  ClaudePlanCostUsd = "100"
+  CodexPlan = "pro"
+  CodexPlanCostUsd = "20"
+}
+```
+
+`GithubRepo` enables the public repository source. The panel firmware must
+also be built with `TK_GITHUB_SCREEN_ENABLED=1` for the GitHub page and/or
+`TK_GITHUB_NOTIFICATIONS_ENABLED=1` for star notifications. Those device-side
+choices are independent of Windows and remain off in a clean default build.
+
 First verify the exact interpreter, checkout, and runtime construction of the
 ScheduledTasks action, trigger, and settings without changing Windows:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 `
+  -ValidateOnly @VibePulseHost
 ```
 
 Then install the signed-in user's scheduled task:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1
+powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 `
+  @VibePulseHost
 Get-ScheduledTask -TaskName "VibePulse tokenserver" |
   Select-Object TaskName, State
 Get-ScheduledTaskInfo -TaskName "VibePulse tokenserver"

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -74,7 +74,9 @@ foreach ($Script in @(
   $AllErrors += $Errors
 }
 $AllErrors
-.\tools\tokenserver\install-windows-task.ps1 -ValidateOnly
+.\tools\tokenserver\install-windows-task.ps1 -ValidateOnly `
+  -GithubRepo "owner/repository" -ClaudePlan max5x `
+  -ClaudePlanCostUsd "100" -CodexPlan pro -CodexPlanCostUsd "20"
 .\test\windows-task-runner.ps1
 ```
 
@@ -88,6 +90,9 @@ scheduled process must receive its verified bin directory without changing the
 user's global PATH. If the user already has a custom `CODEX_HOME`, the task
 must receive that verified directory process-locally without editing Codex
 settings or authentication.
+It must also prove exact forwarding of the optional GitHub repository, named
+plan labels, and per-provider subscription costs. A Windows support claim is
+not allowed to silently drop display inputs that work in a foreground launch.
 The installed VibePulse MCP row must report `tool_timeout_sec: 130`; a missing
 timeout lets Codex cancel the bridge before the panel's bounded 120-second
 answer window expires and is a failed interaction gate.
@@ -169,7 +174,9 @@ a reason to accept an unstable fallback.
 Only after the release checkout and installer validation pass:
 
 ```powershell
-.\tools\tokenserver\install-windows-task.ps1
+.\tools\tokenserver\install-windows-task.ps1 `
+  -GithubRepo "owner/repository" -ClaudePlan max5x `
+  -ClaudePlanCostUsd "100" -CodexPlan pro -CodexPlanCostUsd "20"
 Get-ScheduledTaskInfo -TaskName "VibePulse tokenserver"
 Invoke-RestMethod http://127.0.0.1:8737/ |
   Select-Object service, rev, srcFingerprint, discovery, claudeProbe, claudeCredential,

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -234,6 +234,14 @@ assert "stderr was not captured" in windows_runner_test
 assert "negative child exit was not normalized to 1" in windows_runner_test
 assert "Codex bin directory was not prepended to PATH" in windows_runner_test
 assert "Codex home was not passed to the child process" in windows_runner_test
+assert "GitHub and subscription display inputs were not forwarded" in \
+    windows_runner_test
+for required in (
+        "GithubRepo", "ClaudePlan", "CodexPlan", "ClaudePlanCostUsd",
+        "CodexPlanCostUsd"):
+    assert required in windows_service
+    assert required in windows_runner
+    assert required in tokenserver_readme
 assert "Resolve-VibePulseCodexBinDir" in windows_service
 assert "Resolve-VibePulseCodexHome" in windows_service
 assert "Ubuntu" in readme and "not a support claim" in readme

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1414,7 +1414,8 @@ class PluginPackageTests(unittest.TestCase):
             self.assertIn(completed, lifecycle)
         self.assertIn("persistent lifecycle verified", release)
         self.assertIn("## v1.0.0 — 2026-08-28", changelog)
-        self.assertIn("## Unreleased\n\n## v1.0.0", changelog)
+        self.assertLess(changelog.index("## Unreleased"),
+                        changelog.index("## v1.0.0"))
         for forbidden in ("oauth token:", "refresh token:",
                           "account id:", "relay address:"):
             self.assertNotIn(forbidden, release.lower())

--- a/test/windows-task-runner.ps1
+++ b/test/windows-task-runner.ps1
@@ -23,6 +23,15 @@ print("codex-path-ok" if os.environ["PATH"].split(os.pathsep)[0] ==
       os.environ["VIBEPULSE_TEST_CODEX_DIR"] else "codex-path-bad")
 print("codex-home-ok" if os.environ.get("CODEX_HOME") ==
       os.environ["VIBEPULSE_TEST_CODEX_HOME"] else "codex-home-bad")
+expected = [
+    "--github-repo", "owner/repository",
+    "--claude-plan", "max5x",
+    "--codex-plan", "pro",
+    "--plan", "claude=100",
+    "--plan", "codex=20",
+]
+print("optional-pages-ok" if sys.argv[1:] == expected else
+      "optional-pages-bad")
 '@ | Set-Content -LiteralPath $Fixture -Encoding UTF8
     $CodexDir = Join-Path $TempRoot "Codex bin å"
     New-Item -ItemType Directory -Path $CodexDir -Force | Out-Null
@@ -42,7 +51,9 @@ print("codex-home-ok" if os.environ.get("CODEX_HOME") ==
     [System.IO.File]::AppendAllText($LogPath, "rotation-sentinel")
 
     & $Runner -Python $Python -Server $Fixture -CodexBinDir $CodexDir `
-        -CodexHome $CodexHome
+        -CodexHome $CodexHome -GithubRepo "owner/repository" `
+        -ClaudePlan max5x -CodexPlan pro `
+        -ClaudePlanCostUsd "100" -CodexPlanCostUsd "20"
     if ($LASTEXITCODE -ne 0) {
         throw "runner returned $LASTEXITCODE"
     }
@@ -69,6 +80,9 @@ print("codex-home-ok" if os.environ.get("CODEX_HOME") ==
     }
     if (-not $CurrentText.Contains("codex-home-ok")) {
         throw "Codex home was not passed to the child process"
+    }
+    if (-not $CurrentText.Contains("optional-pages-ok")) {
+        throw "GitHub and subscription display inputs were not forwarded"
     }
 
     $FailingFixture = Join-Path $TempRoot "fixture failure å.py"

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -366,6 +366,20 @@ Autostart ingår via Task Scheduler. Kör från repots rot i PowerShell:
 powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1
 ```
 
+Valfria visningskällor måste anges till den schemalagda tjänsten precis som
+vid en manuell start. Repo-värdet är publikt; abonnemangskostnader gissas
+aldrig:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 `
+  -GithubRepo "owner/repository" `
+  -ClaudePlan max5x -ClaudePlanCostUsd "100" `
+  -CodexPlan pro -CodexPlanCostUsd "20"
+```
+
+GitHub-sidan och stjärnnotiserna behöver dessutom sina separata
+`TK_GITHUB_*_ENABLED`-flaggor i panelens gitignorerade `secrets.h`.
+
 Skriptet registrerar tjänsten för den inloggade användaren, startar den
 direkt och startar om den vid fel. Det bakar inte in Claude/Codex- eller
 detaljval i kommandoraden; samma sparade tokenserver-konfiguration används

--- a/tools/tokenserver/install-windows-task.ps1
+++ b/tools/tokenserver/install-windows-task.ps1
@@ -11,6 +11,11 @@ Körs i PowerShell från repots rot:
   # utan relä (bara LAN-servering):
   powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1
 
+  # valfria GitHub- och värdesidor (ange bara planer du faktiskt betalar):
+  powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 `
+      -GithubRepo "owner/repository" -ClaudePlan max5x `
+      -ClaudePlanCostUsd "100" -CodexPlan pro -CodexPlanCostUsd "20"
+
   # avinstallera:
   powershell -ExecutionPolicy Bypass -File tools\tokenserver\install-windows-task.ps1 -Uninstall
 
@@ -27,6 +32,9 @@ Designval, i linje med resten av repot:
   Keep those choices out of the scheduled command so setup changes cannot go
   stale here. The optional publish arguments below are numbers-relay settings,
   not interaction-provider choices.
+- GitHub monitoring and subscription costs are host-display inputs, not
+  interaction permissions. The installer carries those explicit, non-secret
+  choices to the background process so Windows matches a foreground launch.
 - Ingen hemlighet i den registrerade kommandoraden utom relä-URL:en, som
   användaren själv valt att ge — samma exponeringsnivå som secrets.h.
 - En logon-trigger startar tjänsten och en femminuters-watchdog startar den
@@ -36,6 +44,11 @@ Designval, i linje med resten av repot:
 param(
     [string]$PublishUrl = "",
     [string]$PublishName = "",
+    [string]$GithubRepo = "",
+    [string]$ClaudePlan = "",
+    [string]$CodexPlan = "",
+    [string]$ClaudePlanCostUsd = "",
+    [string]$CodexPlanCostUsd = "",
     [switch]$ValidateOnly,
     [switch]$Uninstall
 )
@@ -45,6 +58,26 @@ $TaskName = "VibePulse tokenserver"
 
 if ($ValidateOnly -and $Uninstall) {
     throw "-ValidateOnly and -Uninstall cannot be combined"
+}
+
+if ($GithubRepo -and
+        $GithubRepo -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    throw "-GithubRepo must use owner/repository"
+}
+if ($ClaudePlan -and $ClaudePlan -notin @("pro", "max5x", "max20x")) {
+    throw "-ClaudePlan must be pro, max5x, or max20x"
+}
+if ($CodexPlan -and $CodexPlan -notin @("plus", "pro")) {
+    throw "-CodexPlan must be plus or pro"
+}
+foreach ($Cost in @($ClaudePlanCostUsd, $CodexPlanCostUsd)) {
+    if ($Cost -and $Cost -notmatch '^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,2})?$') {
+        throw "Plan costs must be positive USD values with at most two decimals"
+    }
+    if ($Cost -and [decimal]::Parse(
+            $Cost, [Globalization.CultureInfo]::InvariantCulture) -le 0) {
+        throw "Plan costs must be greater than zero"
+    }
 }
 
 function Resolve-VibePulsePython {
@@ -175,6 +208,21 @@ if ($CodexBinDir) {
 if ($CodexHome) {
     $RunnerArgs += " -CodexHome `"$CodexHome`""
 }
+if ($GithubRepo) {
+    $RunnerArgs += " -GithubRepo `"$GithubRepo`""
+}
+if ($ClaudePlan) {
+    $RunnerArgs += " -ClaudePlan `"$ClaudePlan`""
+}
+if ($CodexPlan) {
+    $RunnerArgs += " -CodexPlan `"$CodexPlan`""
+}
+if ($ClaudePlanCostUsd) {
+    $RunnerArgs += " -ClaudePlanCostUsd `"$ClaudePlanCostUsd`""
+}
+if ($CodexPlanCostUsd) {
+    $RunnerArgs += " -CodexPlanCostUsd `"$CodexPlanCostUsd`""
+}
 if ($PublishUrl) {
     $RunnerArgs += " -PublishUrl `"$PublishUrl`""
     if ($PublishName) { $RunnerArgs += " -PublishName `"$PublishName`"" }
@@ -196,6 +244,8 @@ if ($ValidateOnly) {
     Write-Host "  runner:  $Runner"
     Write-Host "  python:  $PythonConsole ($Version)"
     Write-Host "  task objects: runtime construction passed"
+    Write-Host "  GitHub page source: $([bool]$GithubRepo)"
+    Write-Host "  subscription costs: $([bool]($ClaudePlanCostUsd -or $CodexPlanCostUsd))"
     Write-Host "  action:  no Task Scheduler changes were made"
     exit 0
 }
@@ -221,6 +271,10 @@ Start-ScheduledTask -TaskName $TaskName
 Write-Host "Uppgiften '$TaskName' registrerad och startad."
 Write-Host "  server:  $Server"
 if ($PublishUrl) { Write-Host "  relä:    $PublishUrl" }
+if ($GithubRepo) { Write-Host "  GitHub:  configured" }
+if ($ClaudePlanCostUsd -or $CodexPlanCostUsd) {
+    Write-Host "  plans:   configured"
+}
 Write-Host "  state:   $env:LOCALAPPDATA\VibePulse\"
 Write-Host "  logg:    $env:LOCALAPPDATA\VibePulse\Logs\torget-tokenserver.log"
 Write-Host "Verifiera:  curl http://localhost:8737/  (claudeProbe ska visa ok)"

--- a/tools/tokenserver/run-windows-task.ps1
+++ b/tools/tokenserver/run-windows-task.ps1
@@ -12,6 +12,11 @@ param(
     [string]$Server,
     [string]$CodexBinDir = "",
     [string]$CodexHome = "",
+    [string]$GithubRepo = "",
+    [string]$ClaudePlan = "",
+    [string]$CodexPlan = "",
+    [string]$ClaudePlanCostUsd = "",
+    [string]$CodexPlanCostUsd = "",
     [string]$PublishUrl = "",
     [string]$PublishName = ""
 )
@@ -94,6 +99,21 @@ function Write-VibePulseLogLine {
 Rotate-VibePulseLog
 
 $ServerArgs = @("-u", $Server)
+if ($GithubRepo) {
+    $ServerArgs += @("--github-repo", $GithubRepo)
+}
+if ($ClaudePlan) {
+    $ServerArgs += @("--claude-plan", $ClaudePlan)
+}
+if ($CodexPlan) {
+    $ServerArgs += @("--codex-plan", $CodexPlan)
+}
+if ($ClaudePlanCostUsd) {
+    $ServerArgs += @("--plan", "claude=$ClaudePlanCostUsd")
+}
+if ($CodexPlanCostUsd) {
+    $ServerArgs += @("--plan", "codex=$CodexPlanCostUsd")
+}
 if ($PublishUrl) {
     $ServerArgs += @("--publish", $PublishUrl)
     if ($PublishName) { $ServerArgs += @("--publish-name", $PublishName) }


### PR DESCRIPTION
## Root cause
The Windows scheduled task launched the tokenserver without the optional `--github-repo`, named plan, or per-provider `--plan` inputs. A foreground/macOS launch could therefore show GitHub Stars and API-vs-subscription while the verified Windows background service silently returned `github.enabled: false` and `value.state: no_plan_cost`.

The device-side GitHub screen remains a separate explicit firmware opt-in.

## Fix
- add validated `GithubRepo`, Claude/Codex plan labels, and exact per-provider USD cost parameters to the Windows installer
- forward those values exactly through the bounded-log runner to tokenserver CLI flags
- extend the real Windows runner fixture and CI `-ValidateOnly` invocation
- document the host + firmware two-sided GitHub gate and explicit plan-cost setup
- record the fix under `Unreleased`

## Verification
- PowerShell parser: 3/3 scripts PASS
- installer `-ValidateOnly` with all new inputs: PASS, no task change
- `test/windows-task-runner.ps1`: PASS
- tokenserver suite: 788 tests, 11 skips, 0 failures/errors
- setup/plugin suite: 118 tests, 6 skips, 0 failures
- relay/privacy boundary: PASS
- `git diff --check`: PASS

No credentials, relay URLs, or private payloads are added or logged. Subscription costs are never guessed.