### PR TITLE
Fix Windows Codex value lookup with custom CODEX_HOME

### DIFF
--- a/tools/tokenserver/codex_usage.py
+++ b/tools/tokenserver/codex_usage.py
@@ -36,6 +36,7 @@ the Codex source rather than assumed:
 from __future__ import annotations
 
 import json
+import os
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -52,8 +53,27 @@ else:  # direct execution
                                codex_rollout_turn_model)
     import value_meter
 
+DEFAULT_SESSIONS_DIR: Optional[Path] = None
 
-DEFAULT_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+
+def _default_sessions_dir() -> Path:
+    """Resolve the sessions directory the same way the Codex CLI does.
+
+    ``CODEX_HOME`` is commonly set by the desktop app and by managed Windows
+    installations.  Falling back unconditionally to ``~/.codex`` makes quota
+    reads work while the month-value scan silently reads a different profile.
+    Resolve at call time so a long-lived tokenserver also follows the
+    environment it was started with, without capturing an import-time test or
+    launcher override.
+    """
+    # Kept as an override for the existing integration-test seam. Production
+    # leaves it at None and follows the process environment.
+    if DEFAULT_SESSIONS_DIR is not None:
+        return Path(DEFAULT_SESSIONS_DIR)
+    configured = os.environ.get("CODEX_HOME")
+    codex_home = Path(configured).expanduser() if configured else (
+        Path.home() / ".codex")
+    return codex_home / "sessions"
 
 _lock = threading.Lock()
 # path -> {"stat", "identity", "offset", "month", "model", "session_id",
@@ -161,7 +181,8 @@ def month_value(sessions_dir: Optional[Path] = None,
     returns zeros -- not an error, and not an unpriced tally, because there is
     genuinely nothing there to price.
     """
-    root = Path(sessions_dir) if sessions_dir else DEFAULT_SESSIONS_DIR
+    root = (Path(sessions_dir) if sessions_dir is not None
+            else _default_sessions_dir())
     if not root.is_dir():
         return 0.0, 0, 0
 

--- a/tools/tokenserver/test_codex_usage.py
+++ b/tools/tokenserver/test_codex_usage.py
@@ -20,10 +20,12 @@ or message leaves the box -- holds for fixtures too.
 """
 
 import json
+import os
 import tempfile
 import unittest
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest import mock
 
 from tools.tokenserver import codex_usage
 
@@ -148,6 +150,20 @@ class CodexUsageScanTest(unittest.TestCase):
     def test_missing_sessions_dir_is_zero_not_an_error(self):
         self.assertEqual(
             codex_usage.month_value(self.root / "nope"), (0.0, 0, 0))
+
+    def test_default_sessions_dir_honors_codex_home(self):
+        sessions = self.root / "custom-codex-home" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "rollout-a.jsonl").write_text(
+            turn_context() + token_count(ONE_MILLION_FRESH))
+
+        with mock.patch.dict(
+                os.environ, {"CODEX_HOME": str(sessions.parent)}):
+            usd, priced, unpriced = codex_usage.month_value()
+
+        self.assertAlmostEqual(usd, 5.00)
+        self.assertEqual(priced, 1_000_000)
+        self.assertEqual(unpriced, 0)
 
     def test_prices_a_turn_against_the_preceding_turn_context(self):
         self.write("rollout-a.jsonl",


### PR DESCRIPTION
## Summary
- resolve Codex rollout sessions from CODEX_HOME before the standard home fallback
- retain the existing explicit test override
- add a Windows-relevant regression test

## Verification
- focused: 26 tests passed
- complete tokenserver suite: 789 passed, 11 named platform skips, 0 failures/errors
- real-host sanitized probe finds priced usage through configured CODEX_HOME

No authentication files, prompts, rollout contents, or quota values are exposed.