### PR TITLE
Distinguish live Claude quota sources from expired fallbacks

### DIFF
--- a/.agents/plugins/plugins/vibepulse/.codex-plugin/plugin.json
+++ b/.agents/plugins/plugins/vibepulse/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibepulse",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Optional local VibePulse panel interactions for Codex.",
   "author": {
     "name": "Niclas Vestlund",

--- a/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
@@ -261,7 +261,7 @@ def _initialize(params):
     return {
         "protocolVersion": selected,
         "capabilities": {"tools": {"listChanged": False}},
-        "serverInfo": {"name": "vibepulse", "version": "0.1.1"},
+        "serverInfo": {"name": "vibepulse", "version": "0.1.2"},
     }
 
 

--- a/.agents/plugins/plugins/vibepulse/skills/vibepulse/SKILL.md
+++ b/.agents/plugins/plugins/vibepulse/skills/vibepulse/SKILL.md
@@ -31,4 +31,27 @@ interaction content remain local in this phase.
 
 When setup state is relevant, run `python3 tools/vibepulse_setup.py status`.
 When troubleshooting is relevant, run `python3 tools/vibepulse_setup.py doctor`.
+From a checkout, prefer its `.venv/bin/python` on POSIX or
+`.venv\Scripts\python.exe` on Windows when present; a system `python3` can be
+older than the interpreter that actually runs the service. Also run
+`tools/tokenserver/smoke.py` with that interpreter for a stale report.
+
+Diagnose these safe signals separately: `claudeProbe` is the active quota
+source outcome, `claudeCredential` is saved-credential readiness, and the
+`/api/tokens` stale flags are the data actually sent to the panel. If
+`claudeProbe` is `usage_http_200 + ok` and the relevant stale flag is false,
+the source is live even when the saved credential says `expired`; call that a
+future recovery risk, not the current stale cause. Start a new Claude Code CLI
+turn to refresh the saved fallback. VibePulse rereads local credentials every
+15 seconds, so do not prescribe a tokenserver restart first.
+
+If the local API and configured numbers relay are fresh while the glass is
+stale, inspect recent panel polling and passive device logs. Do not reset or
+flash the panel without explicit permission. Silence from serial is not proof
+that the firmware is healthy or unhealthy.
+
+Explain when asked that this skill is versioned with the plugin; it does not
+learn or update itself. New lessons reach installed Codex sessions only after
+the repository skill is changed, the plugin version is released/updated, and a
+new task loads that version.
 Do not run install, disable, or uninstall without the user's explicit request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- The VibePulse Codex plugin advances to `0.1.2`. Its skill, setup doctor,
+  and host smoke check now distinguish a currently live Claude process source
+  from an expired saved fallback credential. Recovery is re-read locally
+  within 15 seconds and no longer prescribes an unnecessary tokenserver
+  restart.
 - Windows Task Scheduler installation now uses the Windows 10-compatible
   `IgnoreNew` instance policy and explicitly stops only its own running task
   during an idempotent update; the previous `StopExisting` enum value parsed

--- a/README.md
+++ b/README.md
@@ -319,7 +319,10 @@ The startup/doctor health check also guards Claude's saved usage credential.
 never an access or refresh token—and warns 30 minutes before expiry. This
 matters because Claude Desktop can remain logged in after the separate
 credential readable by VibePulse has aged out; stale Fable data is never
-reported as current.
+reported as current. Read that guard together with `claudeProbe` and the
+`/api/tokens` stale flags: a successful probe plus a fresh model-week flag
+means the current source is live even if the saved fallback is expired. That
+is a future recovery risk, not a reason to restart the tokenserver.
 
 ## What you need
 

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -198,9 +198,12 @@ safe status and whole minutes remaining—never either OAuth token. `expiring`
 starts 30 minutes before failure; `expired` is actionable even when
 `claude auth status` still says logged in. `python3 tools/vibepulse_setup.py
 doctor`, Codex `SessionStart`, and `python3 tools/tokenserver/smoke.py` all
-consume this guard. After Claude's supported client refreshes the credential,
-the service notices locally within 15 seconds; it does not call an
-undocumented refresh endpoint or mutate the refresh token itself.
+consume this guard. Do not confuse it with the active source outcome: if
+`claudeProbe` is `usage_http_200 + ok` and the relevant `/api/tokens` stale
+flag is false, current quota is live while the expired saved credential is a
+future recovery risk. Start a new Claude Code CLI turn to refresh that saved
+fallback. The service notices locally within 15 seconds; it does not need a
+restart, call an undocumented refresh endpoint, or mutate the refresh token.
 
 Then check the endpoints the screen polls:
 
@@ -440,7 +443,7 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 | A test question shows only **LEAVE IT** | The request has no single explicit recommendation | Use 2–3 short options and mark exactly one genuinely recommended option |
 | **SOMETHING IS WAITING** appears with no answer buttons | The question failed the physical fit/privacy gate | Finish on the computer. For a diagnostic only, use the canonical short smoke test above |
 | Letters become boxes in project/status text | The UI selected an uppercase-only font | Use `plex_ui_21` for mixed-case/localized text and verify with `RÄKSMÖRGÅS` |
-| Panel shows stale quota / empty Fable weekly in the morning | The readable OAuth copy expired/rejected, or an upstream 429 penalty is active | The general week can recover from Claude Desktops bounded local plan history; the named Fable/Opus pool still requires OAuth. Check both `claudeProbe` and `claudeLocalUsage` on `curl localhost:8737/` |
+| Panel shows stale quota / empty Fable weekly in the morning | The readable OAuth copy expired/rejected, or an upstream 429 penalty is active | Check `claudeProbe`, `claudeCredential`, `claudeLocalUsage`, and `/api/tokens` together. The named Fable/Opus pool requires a live OAuth source. Start a new Claude Code CLI turn, then allow the automatic 15-second local recheck; restart is not the first recovery step |
 | Panel shows stale while powered from the computer USB port | The Mac port cannot feed WiFi TX bursts — fetches time out | Expected on Mac USB; run from wall power. Logs stay valid on Mac USB, data does not |
 | OTA boots always show state 0xffffffff and the health gate always rests | `sdkconfig` generated before the rollback line landed in `sdkconfig.defaults` (defaults only apply on fresh generation) | `grep BOOTLOADER_APP_ROLLBACK sdkconfig` — set `=y`, rebuild, and USB-flash ONCE (the bootloader carries the logic; OTA never writes it) |
 | No `/dev/cu.usbmodem*` or Windows `COM` port | Not in download mode | Hold BOOT, tap RESET, release BOOT |

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,19 @@ point at the backlog item.
 
 ---
 
+## 2026-08-29 · A dead saved credential and a live quota source coexisted
+
+**What happened:** Fable went stale after the saved Claude credential expired;
+later the usage probe recovered through a newly started Claude client, but
+doctor still described the saved credential as if the current source were
+dead. **Root cause:** active process candidates have no readable expiry, while
+the content-free guard correctly retained the expired saved-Keychain state;
+the diagnostics then collapsed those two truths and prescribed a needless
+server restart. **The rule:** diagnose active source outcome, saved recovery
+readiness, and served stale flags separately. **Guards:** plugin 0.1.2 skill,
+doctor/smoke regression tests, and the 15-second local reread. **Watch for:**
+calling an expired fallback the current outage when `claudeProbe` is healthy.
+
 ## 2026-08-28 · A healthy scheduled Codex source failed in the interactive shell
 
 **What happened:** a direct Windows probe failed while the scheduled API

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -6,7 +6,7 @@ around them (2026-08-13). How these get found and worked is described in
 [observability.md](observability.md); stories behind them live in
 [lessons.md](lessons.md).
 
-**Last combed: 2026-08-13 (initial audit — this document is its result).**
+**Last combed: 2026-08-29 (Claude stale/source-readiness incident).**
 
 Rules of the file:
 
@@ -202,6 +202,18 @@ false on client-init failure with no log at all — the only silent path in
 an otherwise well-logged function.
 **Fix:** log the real enum + URL; retry instead of task suicide; add the
 missing log line.
+
+### OBS-32 · Saved-credential expiry impersonated the active quota source
+`host · S · done (2026-08-29)`
+The root endpoint intentionally reported saved Claude credential readiness
+separately from `claudeProbe`, but doctor, smoke, and the Codex skill read an
+expired saved fallback as if it proved the current process source was dead.
+That contradiction appeared in production when `claudeProbe` was
+`usage_http_200 + ok`, Fable was fresh, and `claudeCredential` was expired.
+Doctor also prescribed a server restart even though credentials are reread
+locally every 15 seconds. The tools and versioned plugin 0.1.2 skill now name
+all three dimensions—active probe, saved fallback, and served stale flags—and
+tests pin both the live-source and genuinely stale cases.
 
 ---
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -784,7 +784,7 @@ class McpServerTests(unittest.TestCase):
         initialized = responses[0]["result"]
         self.assertEqual(initialized["protocolVersion"], "2025-06-18")
         self.assertEqual(initialized["serverInfo"]["name"], "vibepulse")
-        self.assertEqual(initialized["serverInfo"]["version"], "0.1.1")
+        self.assertEqual(initialized["serverInfo"]["version"], "0.1.2")
         self.assertEqual(initialized["capabilities"], {"tools": {"listChanged": False}})
         self.assertEqual(responses[1]["result"], {})
         tools = responses[2]["result"]["tools"]
@@ -1239,7 +1239,7 @@ class PluginPackageTests(unittest.TestCase):
         self.assertRegex(
             manifest["version"], r"^(0|[1-9][0-9]*)\."
             r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
-        self.assertEqual(manifest["version"], "0.1.1")
+        self.assertEqual(manifest["version"], "0.1.2")
         self.assertEqual(manifest["author"]["name"], "Niclas Vestlund")
         self.assertNotIn("email", manifest["author"])
         self.assertEqual(manifest["license"], "MIT")
@@ -1308,6 +1308,12 @@ class PluginPackageTests(unittest.TestCase):
             self.assertIn(safety, body.lower())
         self.assertIn("python3 tools/vibepulse_setup.py status", body)
         self.assertIn("python3 tools/vibepulse_setup.py doctor", body)
+        for stale_guard in (
+                "claudeProbe", "claudeCredential", "/api/tokens",
+                "usage_http_200 + ok", "15 seconds",
+                "do not prescribe a tokenserver restart first",
+                "learn or update itself"):
+            self.assertIn(stale_guard, body)
         self.assertRegex(body.lower(), r"relay (?:is|remains) not enabled")
         for physical_guard in (
                 "Ser du APPROVE?", "SOMETHING IS WAITING",
@@ -1386,6 +1392,36 @@ class PluginPackageTests(unittest.TestCase):
 
 
 class SetupPlanTests(unittest.TestCase):
+    def test_doctor_separates_live_source_from_expired_saved_fallback(self):
+        setup = load_setup()
+        output = io.StringIO()
+
+        healthy = setup._doctor_claude_quota({
+            "claudeProbe": "usage_http_200 + ok",
+            "claudeCredential": {"status": "expired", "expiresInMin": 0},
+        }, output)
+
+        self.assertFalse(healthy)
+        text = output.getvalue()
+        self.assertIn("current quota source is live", text)
+        self.assertIn("next client gap can make Fable stale", text)
+        self.assertIn("does not need a restart", text)
+
+    def test_doctor_never_calls_failed_probe_live_or_requires_restart(self):
+        setup = load_setup()
+        output = io.StringIO()
+
+        healthy = setup._doctor_claude_quota({
+            "claudeProbe": "token_expired_15:34",
+            "claudeCredential": {"status": "expired", "expiresInMin": 0},
+        }, output)
+
+        self.assertFalse(healthy)
+        text = output.getvalue()
+        self.assertNotIn("source is live", text)
+        self.assertIn("rechecks automatically", text)
+        self.assertIn("does not need a restart", text)
+
     def test_auto_executable_resolution_uses_shared_codex_resolver(self):
         setup = load_setup()
         expected = Path(

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -46,9 +46,12 @@ The same doctor path reads a content-free Claude credential guard from
 `GET /`: `ready`, `expiring`, `expired`, `unavailable`, or `unknown`, plus
 whole minutes remaining when known. It warns 30 minutes before expiry and
 never returns or logs an access token, refresh token, account id, or Keychain
-body. A new Claude Code CLI turn is the supported refresh path; the service
-then detects the new local credential within 15 seconds without retrying a
-dead token upstream.
+body. Read it together with `claudeProbe` and `/api/tokens`: when the probe is
+`usage_http_200 + ok` and the relevant stale flag is false, a current Claude
+client is feeding live quota even if the saved fallback says `expired`. A new
+Claude Code CLI turn is the supported way to refresh that fallback; the
+service detects it within 15 seconds without retrying a dead token upstream or
+needing a restart.
 
 The Codex safe-command tier only offers **ALLOW ONCE** for recognized
 read-only, test, and build commands. Unknown, mutating, secret-bearing, or

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -211,12 +211,22 @@ def check_server(base_url, checkout_rev=None, checkout_src=None):
         if credential_status == "ready" and isinstance(remaining, int):
             results.append((OK, f"claude-credential: {remaining} min kvar"))
         elif credential_status == "expiring" and isinstance(remaining, int):
-            results.append((VARN, f"claude-credential går ut om {remaining} "
-                                  "min — starta en ny Claude Code CLI-turn "
-                                  "innan dess"))
+            current = ("; nuvarande kvotkälla är live" if probe == PROBE_OK
+                       else "")
+            results.append((VARN, f"sparad claude-credential går ut om "
+                                  f"{remaining} min{current} — starta en ny "
+                                  "Claude Code CLI-turn innan dess"))
         elif credential_status == "expired":
-            results.append((VARN, "claude-credential har gått ut — en ny "
-                                  "Claude Code CLI-turn måste förnya den"))
+            if probe == PROBE_OK:
+                results.append((VARN, "sparad claude-credential har gått "
+                                      "ut; nuvarande kvotkälla är live, "
+                                      "men nästa klientglapp kan göra Fable "
+                                      "stale — starta en ny Claude Code "
+                                      "CLI-turn; ingen serveromstart behövs"))
+            else:
+                results.append((VARN, "sparad claude-credential har gått "
+                                      "ut — starta en ny Claude Code CLI-turn; "
+                                      "VibePulse läser om den automatiskt"))
         else:
             results.append((VARN, "claude-credential kan inte "
                                   "utgångsbevakas — kör setup doctor"))

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -109,6 +109,30 @@ class ServerCheckTests(unittest.TestCase):
         self.assertIn("19 min", warnings[0])
         self.assertIn("ny Claude Code CLI-turn", warnings[0])
 
+    def test_expired_saved_credential_does_not_hide_live_process_source(self):
+        root = dict(HEALTHY_ROOT, claudeCredential={
+            "status": "expired", "expiresInMin": 0})
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        warnings = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("nuvarande kvotkälla är live", warnings[0])
+        self.assertIn("nästa klientglapp", warnings[0])
+        self.assertIn("ingen serveromstart behövs", warnings[0])
+
+    def test_expired_saved_credential_with_dead_probe_is_not_called_live(self):
+        root = dict(HEALTHY_ROOT, claudeProbe="token_expired_15:34",
+                    claudeCredential={"status": "expired",
+                                      "expiresInMin": 0})
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        warnings = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warnings), 2)
+        self.assertFalse(any("kvotkälla är live" in text
+                             for text in warnings))
+        self.assertTrue(any("läser om den automatiskt" in text
+                            for text in warnings))
+
     def test_unknown_buckets_warn(self):
         root = dict(HEALTHY_ROOT, unknownRateLimitBuckets=["7d_haiku"])
         with canned_server({"/": root}) as base:

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1570,8 +1570,9 @@ def _doctor_claude_quota(payload: dict, stdout) -> bool:
 
     status = credential.get("status")
     remaining = credential.get("expiresInMin")
+    source_live = probe == "usage_http_200 + ok"
     if status == "ready" and isinstance(remaining, int) and remaining >= 0:
-        if probe == "usage_http_200 + ok":
+        if source_live:
             print(f"PASS Claude quota credential: ready ({remaining} min "
                   "remaining)", file=stdout)
             return True
@@ -1584,23 +1585,35 @@ def _doctor_claude_quota(payload: dict, stdout) -> bool:
         return False
 
     if status == "expiring" and isinstance(remaining, int) and remaining >= 0:
-        print(f"FIX Claude quota credential: expires in {remaining} min; "
-              "start a new Claude Code CLI turn before then so its supported "
-              "client refreshes Keychain", file=stdout)
+        live = ("; the current quota source is live, but "
+                if source_live else "; ")
+        print(f"FIX Saved Claude quota credential: expires in {remaining} "
+              f"min{live}start a new Claude Code CLI turn before then so its "
+              "supported client refreshes Keychain", file=stdout)
         return False
     if status == "expired":
-        print("FIX Claude quota credential: expired; login status alone is "
-              "not enough—start a new Claude Code CLI turn, then restart "
-              "the VibePulse tokenserver", file=stdout)
+        if source_live:
+            print("FIX Saved Claude quota credential: expired; the current "
+                  "quota source is live via a current Claude client, but the "
+                  "next client gap can make Fable stale—start a new Claude "
+                  "Code CLI turn; VibePulse rechecks automatically and does "
+                  "not need a restart", file=stdout)
+        else:
+            print("FIX Saved Claude quota credential: expired; login status "
+                  "alone is not enough—start a new Claude Code CLI turn; "
+                  "VibePulse rechecks automatically and does not need a "
+                  "restart", file=stdout)
         return False
     if status == "unavailable":
         print("FIX Claude quota credential: no supported Claude credential "
               "was found on this computer", file=stdout)
         return False
     if status == "unknown":
-        print("FIX Claude quota credential: a process token exists but its "
-              "expiry cannot be guarded; sign in with Claude Code so the "
-              "supported credential store is populated", file=stdout)
+        live = (" The current quota source is live, but its" if source_live
+                else " Its")
+        print("FIX Claude quota credential:" + live + " process-token expiry "
+              "cannot be guarded; sign in with Claude Code so the supported "
+              "credential store is populated", file=stdout)
         return False
 
     print("FIX Claude quota credential: invalid diagnostics", file=stdout)


### PR DESCRIPTION
## Summary
- distinguish the active Claude quota probe from saved credential readiness in doctor and smoke
- teach the versioned VibePulse 0.1.2 skill the proven stale recovery sequence
- record the incident in README, agent setup, lessons, observability, and changelog

## Validation
- 785 tokenserver tests pass
- 114 VibePulse Codex plugin tests pass
- live doctor/smoke correctly report a fresh current source plus an expired saved fallback without prescribing a server restart

## Physical boundary
- local quota endpoints are fresh and the encrypted numbers relay was fresh during diagnosis
- the current server has no recent direct LAN panel poll; passive serial produced no evidence
- no reset, flash, provider setting, hook trust, or installed plugin cache was changed