### PR TITLE
Fix stale-glass diagnostics

### DIFF
--- a/.agents/plugins/plugins/vibepulse/.codex-plugin/plugin.json
+++ b/.agents/plugins/plugins/vibepulse/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibepulse",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Optional local VibePulse panel interactions for Codex.",
   "author": {
     "name": "Niclas Vestlund",

--- a/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
@@ -261,7 +261,7 @@ def _initialize(params):
     return {
         "protocolVersion": selected,
         "capabilities": {"tools": {"listChanged": False}},
-        "serverInfo": {"name": "vibepulse", "version": "0.1.2"},
+        "serverInfo": {"name": "vibepulse", "version": "0.1.3"},
     }
 
 

--- a/.agents/plugins/plugins/vibepulse/skills/vibepulse/SKILL.md
+++ b/.agents/plugins/plugins/vibepulse/skills/vibepulse/SKILL.md
@@ -46,9 +46,19 @@ turn to refresh the saved fallback. VibePulse rereads local credentials every
 15 seconds, so do not prescribe a tokenserver restart first.
 
 If the local API and configured numbers relay are fresh while the glass is
-stale, inspect recent panel polling and passive device logs. Do not reset or
-flash the panel without explicit permission. Silence from serial is not proof
-that the firmware is healthy or unhealthy.
+stale, inspect `GET /` → `interactions.panel` for recent direct polling and
+read passive device logs. A `waiting` direct-poll state does not prove failure
+on a relay-only network, but fresh LAN plus fresh relay plus a stale glass
+localizes the fault to the device-side power/network/firmware hop. Test the
+numbers relay with a panel-compatible User-Agent; Cloudflare may reject
+Python's default User-Agent even when the ESP32 path is healthy. A running
+panel on a computer USB port can consume the full 500 mA budget yet still fail
+during Wi-Fi bursts; use a dedicated 5 V supply for runtime. Compare the
+registered installed firmware with current `main`: firmware older than the
+service-discovery change cannot move automatically between advertising Mac
+and Windows hosts. Do not reset or flash the panel without explicit
+permission. Silence from serial is not proof that the firmware is healthy or
+unhealthy.
 
 Explain when asked that this skill is versioned with the plugin; it does not
 learn or update itself. New lessons reach installed Codex sessions only after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- The VibePulse Codex plugin advances to `0.1.3`. Doctor now surfaces recent
+  direct panel polling without misclassifying a healthy relay-only setup, and
+  the skill distinguishes fresh provider data from the device-side
+  power/network/firmware hop, including computer-USB power limits and
+  panel-compatible relay probes.
 - The local VibePulse MCP bridge now accepts the bounded `_meta` request field
   emitted by current Codex clients during tool discovery and invocation, so
   the physical `APPROVE` question remains available instead of failing MCP

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,22 @@ point at the backlog item.
 
 ---
 
+## 2026-08-30 · A fresh feed did not prove fresh glass
+
+**What happened:** the Mac API and the numbers relay both served fresh Claude,
+Fable, and Codex values while the physical panel still showed `STALE` and made
+no confirmed LAN poll. **Root cause class:** provider freshness had been proved,
+but the device-side hop had not; the installed firmware predated automatic
+Mac/Windows discovery and the running board consumed the computer USB port's
+full 500 mA budget, a known unreliable condition for Wi-Fi bursts. A Python
+relay probe added noise by receiving a User-Agent-specific Cloudflare `403`
+while the ESP32-compatible request was healthy. **The rule:** prove source,
+local API, relay with the real client shape, direct panel polling, firmware
+generation, and power separately. **Guards:** doctor now reports direct panel
+evidence without treating relay-only operation as failure; plugin 0.1.3 carries
+the decision tree. **Watch for:** calling fresh JSON a healthy screen or a
+generic HTTP client equivalent to the panel.
+
 ## 2026-08-29 · A dead saved credential and a live quota source coexisted
 
 **What happened:** Fable went stale after the saved Claude credential expired;

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -6,7 +6,7 @@ around them (2026-08-13). How these get found and worked is described in
 [observability.md](observability.md); stories behind them live in
 [lessons.md](lessons.md).
 
-**Last combed: 2026-08-29 (Claude stale/source-readiness incident).**
+**Last combed: 2026-08-30 (fresh feed / stale glass transport incident).**
 
 Rules of the file:
 
@@ -214,6 +214,17 @@ Doctor also prescribed a server restart even though credentials are reread
 locally every 15 seconds. The tools and versioned plugin 0.1.2 skill now name
 all three dimensions—active probe, saved fallback, and served stale flags—and
 tests pin both the live-source and genuinely stale cases.
+
+### OBS-33 · Fresh server data hid an unproved device hop
+`host + firmware · S · done (2026-08-30)` — local and relay token payloads
+were fresh while the physical glass remained stale and `GET /` reported no
+confirmed direct panel poll. A generic Python relay probe also received a
+Cloudflare `403` that the panel-compatible User-Agent did not. Doctor now
+surfaces `ready`/`waiting`/`stale` direct-poll evidence without calling a
+relay-only network broken, and the versioned skill requires separate checks of
+source, LAN, real-client relay, power, and firmware generation. The installed
+unit still needs a separately authorized physical update and wall-powered
+runtime verification; silence from passive serial remains non-evidence.
 
 ---
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -397,6 +397,12 @@ def healthy_diagnostics():
     }).encode()
 
 
