### PR TITLE
Harden VibePulse launchd install and pin firmware dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   recognized private runtime configuration without printing it, and performs
   a real `bootout` + `bootstrap` so launchd cannot retain an old worktree. A
   failed bootstrap restores and reloads the previous service configuration.
+- The LaunchAgent installer now retries only the short, observed post-`bootout`
+  bootstrap race before rolling back; permanent failures remain fail-closed.
+- The ESP-IDF dependency lock now records the exact resolver result used by the
+  verified ESP32-S3 build, keeping flash candidates reproducible and clean.
 - Windows Task Scheduler installations can now persist the optional public
   GitHub source, named Claude/Codex plan labels, and explicit per-provider
   subscription costs. The background service no longer drops the GitHub Stars

--- a/README.md
+++ b/README.md
@@ -491,7 +491,8 @@ host address, firewall, Task Scheduler, startup health, and recovery steps.
    On macOS, validate and install autostart from this durable checkout with
    `python3 tools/vibepulse_macos_service.py validate` followed by the explicit
    `install` command. It atomically rewrites and fully reloads the LaunchAgent,
-   so launchd cannot keep running a deleted PR worktree. Full details:
+   retries launchd's short post-`bootout` race within a fixed bound, and keeps
+   launchd from running a deleted PR worktree. Full details:
    [tools/tokenserver/README.md](tools/tokenserver/README.md).
 
 ## Over-the-air updates

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -24,7 +24,7 @@ dependencies:
       type: service
     version: 0.5.3
   espressif/esp-nn:
-    component_hash: 83eca824ef501eb0d8ac7d090970d8a2997ac369e5edb86366a5943e4368d5a5
+    component_hash: 003bfc494fd3faf73088b62dc5f565a3c61b9e36494d90e8cbf5f238ff2b98fe
     dependencies:
     - name: idf
       require: private
@@ -32,7 +32,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.3.0
+    version: 1.3.1
   espressif/esp-tflite-micro:
     component_hash: 22fc501ab0b1bd39377048d608e6fce0e7b55cd07d244cbf41044b24d9b7db2e
     dependencies:
@@ -419,6 +419,6 @@ direct_dependencies:
 - lvgl/lvgl
 - waveshare/esp32_s3_touch_amoled_2_16
 - waveshare/qmi8658
-manifest_hash: 7c8e739b247b6f6ffabbe5c5fd6538a7bfe816e61652c1f47cedca4b4f2e388b
+manifest_hash: f65dca1bf4d9546bfa1c41f945ff799791474d6e33a0a3c07c89777db9971446
 target: esp32s3
 version: 2.0.0

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -464,6 +464,15 @@ from one clean, durable checkout, run setup doctor, verify live `rev` and
 Historical tracebacks remain in the bounded log, so a post-repair verdict must
 also prove that no new error appeared after the new timestamp.
 
+**2026-08-30 install recurrence:** the first atomic replacement restored the
+old service after `launchctl bootstrap` transiently failed; an identical second
+bootstrap then succeeded. The installer now retries that narrow post-`bootout`
+race on a fixed short schedule and still restores the previous service after
+the bound. During the same physical gate, ESP-IDF refreshed `dependencies.lock`
+from `esp-nn` 1.3.0 to 1.3.1. The candidate was not flashed while the checkout
+was dirty; the resolved version is committed so the source label, lockfile,
+host advertisement, and physical image can identify one exact build.
+
 ## 2026-08-13 · Stale data replayed as breaking news
 
 **What happened:** after a tokenserver outage, the revived agent feed's

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1732,6 +1732,28 @@ class MacosServiceTests(unittest.TestCase):
             if os.name != "nt":
                 self.assertEqual(plist_path.stat().st_mode & 0o777, 0o644)
 
+    def test_install_retries_transient_launchd_bootstrap_failure(self):
+        service = load_macos_service()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plist_path = root / "Library/LaunchAgents/service.plist"
+            runner = FakeRunner([
+                result(), result(returncode=0), result(returncode=5),
+                result(returncode=0)])
+            delays = []
+            with mock.patch.object(
+                    service, "_launchd_domain", return_value="gui/501"):
+                service.install(
+                    repo_root=ROOT, python=Path(sys.executable),
+                    plist_path=plist_path, home=root,
+                    validate_only=False, run=runner, sleep=delays.append)
+
+            bootstraps = [
+                call[0] for call in runner.calls
+                if call[0][:2] == ["launchctl", "bootstrap"]]
+            self.assertEqual(len(bootstraps), 2)
+            self.assertEqual(delays, [service.BOOTSTRAP_RETRY_DELAYS[0]])
+
     def test_failed_bootstrap_restores_previous_service(self):
         service = load_macos_service()
         with tempfile.TemporaryDirectory() as tmp:
@@ -1747,7 +1769,9 @@ class MacosServiceTests(unittest.TestCase):
             }
             plist_path.write_bytes(plistlib.dumps(old))
             runner = FakeRunner([
-                result(), result(returncode=0), result(returncode=5),
+                result(), result(returncode=0),
+                result(returncode=5), result(returncode=5),
+                result(returncode=5),
                 result(returncode=0)])
             with mock.patch.object(
                     service, "_launchd_domain", return_value="gui/501"), \
@@ -1756,9 +1780,9 @@ class MacosServiceTests(unittest.TestCase):
                 service.install(
                     repo_root=ROOT, python=Path(sys.executable),
                     plist_path=plist_path, home=root,
-                    validate_only=False, run=runner)
+                    validate_only=False, run=runner, sleep=lambda _delay: None)
             self.assertEqual(plistlib.loads(plist_path.read_bytes()), old)
