### PR TITLE
Accept current Codex metadata on VibePulse ask calls

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
@@ -283,7 +283,12 @@ def _dispatch(method, params):
         if method == "tools/list":
             return {"tools": [TOOL]}
         return {}
-    if not isinstance(params, dict) or set(params) != {"name", "arguments"}:
+    if (not isinstance(params, dict) or
+            not {"name", "arguments"}.issubset(params) or
+            not set(params).issubset({"name", "arguments", "_meta"}) or
+            ("_meta" in params and
+             (not isinstance(params["_meta"], dict) or
+              not _bounded_tree(params["_meta"])))):
         return _tool_error("Invalid ask parameters")
     if params["name"] != TOOL_NAME or not _bounded_tree(params["arguments"]) or \
             not _valid_arguments(params["arguments"]):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 ### Fixed
 
 - The local VibePulse MCP bridge now accepts the bounded `_meta` request field
-  emitted by current Codex clients during tool discovery, so the physical
-  `APPROVE` question remains available instead of failing MCP startup.
+  emitted by current Codex clients during tool discovery and invocation, so
+  the physical `APPROVE` question remains available instead of failing MCP
+  startup or rejecting an otherwise valid call.
 - Windows Task Scheduler installations can now persist the optional public
   GitHub source, named Claude/Codex plan labels, and explicit per-provider
   subscription costs. The background service no longer drops the GitHub Stars

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -866,7 +866,10 @@ class McpServerTests(unittest.TestCase):
                     "answer": "Use the trusted hook"}
         with LocalServer(body=compact(answered).encode()) as server:
             completed, responses = run_mcp([
-                rpc("tools/call", 7, {"name": "ask", "arguments": QUESTION})
+                rpc("tools/call", 7, {
+                    "name": "ask", "arguments": QUESTION,
+                    "_meta": {"progressToken": "ask-7"},
+                })
             ], port=server.port, env={
                 "VIBEPULSE_CWD": "/tmp/project",
                 "VIBEPULSE_SESSION_ID": "session-123",
@@ -1128,6 +1131,24 @@ class McpServerTests(unittest.TestCase):
         self.assertEqual(len(server.requests), 0)
         self.assertEqual(len(responses), len(bad_calls))
         self.assertTrue(all(response["result"]["isError"] for response in responses))
+
+    def test_tool_call_rejects_invalid_or_unbounded_metadata(self):
+        deep = {"value": True}
+        for _ in range(20):
+            deep = {"nested": deep}
+        bad_calls = (
+            {"name": "ask", "arguments": QUESTION, "_meta": "bad"},
+            {"name": "ask", "arguments": QUESTION, "_meta": deep},
+            {"name": "ask", "arguments": QUESTION, "unknown": {}},
+        )
+        with LocalServer(body=b'{}') as server:
+            _, responses = run_mcp([
+                rpc("tools/call", index, params)
+                for index, params in enumerate(bad_calls)
+            ], port=server.port)
+        self.assertEqual(server.requests, [])
+        self.assertTrue(all(response["result"]["isError"]
+                            for response in responses))
 
     def test_bad_params_unknown_methods_and_notifications_handle_ids_exactly(self):
         messages = [


### PR DESCRIPTION
Root cause: current Codex adds the bounded MCP _meta request field to tools/call as well as tools/list. PR #54 fixed discovery; the call validator still required exactly name plus arguments and rejected the physical ask before it reached the panel.

Fix: accept only a bounded object-valued _meta alongside the two required tool-call fields. Unknown fields, non-object metadata, and over-deep metadata remain fail-closed.

Verification:
- VibePulse Codex plugin tests: 120 passed, 6 skipped
- Real Codex 0.150 now discovers ask after PR #54; this PR covers the observed tools/call request shape
- The clean full suite on the immediately preceding main passed 789 tests with 11 skips
- A second local full run was invalidated by the host C drive being full and Windows async temp-file timeout/locking; clean CI is the merge gate
- Changelog wording updated