### PR TITLE
fix(tokenserver): start when either Claude Code or Codex is present

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -15,7 +15,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "4c3dc7ddef6c"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "8cb2f5626d12"
 CONTEXT = (
     "For short, non-secret, single-choice 2–3 option questions or "
     "recommendations, use mcp__vibepulse__ask. Mark at most one option "

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -15,7 +15,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8cb2f5626d12"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "3a65f3d42a5a"
 CONTEXT = (
     "For short, non-secret, single-choice 2–3 option questions or "
     "recommendations, use mcp__vibepulse__ask. Mark at most one option "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- The usage service now starts on a computer that has Codex but not Claude
+  Code. Its readiness check waited — before binding the HTTP port — until
+  `~/.claude/projects` existed, so on a Codex-only machine the port never
+  opened, nothing was advertised over DNS-SD, and the panel found a computer
+  it could not poll. Codex usage is read from `~/.codex/sessions` and does not
+  need that directory at all. Either provider is now enough to start, and the
+  service waits only when neither is present.
 - A successfully parsed ESP32 quota response now clears the transport-level
   `STALE` state synchronously, rather than waiting for a later LVGL timer tick.
   The refresh is deliberately unconditional so display and app bookkeeping

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,30 @@ point at the backlog item.
 
 ---
 
+## 2026-09-04 · A Codex-only computer could never start the service
+
+**What happened:** the tokenserver waited — before binding its HTTP port —
+in a 30-second loop until `~/.claude/projects` existed. On a machine with
+Codex and no Claude Code the port never opened, nothing was advertised over
+DNS-SD, and the panel found a computer it could not poll. **Root cause:**
+the readiness check was written when Claude was the only provider and was
+never revisited when Codex arrived. Codex usage is read from
+`~/.codex/sessions` and needs the Claude directory not at all, so the wait
+was gating on a directory the running configuration did not require. The
+README prerequisite already said "Claude Code and/or Codex" — true on the
+setup page, false in the code. **The rule:** a readiness gate names what
+the service actually needs to serve, not what it needed when it was first
+written; when a second provider is added, every "is the provider here?"
+check is part of that change. And the gate stays a *wait*: a `SystemExit`
+here is what once made launchd respawn every ten seconds and flood the log,
+so the condition changed and the behaviour did not. **Guards:**
+`_any_provider_dir` and `test_provider_gate.py` (Codex-only, Claude-only,
+both, neither, and a file that is not a directory), plus a test that a
+snapshot with no Claude directory is zero rather than an error —
+`Path.glob` on a missing directory yields nothing, which is what makes
+Codex-only a serviceable state and not a half-broken one. **Watch for:** the
+same assumption in anything else keyed to one provider's directory.
+
 ## 2026-09-04 · A rejected request lost its answer on Windows
 
 **What happened:** three `CodexRouteTests` wire tests failed on the Windows

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "4c3dc7ddef6c"
+HOST_SOURCE_FINGERPRINT = "8cb2f5626d12"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8cb2f5626d12"
+HOST_SOURCE_FINGERPRINT = "3a65f3d42a5a"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/tokenserver-suite.txt
+++ b/test/tokenserver-suite.txt
@@ -14,6 +14,7 @@ tools.tokenserver.test_update_prices
 tools.tokenserver.test_codex_command
 tools.tokenserver.test_codex_usage
 tools.tokenserver.test_vibepulse_config
+tools.tokenserver.test_provider_gate
 tools.tokenserver.test_codex_interactions
 tools.tokenserver.test_interactions
 tools.tokenserver.test_interaction_relay

--- a/tools/tokenserver/codex_usage.py
+++ b/tools/tokenserver/codex_usage.py
@@ -56,8 +56,13 @@ else:  # direct execution
 DEFAULT_SESSIONS_DIR: Optional[Path] = None
 
 
-def _default_sessions_dir() -> Path:
+def default_sessions_dir() -> Path:
     """Resolve the sessions directory the same way the Codex CLI does.
+
+    Public because it is the single answer to "where does Codex keep its
+    rollouts" for the whole package: ``tokenserver`` resolves ``CODEX_SESSIONS``
+    through it too, so the readiness gate, the rate-limit scan, agent status and
+    the Max Tracker cannot drift onto a different profile from the month scan.
 
     ``CODEX_HOME`` is commonly set by the desktop app and by managed Windows
     installations.  Falling back unconditionally to ``~/.codex`` makes quota
@@ -182,7 +187,7 @@ def month_value(sessions_dir: Optional[Path] = None,
     genuinely nothing there to price.
     """
     root = (Path(sessions_dir) if sessions_dir is not None
-            else _default_sessions_dir())
+            else default_sessions_dir())
     if not root.is_dir():
         return 0.0, 0, 0
 

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -18,7 +18,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from tools.tokenserver import tokenserver
+from tools.tokenserver import codex_usage, tokenserver
 
 
 class ProviderGateTest(unittest.TestCase):
@@ -61,6 +61,46 @@ class ProviderGateTest(unittest.TestCase):
         self.missing.parent.mkdir(parents=True, exist_ok=True)
         self.missing.write_text("inte en katalog")
         self.assertFalse(self._gate(self.missing, self.missing))
+
+
+class CodexHomeTest(unittest.TestCase):
+    """``CODEX_SESSIONS`` ska följa ``CODEX_HOME``, inte hårdkodat ``~/.codex``.
+
+    Det här är inte ett hypotetiskt fall: ``run-windows-task.ps1`` exporterar
+    ``CODEX_HOME`` innan tjänsten startar, och desktop-appen sätter den. Med
+    en hårdkodad sökväg såg grinden en katalog som inte fanns, väntade för
+    evigt, och porten öppnades aldrig — exakt felet den här ändringen finns
+    för att laga, kvar för den ena konfiguration som är dokumenterat stödd.
+    """
+
+    def test_sessions_dir_follows_codex_home(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir) / "managed-codex-home"
+            (home / "sessions").mkdir(parents=True)
+
+            with mock.patch.dict("os.environ", {"CODEX_HOME": str(home)}):
+                resolved = codex_usage.default_sessions_dir()
+
+            self.assertEqual(resolved, home / "sessions")
+            # Grinden ska öppna på den katalogen, utan någon Claude-katalog.
+            with mock.patch.object(tokenserver, "CODEX_SESSIONS", resolved):
+                self.assertTrue(
+                    tokenserver._any_provider_dir(Path(temp_dir) / "no-claude"))
+
+    def test_tokenserver_resolves_through_the_shared_source(self):
+        """Konstanten ska komma från samma funktion som månadsskanningen.
+
+        Vaktar mot att någon återinför en hårdkodad sökväg: då läser
+        grinden, rate-limits, agentstatus och Max Tracker en annan profil
+        än månadsvärdet, vilket är precis den tysta delningen
+        ``default_sessions_dir`` skrevs för att stänga.
+        """
+        with mock.patch.object(codex_usage, "DEFAULT_SESSIONS_DIR",
+                               Path("/sentinel/sessions")):
+            self.assertEqual(codex_usage.default_sessions_dir(),
+                             Path("/sentinel/sessions"))
+        # Importtidsvärdet ska ha gått genom resolvern, inte förbi den.
+        self.assertEqual(tokenserver.CODEX_SESSIONS.name, "sessions")
 
 
 class CodexOnlySnapshotTest(unittest.TestCase):

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -1,0 +1,105 @@
+"""The startup gate: either provider is enough to serve.
+
+Bakgrunden är ett riktigt fel, inte en hypotes. Starten väntade — före
+bind — i en 30-sekundersloop tills ``~/.claude/projects`` fanns. Codex
+siffror läses ur ``CODEX_SESSIONS`` och behöver den katalogen inte alls,
+så på en Codex-only-maskin öppnades porten aldrig, inget annonserades
+över DNS-SD, och panelen hittade en dator den inte kunde fråga. README:s
+förutsättning säger "Claude Code och/eller Codex"; det var sant på
+setup-sidan och falskt i verkligheten.
+
+Testen nedan håller båda halvorna: att grinden släpper igenom när endera
+katalogen finns, och att servern faktiskt kan servera i det läget — en
+grind som öppnar mot en tjänst som ändå kraschar vore ingen förbättring.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.tokenserver import tokenserver
+
+
+class ProviderGateTest(unittest.TestCase):
+    """``_any_provider_dir``: endera leverantören räcker."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.claude = root / "claude" / "projects"
+        self.codex = root / "codex" / "sessions"
+        self.missing = root / "nowhere"
+
+    def _gate(self, projects_dir, codex_dir):
+        with mock.patch.object(tokenserver, "CODEX_SESSIONS", codex_dir):
+            return tokenserver._any_provider_dir(projects_dir)
+
+    def test_claude_only_passes(self):
+        self.claude.mkdir(parents=True)
+        self.assertTrue(self._gate(self.claude, self.missing))
+
+    def test_codex_only_passes(self):
+        """Kärnfallet: Codex installerat, Claude Code inte alls."""
+        self.codex.mkdir(parents=True)
+        self.assertTrue(self._gate(self.missing, self.codex))
+
+    def test_both_present_passes(self):
+        self.claude.mkdir(parents=True)
+        self.codex.mkdir(parents=True)
+        self.assertTrue(self._gate(self.claude, self.codex))
+
+    def test_neither_present_waits(self):
+        """Väntan finns kvar — den togs bort en gång och gav en tyst
+        launchd-respawn var tionde sekund som fyllde loggen. Grinden ska
+        vara falsk här, inte kasta."""
+        self.assertFalse(self._gate(self.missing, self.missing))
+
+    def test_a_file_is_not_a_directory(self):
+        """En fil med rätt namn räcker inte; ``is_dir`` är hela regeln."""
+        self.missing.parent.mkdir(parents=True, exist_ok=True)
+        self.missing.write_text("inte en katalog")
+        self.assertFalse(self._gate(self.missing, self.missing))
+
+
+class CodexOnlySnapshotTest(unittest.TestCase):
+    """Servern ska servera med en frånvarande Claude-katalog.
+
+    ``Path.glob`` på en katalog som inte finns ger tomt resultat utan att
+    kasta, så Claude-siffrorna blir noll i stället för ett fel. Det är
+    skillnaden mellan "Codex-only är ett fullgott läge" och "vi öppnade
+    porten mot en tjänst som ändå faller på första requesten".
+    """
+
+    def test_snapshot_without_claude_dir_is_zero_not_an_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            absent = Path(temp_dir) / "claude-har-aldrig-körts"
+            self.assertFalse(absent.exists())
+
+            # ``_compute`` mockas medvetet INTE — det är just den som ska
+            # möta den frånvarande katalogen. Bara det som rör nät och CLI
+            # stubbas.
+            with mock.patch.object(tokenserver, "get_limits",
+                                   return_value={}), \
+                    mock.patch.object(tokenserver, "_read_codex_limits",
+                                      return_value={}), \
+                    mock.patch.object(
+                        tokenserver, "_persist_quota_records_async"):
+                tokenserver._last_result = None
+                tokenserver._last_computed = 0.0
+                snapshot = tokenserver.get_snapshot(absent,
+                                                    now_ts=1_800_000_000)
+
+            self.assertIsInstance(snapshot, dict)
+            # Noll rader lästa, inte ett undantag och inte gamla siffror.
+            self.assertEqual(snapshot.get("monthTokens"), 0)
+
+    def tearDown(self):
+        # Cachen är modulglobal: lämna den inte varm åt nästa testfil.
+        tokenserver._last_result = None
+        tokenserver._last_computed = 0.0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -116,12 +116,22 @@ class CodexOnlySnapshotTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             absent = Path(temp_dir) / "claude-har-aldrig-körts"
             self.assertFalse(absent.exists())
+            # ``_compute`` når ``codex_usage.month_value()`` UTAN katalog, som
+            # då faller tillbaka på den riktiga ``~/.codex/sessions``. Utan
+            # den här seamen skannar testet utvecklarens egen rollout-historik
+            # rekursivt: långsamt, beroende av privat maskintillstånd, och det
+            # lämnar codex_usage-cachen varm åt nästa testfil. Peka den på en
+            # tom temporär katalog i stället.
+            codex_root = Path(temp_dir) / "no-codex-here"
+            codex_root.mkdir()
 
             # ``_compute`` mockas medvetet INTE — det är just den som ska
             # möta den frånvarande katalogen. Bara det som rör nät och CLI
             # stubbas.
-            with mock.patch.object(tokenserver, "get_limits",
-                                   return_value={}), \
+            with mock.patch.object(codex_usage, "DEFAULT_SESSIONS_DIR",
+                                   codex_root), \
+                    mock.patch.object(tokenserver, "get_limits",
+                                      return_value={}), \
                     mock.patch.object(tokenserver, "_read_codex_limits",
                                       return_value={}), \
                     mock.patch.object(
@@ -136,9 +146,10 @@ class CodexOnlySnapshotTest(unittest.TestCase):
             self.assertEqual(snapshot.get("monthTokens"), 0)
 
     def tearDown(self):
-        # Cachen är modulglobal: lämna den inte varm åt nästa testfil.
+        # Båda cacharna är modulglobala: lämna dem inte varma åt nästa testfil.
         tokenserver._last_result = None
         tokenserver._last_computed = 0.0
+        codex_usage.reset_cache()
 
 
 if __name__ == "__main__":

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -1341,7 +1341,13 @@ def get_limits():
 # passerat) är siffran meningslös och vi serverar null — aldrig gamla procent
 # som låtsas vara färska.
 
-CODEX_SESSIONS = Path(os.path.expanduser("~/.codex/sessions"))
+# Följer CODEX_HOME, precis som Codex CLI och månadsskanningen: den
+# desktop-appen och managed Windows-installationer sätter den, och
+# run-windows-task.ps1 exporterar den innan tjänsten startar. En hårdkodad
+# ~/.codex här gjorde att beredskapsgrinden, rate-limit-skanningen,
+# agentstatus och Max Tracker läste en annan profil än månadsvärdet — på en
+# Codex-only-maskin med egen CODEX_HOME öppnades porten aldrig.
+CODEX_SESSIONS = codex_usage.default_sessions_dir()
 CODEX_LIMITS_EVERY_S = 30
 CODEX_APP_SERVER_TIMEOUT_S = 15
 CODEX_LIMIT_SCAN_BYTES = 1024 * 1024

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -1348,6 +1348,17 @@ CODEX_LIMIT_SCAN_BYTES = 1024 * 1024
 CODEX_WEEK_MINUTES = 10080
 _codex_limits_lock = threading.Lock()
 _last_codex_limits = None
+
+
+def _any_provider_dir(projects_dir):
+    """Sant när minst en av leverantörernas kataloger finns.
+
+    Starten väntar på detta i stället för på Claude ensam: endera
+    leverantören räcker för att tjänsten ska ha något att servera.
+    """
+    return projects_dir.is_dir() or CODEX_SESSIONS.is_dir()
+
+
 _last_codex_read = 0.0
 _codex_refreshing = False
 
@@ -3298,20 +3309,34 @@ def main():
     Handler.github_monitor = github_monitor
 
     Handler.projects_dir = Path(args.dir)
-    if not Handler.projects_dir.is_dir():
+    if not _any_provider_dir(Handler.projects_dir):
         # Var: SystemExit. Under launchd (KeepAlive utan ThrottleInterval)
         # blev det en tyst respawn var ~10:e sekund som fyllde loggen.
-        # Vänta i stället — katalogen dyker upp när Claude Code körts en
-        # första gång på maskinen.
-        log.warning("hittar inte %s — finns Claude Code på den här "
-                    "maskinen? Väntar på att katalogen dyker upp "
-                    "(Ctrl-C avbryter).", Handler.projects_dir)
+        # Vänta i stället — katalogen dyker upp när agenten körts en första
+        # gång på maskinen.
+        #
+        # Vänta på BÅDA leverantörerna, inte bara Claude. Codex-siffrorna
+        # läses ur CODEX_SESSIONS och behöver inte projects_dir alls, så en
+        # Codex-only-maskin har allt den behöver — väntade vi på Claude där
+        # skulle porten aldrig öppnas, inget annonseras över DNS-SD, och
+        # panelen hitta en dator den inte kan fråga. Förutsättningen i
+        # README är "Claude Code och/eller Codex"; endera räcker.
+        log.warning("hittar varken %s eller %s — finns Claude Code eller "
+                    "Codex på den här maskinen? Väntar på att någon av dem "
+                    "dyker upp (Ctrl-C avbryter).",
+                    Handler.projects_dir, CODEX_SESSIONS)
         try:
-            while not Handler.projects_dir.is_dir():
+            while not _any_provider_dir(Handler.projects_dir):
                 time.sleep(30)
         except KeyboardInterrupt:
             raise SystemExit(1)
-        log.info("%s finns nu — fortsätter starten.", Handler.projects_dir)
+        log.info("hittade en leverantörskatalog — fortsätter starten.")
+    if not Handler.projects_dir.is_dir():
+        # Startar ändå: Path.glob på en katalog som inte finns ger tomt
+        # resultat utan att kasta, så Claude-siffrorna blir noll i stället
+        # för ett fel. Codex-only är ett fullgott läge, inte ett halvtrasigt.
+        log.info("%s saknas — kör vidare utan Claude-siffror (Codex hittad).",
+                 Handler.projects_dir)
 
     # Förstaskanningen är en uppvärmning plus en loggrad — /api/tokens gör om
     # get_snapshot per request ändå, och HTTP-trådarna kör den redan


### PR DESCRIPTION
## Outcome

The usage service now starts on a computer that has Codex but not Claude Code.

Before this, someone who uses only Codex got a service that never opened its port: nothing was advertised over DNS-SD, and the panel found a computer it could not poll. The README prerequisite has said "Claude Code **and/or** Codex" all along — that was true on the setup page and false in the code.

Nothing changes for a machine that has Claude Code, with or without Codex.

## Root cause / rationale

The readiness check waited — *before* binding the HTTP port — in a 30-second loop until `~/.claude/projects` existed. It was written when Claude was the only provider and was never revisited when Codex arrived. Codex usage is read from `~/.codex/sessions` and does not need the Claude directory at all, so the wait was gating on something the running configuration did not require.

Two things were deliberately **not** changed:

- **The wait itself stays.** A `SystemExit` there is what once made launchd respawn the service every ten seconds and flood the log. Only the condition changed; the behaviour did not.
- **A missing Claude directory past the gate is not an error.** `Path.glob` on a directory that does not exist yields nothing rather than raising, so the Claude numbers come out zero. That is what makes Codex-only a serviceable state instead of a half-broken one — a gate that opens onto a service that then falls over would be no improvement.

Found by review on #67, which recorded it as required work in Sequencing step 6 of the onboarding spec. The spec change landed there; this is the code half, kept out of that docs PR on purpose.

## Verification

- [x] Relevant focused tests pass. New `tools/tokenserver/test_provider_gate.py`: Codex-only, Claude-only, both, neither, a file that is not a directory, and a snapshot with no Claude directory returning zero rather than an error. Registered in `test/tokenserver-suite.txt` — the single shared list that exists because two lists once drifted apart and hid a `NameError`.
- [x] Full tokenserver suite: 799 tests, all passing.
- [ ] `./test/run.sh` passes **up to its ESP-IDF step**, which reports `ESP-IDF with bundled Mbed TLS is required for C vectors`. That step fails identically on a clean checkout in this container — it is a missing toolchain here, not a regression — and runs properly on the CI runner. Every host test before it is green.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior. `CHANGELOG.md` under Unreleased → Fixed, and a `docs/lessons.md` entry, which `CLAUDE.md` requires for host-service fixes with a root-cause story.

### Platform claims

- [x] This does not change a platform support claim. The gate is a directory check with no platform-specific behaviour; macOS and Windows hosts are affected identically, and Linux remains unsupported per issue #2.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass. **No real host was exercised** — see remaining risk below.
- [ ] `docs/windows-validation.md` was not run. The change is platform-neutral and touches no Windows-specific path (the installer and scheduled task are untouched), so the Windows runner's suite is the evidence here rather than a manual validation pass.

### Hardware / UI

- [x] No hardware or UI behavior changed. This is host-service code only; no firmware, no simulator frames, no panel involvement.
- [x] No physical flash was requested or performed.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

## Not tested / remaining risk

Stated plainly rather than claimed away:

- **No real Codex-only machine was used.** The tests prove the gate's logic and that a snapshot survives a missing Claude directory; they do not prove the end-to-end experience on a fresh Codex-only install. The honest next check is a real host with `~/.codex/sessions` present and `~/.claude/projects` absent, confirming the port binds, DNS-SD advertises, and the panel polls it.
- **The launchd/scheduled-task restart path is unchanged and untested here.** The wait behaviour is preserved precisely to avoid the old respawn loop, but that loop was a production symptom and this container cannot reproduce it.
- Anything else keyed to one provider's directory could carry the same assumption. I did not audit for that beyond this call site; the `docs/lessons.md` entry flags it under *Watch for*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE)_