-            self.assertEqual(runner.calls[3][0], [
+            self.assertEqual(runner.calls[5][0], [
                 "launchctl", "bootstrap", "gui/501", str(plist_path)])
 
     def test_failed_first_bootstrap_removes_new_service_file(self):
@@ -1767,7 +1791,9 @@ class MacosServiceTests(unittest.TestCase):
             root = Path(tmp)
             plist_path = root / "Library/LaunchAgents/service.plist"
             runner = FakeRunner([
-                result(), result(returncode=0), result(returncode=5)])
+                result(), result(returncode=0),
+                result(returncode=5), result(returncode=5),
+                result(returncode=5)])
             with mock.patch.object(
                     service, "_launchd_domain", return_value="gui/501"), \
                     self.assertRaisesRegex(
@@ -1775,7 +1801,7 @@ class MacosServiceTests(unittest.TestCase):
                 service.install(
                     repo_root=ROOT, python=Path(sys.executable),
                     plist_path=plist_path, home=root,
-                    validate_only=False, run=runner)
+                    validate_only=False, run=runner, sleep=lambda _delay: None)
             self.assertFalse(plist_path.exists())
 
     def test_foreign_or_unrecognized_existing_plist_is_never_overwritten(self):

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -512,9 +512,10 @@ python3 tools/vibepulse_macos_service.py install
 existing runtime arguments and environment values without printing them, and
 uses `bootout` plus `bootstrap` so launchd cannot retain an older cached
 command. It refuses foreign, symlinked, malformed, or unrecognized existing
-plists. If the new service cannot be bootstrapped, the previous plist is
-restored and reloaded automatically. Python 3.11+ and the exact tokenserver
-source must exist before it changes anything.
+plists. A short, bounded retry absorbs launchd's transient post-`bootout`
+bootstrap race. If every new-service attempt fails, the previous plist is
+restored and reloaded with the same bounded retry. Python 3.11+ and the exact
+tokenserver source must exist before it changes anything.
 
 Manual installation remains available for unusual layouts:
 

--- a/tools/vibepulse_macos_service.py
+++ b/tools/vibepulse_macos_service.py
@@ -10,12 +10,14 @@ import plistlib
 import subprocess
 import sys
 import tempfile
+import time
 
 
 LABEL = "se.torget.tokenserver"
 PLIST_NAME = f"{LABEL}.plist"
 PYTHON_PROBE = (
     "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)")
+BOOTSTRAP_RETRY_DELAYS = (0.25, 0.75)
 
 
 class ServiceConfigError(ValueError):
@@ -141,8 +143,23 @@ def _launchd_domain():
     return f"gui/{os.getuid()}"
 
 
+def _bootstrap(domain: str, plist_path: Path, *, run, sleep):
+    """Bound launchd's short post-bootout race without hiding hard failures."""
+    command = ["launchctl", "bootstrap", domain, str(plist_path)]
+    started = run(
+        command, capture_output=True, text=True, timeout=15, check=False)
+    for delay in BOOTSTRAP_RETRY_DELAYS:
+        if started.returncode == 0:
+            break
+        sleep(delay)
+        started = run(
+            command, capture_output=True, text=True, timeout=15,
+            check=False)
+    return started
+
+
 def install(*, repo_root: Path, python: Path, plist_path: Path, home: Path,
-            validate_only=False, run=subprocess.run):
+            validate_only=False, run=subprocess.run, sleep=time.sleep):
     previous_payload = (_read_owned_plist(plist_path)
                         if plist_path.exists() else None)
     extras, environment = _read_preserved(plist_path)
@@ -160,9 +177,8 @@ def install(*, repo_root: Path, python: Path, plist_path: Path, home: Path,
     _atomic_write(plist_path, payload)
     run(["launchctl", "bootout", f"{domain}/{LABEL}"],
         capture_output=True, text=True, timeout=15, check=False)
-    started = run(
-        ["launchctl", "bootstrap", domain, str(plist_path)],
-        capture_output=True, text=True, timeout=15, check=False)
+    started = _bootstrap(
+        domain, plist_path, run=run, sleep=sleep)
     if started.returncode != 0:
         if previous_payload is None:
             try:
@@ -172,9 +188,8 @@ def install(*, repo_root: Path, python: Path, plist_path: Path, home: Path,
             raise ServiceConfigError(
                 "launchctl bootstrap failed; new service file was removed")
         _atomic_write(plist_path, previous_payload)
-        restored = run(
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-            capture_output=True, text=True, timeout=15, check=False)
+        restored = _bootstrap(
+            domain, plist_path, run=run, sleep=sleep)
         if restored.returncode != 0:
             raise ServiceConfigError(
                 "launchctl bootstrap failed and previous service could not "


### PR DESCRIPTION
## Summary
- retry the short observed macOS `launchctl bootstrap` race on a fixed bounded schedule
- keep permanent failures fail-closed and restore the prior LaunchAgent after the retry bound
- commit the exact ESP-IDF dependency resolution used by the verified firmware build
- document the install recurrence and the no-dirty-flash rule

## Evidence
- 134/134 VibePulse plugin and service tests pass locally
- dedicated transient-retry, bounded-failure, rollback, and first-install cleanup tests pass
- `git diff --check` passes
- a full local ESP32-S3 build succeeded before the lock commit with app version `v1.0.0-29-g13cebc3`; the exact final commit build is delegated to CI, then rebuilt incrementally before flash

## Live boundary
The durable Mac service is running merged revision `13cebc3` and validates against its checkout. No firmware from this follow-up branch has been flashed yet.