+def panel_diagnostics(status, **extra):
+    payload = json.loads(healthy_diagnostics())
+    payload["interactions"]["panel"] = {"status": status, **extra}
+    return json.dumps(payload).encode()
+
+
 class StatefulCodexRunner:
     """Small exact Codex model for transaction and reconciliation tests."""
 
@@ -793,7 +799,7 @@ class McpServerTests(unittest.TestCase):
         initialized = responses[0]["result"]
         self.assertEqual(initialized["protocolVersion"], "2025-06-18")
         self.assertEqual(initialized["serverInfo"]["name"], "vibepulse")
-        self.assertEqual(initialized["serverInfo"]["version"], "0.1.2")
+        self.assertEqual(initialized["serverInfo"]["version"], "0.1.3")
         self.assertEqual(initialized["capabilities"], {"tools": {"listChanged": False}})
         self.assertEqual(responses[1]["result"], {})
         tools = responses[2]["result"]["tools"]
@@ -1285,7 +1291,7 @@ class PluginPackageTests(unittest.TestCase):
         self.assertRegex(
             manifest["version"], r"^(0|[1-9][0-9]*)\."
             r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
-        self.assertEqual(manifest["version"], "0.1.2")
+        self.assertEqual(manifest["version"], "0.1.3")
         self.assertEqual(manifest["author"]["name"], "Niclas Vestlund")
         self.assertNotIn("email", manifest["author"])
         self.assertEqual(manifest["license"], "MIT")
@@ -2399,6 +2405,43 @@ class RelaySetupTests(unittest.TestCase):
             self.assertIn("--no-legacy-claude-panel-v1",
                           output.getvalue())
             self.assertIn("PASS Tokenserver", output.getvalue())
+
+    def test_doctor_reports_panel_lan_contact_without_failing_relay_only_use(self):
+        setup = load_setup()
+        cases = (
+            ("ready", {"route": "/api/tokens"},
+             "PASS Panel LAN contact: recent confirmed poll via /api/tokens"),
+            ("waiting", {},
+             "WAIT Panel LAN contact: no confirmed direct poll"),
+            ("stale", {"ageS": 90, "route": "/api/agent-status"},
+             "WAIT Panel LAN contact: the last confirmed direct poll is stale"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            setup.save_config(path, setup.VibePulseConfig(
+                codex_interactions=True))
+            for status, extra, expected in cases:
+                with self.subTest(status=status):
+                    output = io.StringIO()
+                    body = panel_diagnostics(status, **extra)
+                    code = setup.main(
+                        ["doctor"], config_path=path,
+                        python=Path(sys.executable), codex=Path("/codex"),
+                        run=FakeRunner([
+                            python_probe_ok(), codex_probe_ok(),
+                            json_result(plugin_listing()),
+                            json_result([owned_mcp()]),
+                        ]),
+                        urlopen=lambda *_args, _body=body, **_kwargs:
+                            BytesResponse(_body),
+                        stdout=output)
+                    # Hook trust is deliberately not machine-readable, but a
+                    # waiting relay-only panel must not add another failure.
+                    self.assertEqual(code, 1)
+                    self.assertIn(expected, output.getvalue())
+                    if status != "ready":
+                        self.assertIn("relay-only use may still be healthy",
+                                      output.getvalue())
 
     def test_disable_and_uninstall_preserve_non_target_state(self):
         setup = load_setup()

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1566,10 +1566,36 @@ def _doctor(
             fixes = True
         else:
             print("PASS Tokenserver", file=stdout)
+            _doctor_panel_lan_contact(interactions, stdout)
             if config.claude_interactions and not _doctor_claude_quota(
                     payload, stdout):
                 fixes = True
     return not fixes
+
+
+def _doctor_panel_lan_contact(interactions: dict, stdout) -> None:
+    """Describe direct panel evidence without misclassifying relay-only use."""
+    panel = interactions.get("panel")
+    if not isinstance(panel, dict):
+        return
+    status = panel.get("status")
+    if status == "ready":
+        route = panel.get("route")
+        suffix = f" via {route}" if isinstance(route, str) else ""
+        print(f"PASS Panel LAN contact: recent confirmed poll{suffix}",
+              file=stdout)
+        return
+    if status == "stale":
+        print("WAIT Panel LAN contact: the last confirmed direct poll is "
+              "stale; relay-only use may still be healthy. If the glass "
+              "shows STALE, use a dedicated power supply and verify current "
+              "discovery-capable firmware", file=stdout)
+        return
+    if status == "waiting":
+        print("WAIT Panel LAN contact: no confirmed direct poll since service "
+              "start; relay-only use may still be healthy. If the glass "
+              "shows STALE, use a dedicated power supply and verify current "
+              "discovery-capable firmware", file=stdout)
 
 
 def _doctor_claude_quota(payload: dict, stdout) -> bool:


### PR DESCRIPTION
## Summary
- surface recent direct panel polling in setup doctor without treating relay-only operation as failure
- teach the versioned VibePulse skill to separate source, LAN, real-client relay, power, and firmware generation
- record the fresh-feed/stale-glass incident and bump the plugin to 0.1.3

## Verification
- .venv/bin/python test/test_vibepulse_codex_plugin.py (123 tests)
- git diff --check
- ESP-IDF firmware build from pre-change current main 10589f4 with mDNS/discovery present in the binary

No firmware was flashed by this PR.