### PR TITLE
fix(tokens): mark an absent Claude source instead of reporting zeros

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -15,7 +15,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "3ed0068168fe"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "8ab819afb029"
 CONTEXT = (
     "For short, non-secret, single-choice 2–3 option questions or "
     "recommendations, use mcp__vibepulse__ask. Mark at most one option "

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -15,7 +15,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8ab819afb029"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
 CONTEXT = (
     "For short, non-secret, single-choice 2–3 option questions or "
     "recommendations, use mcp__vibepulse__ask. Mark at most one option "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- `/api/tokens` no longer reports a Codex-only computer's Claude counters as
+  measured zeros. A new additive `claudeSourcePresent` flag says when the
+  Claude directory is absent, so the zeros are not mistaken for a day with no
+  work — by the panel's log, by the simulator, or by a future reader. The
+  percentages already came over as `null` and rendered as dashes; this closes
+  the same invariant at the API and log boundaries. Flashed panels are
+  unaffected: unknown keys are skipped, and an absent flag means present.
 - The usage service now starts on a computer that has Codex but not Claude
   Code. Its readiness check waited — before binding the HTTP port — until
   `~/.claude/projects` existed, so on a Codex-only machine the port never

--- a/components/app_tokens/net.c
+++ b/components/app_tokens/net.c
@@ -121,12 +121,22 @@ static void net_task(void *arg) {
       torget_update_available(
           t.has_ota_available_version ? t.ota_available_version : NULL);
       note_tokens_success();
-      ESP_LOGI(TAG,
-               "hämtning ok (%.2f Mtok idag, %d sessioner; "
-               "stale claude=%d fable=%d codex=%d)",
-               t.day_tokens / 1e6, t.day_sessions,
-               t.claude_week.stale, t.claude_model_week.stale,
-               t.codex_week.stale);
+      /* Utan Claude-källa är volymsiffrorna nollor som inte är mätningar.
+       * Loggen säger det i stället för att skriva ut "0.00 Mtok idag",
+       * som läses som en dag utan arbete. */
+      if (t.claude_source_present) {
+        ESP_LOGI(TAG,
+                 "hämtning ok (%.2f Mtok idag, %d sessioner; "
+                 "stale claude=%d fable=%d codex=%d)",
+                 t.day_tokens / 1e6, t.day_sessions,
+                 t.claude_week.stale, t.claude_model_week.stale,
+                 t.codex_week.stale);
+      } else {
+        ESP_LOGI(TAG,
+                 "hämtning ok (ingen Claude-källa på datorn — volym "
+                 "okänd, inte noll; stale codex=%d)",
+                 t.codex_week.stale);
+      }
     } else {
       ESP_LOGW(TAG, "hämtningen avvisad, värden står kvar");
     }

--- a/components/app_tokens/tokens.h
+++ b/components/app_tokens/tokens.h
@@ -97,6 +97,13 @@ typedef struct {
   int day_sessions;           /* sessioner med aktivitet idag */
   double month_tokens;        /* kalendermånaden */
 
+  /* 0 när tjänsten säger att Claude-katalogen inte finns (Codex-only-
+   * maskin): de fyra räknarna ovan är då nollor, inte mätningar. Saknas
+   * nyckeln — äldre tjänst — antas källan finnas, så beteendet är
+   * oförändrat. Procenttalen behöver ingen flagga: de kommer redan som
+   * null och renderas som streck. */
+  int claude_source_present;
+
   /* taken (null-bara). claude_model_week är veckofönstret för tyngsta
    * modellen (Fable/Opus) — tredje raden i Claudes egen usage-panel. */
   tk_limit claude_session, claude_week, claude_model_week;

--- a/components/app_tokens/tokens_parse.c
+++ b/components/app_tokens/tokens_parse.c
@@ -206,7 +206,7 @@ static bool known_top_level_key(const char *key) {
       "claudeForecastOffsetMin", "codexForecastState",
       "codexForecastPctAtReset", "codexForecastPaceFactor",
       "codexForecastAt", "codexForecastOffsetMin",
-      "otaAvailableVersion", "value",
+      "otaAvailableVersion", "value", "claudeSourcePresent",
   };
   for (size_t index = 0; index < sizeof keys / sizeof keys[0]; index++) {
     if (strcmp(key, keys[index]) == 0) return true;
@@ -390,6 +390,10 @@ bool tk_tokens_parse(const char *json, size_t len, tk_tokens *out) {
 
   bool ok = false;
   tk_tokens t = {0};
+  /* Frånvarande nyckel betyder närvarande källa (äldre tjänst), så
+   * defaulten måste sättas här — {0} skulle annars säga "saknas" om varje
+   * payload som inte nämner den. */
+  t.claude_source_present = 1;
   double v = 0, day = 0, per_hour = 0, sessions = 0, month = 0;
   raw_json_string_scan strings = {0};
   if (!scan_raw_json_strings(json, len, &strings) || strings.nul_key ||
@@ -407,6 +411,18 @@ bool tk_tokens_parse(const char *json, size_t len, tk_tokens *out) {
   if (!num(root, "dayTokensPerHour", &per_hour)) goto done;
   if (!num(root, "daySessions", &sessions)) goto done;
   if (!num(root, "monthTokens", &month)) goto done;
+
+  /* Additiv, valfri: saknas den är källan närvarande (äldre tjänst). Bara
+   * en riktig false stänger av — allt annat än en boolean avvisas hellre
+   * än tolkas, samma stränghet som resten av kontraktet. */
+  {
+    const cJSON *source = cJSON_GetObjectItemCaseSensitive(
+        root, "claudeSourcePresent");
+    if (source) {
+      if (!cJSON_IsBool(source)) goto done;
+      t.claude_source_present = cJSON_IsTrue(source) ? 1 : 0;
+    }
+  }
 
   if (!limit_pair(root, "claudeSessionPct", "claudeSessionResetMin",
                   &t.claude_session)) goto done;

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,30 @@ point at the backlog item.
 
 ---
 
+## 2026-09-04 · The screen was honest, the API was not
+
+**What happened:** once a Codex-only computer could start (entry below), a
+review flagged that `/api/tokens` reported `dayTokens`/`daySessions`/
+`monthTokens` as `0` on a machine with no Claude directory — measured zeros
+where there was no measurement. **Root cause:** two honesty boundaries were
+assumed to be one. The *display* was already correct: the percentages come
+over as `null`, `pct_or_null` turns that into `has_pct = 0`, and the
+presenter renders `–` with USAGE UNAVAILABLE; a value row of `0` is dropped
+entirely. The *wire* was not, and neither was the log, where
+`net.c` printed "0.00 Mtok idag" — indistinguishable from a real day with
+no work. **The rule now:** check the invariant at every boundary a number
+crosses, not just the glass. A field that no view renders today is still
+read by logs, by future consumers, and by whoever is debugging at 2am.
+**Guards:** `claudeSourcePresent` in the payload (additive; unknown keys
+are skipped, so flashed panels are unaffected), defaulting to *present*
+when absent so an older service is unchanged; parser tests for absent,
+true, false and non-boolean in `test_tokens.c`; an end-to-end
+`/api/tokens` test on a Codex-only tree in `test_provider_gate.py`.
+**Watch for:** the counters still cannot be `null` — `tokens_parse.c`
+rejects a missing or null `dayTokens` outright and every flashed panel
+would stop parsing. The flag is the honest signal until that contract can
+change.
+
 ## 2026-09-04 · A Codex-only computer could never start the service
 
 **What happened:** the tokenserver waited — before binding its HTTP port —

--- a/sim/main.c
+++ b/sim/main.c
@@ -341,8 +341,15 @@ static void feed_tokens_file(const char *file) {
   tk_tokens t;
   if (json && tk_tokens_parse(json, len, &t)) {
     tokens_apply(&t);
-    printf("tokens: %.2f Mtok idag, %d sessioner, takt %.2f Mtok/h\n",
-           t.day_tokens / 1e6, t.day_sessions, t.day_tokens_per_hour / 1e6);
+    if (t.claude_source_present) {
+      printf("tokens: %.2f Mtok idag, %d sessioner, takt %.2f Mtok/h\n",
+             t.day_tokens / 1e6, t.day_sessions,
+             t.day_tokens_per_hour / 1e6);
+    } else {
+      /* Codex-only: volymen är okänd, inte noll. Samma ärlighet som
+         net.c, så simulatorn och panelen inte säger olika saker. */
+      printf("tokens: ingen Claude-källa — volym okänd, inte noll\n");
+    }
   } else {
     printf("tokens: fixtur saknas/avvisad, vyn visar streck\n");
   }

--- a/test/test_tokens.c
+++ b/test/test_tokens.c
@@ -632,6 +632,51 @@ int main(void) {
           v.value.state == TK_VALUE_UNAVAILABLE);
   }
 
+  /* claudeSourcePresent: additiv, valfri, och defaulten måste vara
+   * "närvarande". En Codex-only-maskin skickar false och volymsiffrorna
+   * är då nollor som inte är mätningar — flaggan är det enda som skiljer
+   * dem från en riktig nolldag. */
+  {
+    tk_tokens v;
+    char payload[512];
+
+    snprintf(payload, sizeof payload,
+             "{\"v\":2,\"dayTokens\":1,\"dayTokensPerHour\":0,"
+             "\"daySessions\":1,\"monthTokens\":1," BASE_NULLS "}");
+    check("utan claudeSourcePresent parsas", PARSE(payload, &v));
+    check("utan claudeSourcePresent antas källan finnas",
+          v.claude_source_present == 1);
+
+    snprintf(payload, sizeof payload,
+             "{\"v\":2,\"dayTokens\":0,\"dayTokensPerHour\":0,"
+             "\"daySessions\":0,\"monthTokens\":0,"
+             "\"claudeSourcePresent\":false," BASE_NULLS "}");
+    check("claudeSourcePresent false parsas", PARSE(payload, &v));
+    check("claudeSourcePresent false bevaras",
+          v.claude_source_present == 0);
+
+    snprintf(payload, sizeof payload,
+             "{\"v\":2,\"dayTokens\":1,\"dayTokensPerHour\":0,"
+             "\"daySessions\":1,\"monthTokens\":1,"
+             "\"claudeSourcePresent\":true," BASE_NULLS "}");
+    check("claudeSourcePresent true parsas", PARSE(payload, &v));
+    check("claudeSourcePresent true bevaras",
+          v.claude_source_present == 1);
+
+    /* Sträng eller siffra i stället för boolean: avvisa hellre än tolka. */
+    snprintf(payload, sizeof payload,
+             "{\"v\":2,\"dayTokens\":1,\"dayTokensPerHour\":0,"
+             "\"daySessions\":1,\"monthTokens\":1,"
+             "\"claudeSourcePresent\":0," BASE_NULLS "}");
+    check("claudeSourcePresent som siffra avvisas", !PARSE(payload, &v));
+
+    snprintf(payload, sizeof payload,
+             "{\"v\":2,\"dayTokens\":1,\"dayTokensPerHour\":0,"
+             "\"daySessions\":1,\"monthTokens\":1,"
+             "\"claudeSourcePresent\":\"false\"," BASE_NULLS "}");
+    check("claudeSourcePresent som sträng avvisas", !PARSE(payload, &v));
+  }
+
   if (failures == 0) { printf("OK: alla tokens-tester gröna\n"); return 0; }
   printf("%d test föll\n", failures);
   return 1;

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8ab819afb029"
+HOST_SOURCE_FINGERPRINT = "8772b9339e93"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "3ed0068168fe"
+HOST_SOURCE_FINGERPRINT = "8ab819afb029"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -152,5 +152,89 @@ class CodexOnlySnapshotTest(unittest.TestCase):
         codex_usage.reset_cache()
 
 
+class CodexOnlyEndToEndTest(unittest.TestCase):
+    """Hela vägen: en Codex-only-maskin ska ge ett serverbart svar.
+
+    Grindtesten ovan bevisar logiken; det här bevisar att en riktig
+    ``/api/tokens``-förfrågan går igenom ``Handler.do_GET`` med en
+    Claude-katalog som inte finns och en Codex-katalog som gör det.
+
+    Det ersätter inte en riktig Codex-only-dator — ingen har sett porten
+    öppnas, DNS-SD annonsera och panelen fråga på en färsk installation.
+    Det stänger den del som CI faktiskt kan bevisa: att svaret blir 200,
+    att Claudes procenttal är null (streck på skärmen, inte nollor), och
+    att ``claudeSourcePresent`` säger varför volymsiffrorna är noll.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.claude_absent = root / "claude" / "projects"   # skapas aldrig
+        self.codex_sessions = root / "codex" / "sessions"
+        self.codex_sessions.mkdir(parents=True)
+        self.addCleanup(codex_usage.reset_cache)
+
+    def _tokens_payload(self):
+        handler = tokenserver.Handler.__new__(tokenserver.Handler)
+        handler.path = "/api/tokens"
+        handler.projects_dir = self.claude_absent
+        handler.max_tracker_store = None
+        handler.agent_status = mock.Mock()
+        handler._send = mock.Mock()
+
+        with mock.patch.object(codex_usage, "DEFAULT_SESSIONS_DIR",
+                               self.codex_sessions), \
+                mock.patch.object(tokenserver, "CODEX_SESSIONS",
+                                  self.codex_sessions), \
+                mock.patch.object(tokenserver, "get_limits",
+                                  return_value={}), \
+                mock.patch.object(tokenserver, "_read_codex_limits",
+                                  return_value={}), \
+                mock.patch.object(tokenserver,
+                                  "_persist_quota_records_async"):
+            tokenserver._last_result = None
+            tokenserver._last_computed = 0.0
+            handler.do_GET()
+
+        handler._send.assert_called_once()
+        code, payload = handler._send.call_args.args
+        return code, payload
+
+    def test_serves_200_with_no_claude_directory(self):
+        code, payload = self._tokens_payload()
+        self.assertEqual(code, 200)
+        # v=2 är kontraktet tokens_parse.c kräver (`v != 2.0` avvisar).
+        self.assertEqual(payload["v"], 2)
+
+    def test_claude_percentages_are_null_so_the_panel_shows_dashes(self):
+        """Ärlighetsinvarianten där den syns: procenttalen blir null, och
+        ``pct_or_null`` i tokens_parse.c gör null till has_pct=0, vilket
+        presentern renderar som "–" och "USAGE UNAVAILABLE"."""
+        _, payload = self._tokens_payload()
+        for key in ("claudeSessionPct", "claudeWeekPct",
+                    "claudeModelWeekPct"):
+            self.assertIsNone(payload[key], key)
+
+    def test_volume_zeroes_are_marked_as_an_absent_source(self):
+        """De fyra räknarna kan inte bli null utan att äldre paneler slutar
+        parsa, så flaggan bär sanningen i stället."""
+        _, payload = self._tokens_payload()
+        self.assertFalse(payload["claudeSourcePresent"])
+        self.assertEqual(payload["dayTokens"], 0)
+        self.assertEqual(payload["monthTokens"], 0)
+
+    def test_a_present_claude_directory_reports_the_source_as_present(self):
+        """Kontrollen åt andra hållet: flaggan följer katalogen, den är
+        inte hårdkodad till false av testuppsättningen."""
+        self.claude_absent.mkdir(parents=True)
+        _, payload = self._tokens_payload()
+        self.assertTrue(payload["claudeSourcePresent"])
+
+    def tearDown(self):
+        tokenserver._last_result = None
+        tokenserver._last_computed = 0.0
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -13,6 +13,7 @@ katalogen finns, och att servern faktiskt kan servera i det läget — en
 grind som öppnar mot en tjänst som ändå kraschar vore ingen förbättring.
 """
 
+import inspect
 import tempfile
 import unittest
 from pathlib import Path
@@ -234,6 +235,26 @@ class CodexOnlyEndToEndTest(unittest.TestCase):
     def tearDown(self):
         tokenserver._last_result = None
         tokenserver._last_computed = 0.0
+
+
+class WarmupLogHonestyTest(unittest.TestCase):
+    """Starthändelsen ska inte heller skriva ut nollor som mätningar.
+
+    ``_first_scan_warmup`` bor inne i ``main()`` och går inte att kalla
+    isolerat, så vakten läser källan — samma mönster som testet för
+    ``BoundedThreadingHTTPServer`` i test_tokenserver.py. Det räcker för
+    det den ska fånga: att någon lägger tillbaka en ovillkorlig
+    "0 tokens idag"-rad.
+    """
+
+    def test_warmup_log_consults_the_source_flag(self):
+        source = inspect.getsource(tokenserver.main)
+        self.assertIn("claudeSourcePresent", source)
+        # Formateringen av räknarna ska ligga efter flaggkontrollen, inte
+        # före den.
+        flag_at = source.index("claudeSourcePresent")
+        counters_at = source.index("snap['dayTokens']")
+        self.assertLess(flag_at, counters_at)
 
 
 if __name__ == "__main__":

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -649,6 +649,16 @@ def _compute(projects_dir: Path, max_tracker_store=None):
         "dayTokensPerHour": hour_tokens,  # senaste timmen = takt per timme
         "daySessions": len(day_sessions),
         "monthTokens": month_tokens,
+        # Ärlighetsinvarianten, API-sidan: på en Codex-only-maskin finns
+        # ingen Claude-katalog, och de fyra räknarna ovan blir nollor som
+        # inte är mätningar. Procenttalen säger redan sanningen (de blir
+        # null och skärmen visar streck), men räknarna kan inte bli null
+        # utan att äldre paneler slutar parsa payloaden helt
+        # (tokens_parse.c: `if (!num(root, "dayTokens", &day)) goto done;`).
+        # Den här flaggan säger i stället vad nollorna betyder, så ingen
+        # läsare — logg, panel eller framtida konsument — behöver gissa.
+        # Additiv nyckel, samma mönster som "value" nedan.
+        "claudeSourcePresent": projects_dir.is_dir(),
         # Additive key: tokens_parse.c:219 skips unknown top-level keys, so
         # already-flashed screens ignore it instead of failing to parse.
         "value": value_meter.build_payload(

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -3454,6 +3454,14 @@ def main():
             log.exception("förstaskanningen kraschade — /api/tokens värmer "
                           "vid första anropet i stället")
             return
+        # Samma ärlighet som net.c och simulatorn: utan Claude-källa är
+        # nollorna inte mätningar, och "0 tokens idag" i starthändelsen
+        # läses som en dag utan arbete av den som kammar loggarna.
+        if not snap.get("claudeSourcePresent", True):
+            log.info("förstaskanning %.1f s: ingen Claude-källa på den här "
+                     "maskinen — volym okänd, inte noll",
+                     time.monotonic() - t0)
+            return
         log.info("förstaskanning %.1f s: %s tokens idag, %d sessioner, "
                  "%s denna månad",
                  time.monotonic() - t0,


### PR DESCRIPTION
## Outcome

On a Codex-only computer, `/api/tokens` reported `dayTokens`, `daySessions` and `monthTokens` as `0` — measured zeros where nothing was measured. The panel's log printed `0.00 Mtok idag`, which reads as a real day with no work rather than a machine with no Claude Code on it.

An additive `claudeSourcePresent` flag now says when the Claude directory is absent, and the firmware and simulator logs say the volume is unknown rather than printing zeros.

Nothing changes on a machine that has Claude Code, and nothing changes for a panel running older firmware.

## Root cause / rationale

Raised as a P1 on #70 against `AGENTS.md`'s *"aldrig påhittade nollor — utan data visas streck"*.

Investigating it turned up something worth stating plainly, because it changes how big this is: **the display was already honest.** The percentages arrive as `null`, `pct_or_null` turns that into `has_pct = 0`, and the presenter renders `–` with USAGE UNAVAILABLE; a value row of `0` is dropped by `if (!has_value || value_usd <= 0) return 0;`. The three counters are **not rendered anywhere** — they appear only in log lines in `net.c` and `sim/main.c`.

So this was never the large firmware change it first looked like. Two honesty boundaries had been assumed to be one: the glass was right, the wire and the logs were not.

**Why a flag rather than `null`:** `tokens_parse.c:406` reads these with `if (!num(root, "dayTokens", &day)) goto done;`. A missing or null value fails the whole payload, so every flashed panel would stop parsing `/api/tokens` entirely. The counters cannot become null until that contract can change; the flag carries the truth in the meantime. It follows the additive-key precedent already documented beside `value` — unknown top-level keys are skipped, and `known_top_level_key` only guards against duplicates — and an absent key means *present*, so an older service is unchanged.

## Verification

- [x] Relevant focused tests pass. Parser cases in `test_tokens.c` for absent (defaults to present), explicit `true`, explicit `false`, and non-boolean values (a number or string is rejected rather than coerced). New end-to-end test in `test_provider_gate.py` driving a real `/api/tokens` request through `Handler.do_GET` against a Codex-only tree: asserts 200, that all three Claude percentages are `null`, that the flag is false with the counters at zero, and that it flips to true when the directory exists — so it follows the directory rather than being hardcoded by the fixture.
- [x] 813 tokenserver tests and 134 plugin tests pass.
- [ ] `./test/run.sh` passes up to its ESP-IDF step, which fails identically on a clean checkout in this container (missing toolchain, not a regression). Every host test before it is green, and I ran each step after the cutoff individually — all pass.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior: `CHANGELOG.md` under Unreleased → Fixed, and a `docs/lessons.md` entry, which `CLAUDE.md` requires for parser and host-service fixes with a root-cause story.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass. **No panel was flashed and no real host was exercised.**
- [x] No Windows-specific path is touched.

### Hardware / UI

- [x] **No hardware or UI behavior changed, so there are no new 480×480 captures.** `usage_presenter.c` and `usage_screen.c` are untouched; the pixels this could have affected were already correct before the change. Attaching simulator frames here would imply a visual change that does not exist.
- [x] No physical flash was requested or performed.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

## Not tested / remaining risk

- **`sim/main.c` was not compiled here.** The simulator build fetches LVGL over the network, which this container's policy blocks. CI installs SDL2/Ninja/xvfb and runs the gate under a virtual display, so it is compiled and exercised there. The edit is an `if`/`else` around a `printf` on a field the C parser tests already compile against, but I could not prove it locally and am not claiming otherwise.
- **Still no real Codex-only machine.** The new end-to-end test closes the part CI can prove — a real request, a real absent directory, a real response. Nobody has yet watched a fresh Codex-only install bind its port, advertise over DNS-SD, and get polled by a panel.
- The counters remain `0` on the wire rather than `null`, by necessity. Changing that needs a firmware release that can parse a null, and every panel in the field updated first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE)_