### PR TITLE
Fix VibePulse discovery with current Codex MCP metadata

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
@@ -265,12 +265,20 @@ def _initialize(params):
     }
 
 
+def _empty_or_metadata_only(params):
+    if params in (_MISSING, None, {}):
+        return True
+    return (isinstance(params, dict) and set(params) == {"_meta"} and
+            isinstance(params["_meta"], dict) and
+            _bounded_tree(params["_meta"]))
+
+
 def _dispatch(method, params):
     if method == "initialize":
         result = _initialize(params)
         return result if result is not None else _MISSING
     if method in {"ping", "tools/list", "notifications/initialized"}:
-        if params not in (_MISSING, None, {}):
+        if not _empty_or_metadata_only(params):
             return _MISSING
         if method == "tools/list":
             return {"tools": [TOOL]}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- The local VibePulse MCP bridge now accepts the bounded `_meta` request field
+  emitted by current Codex clients during tool discovery, so the physical
+  `APPROVE` question remains available instead of failing MCP startup.
 - Windows Task Scheduler installations can now persist the optional public
   GitHub source, named Claude/Codex plan labels, and explicit per-provider
   subscription costs. The background service no longer drops the GitHub Stars

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -836,7 +836,7 @@ class McpServerTests(unittest.TestCase):
                 },
             }),
             {"jsonrpc": "2.0", "method": "notifications/initialized"},
-            rpc("tools/list", 2),
+            rpc("tools/list", 2, {"_meta": {}}),
         ])
         self.assertEqual(completed.returncode, 0)
         self.assertEqual([response["id"] for response in responses], [1, 2])
@@ -844,6 +844,22 @@ class McpServerTests(unittest.TestCase):
                          "2025-06-18")
         self.assertEqual([tool["name"] for tool in
                           responses[1]["result"]["tools"]], ["ask"])
+
+    def test_list_and_ping_allow_only_bounded_request_metadata(self):
+        completed, responses = run_mcp([
+            rpc("tools/list", 1, {"_meta": {"progressToken": "list-1"}}),
+            rpc("ping", 2, {"_meta": {}}),
+            rpc("tools/list", 3, {"_meta": "not-an-object"}),
+            rpc("tools/list", 4, {"_meta": {}, "cursor": None}),
+        ])
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([response["id"] for response in responses],
+                         [1, 2, 3, 4])
+        self.assertEqual([tool["name"] for tool in
+                          responses[0]["result"]["tools"]], ["ask"])
+        self.assertEqual(responses[1]["result"], {})
+        self.assertEqual(responses[2]["error"]["code"], -32602)
+        self.assertEqual(responses[3]["error"]["code"], -32602)
 
     def test_answered_call_returns_identical_text_and_structured_content(self):
         answered = {"status": "answered", "option_index": 0,


### PR DESCRIPTION
Root cause: current Codex sends a bounded _meta object with tools/list. The VibePulse MCP bridge rejected every non-empty tools/list params object, so discovery failed before ask became available.

Fix: accept only bounded metadata-only params for tools/list and ping; keep cursor, unknown keys, non-object metadata, and oversized trees fail-closed.

Verification:
- VibePulse Codex plugin tests: 119 passed, 6 skipped
- Full tokenserver suite: 789 passed, 11 skipped
- Real Codex 0.150 MCP startup/tool discovery succeeds with the patched server
- Changelog Unreleased updated