### PR TITLE
refactor(key3): extract the button arbitration into pure platform code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,27 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   internal-RAM budget re-measured on the unit, and PAIR belongs to a later
   step.
 
+### Changed
+
+- KEY3's arbitration — which of the glass's owners gets the button on a given
+  tick — moved out of `main/main.c` into a pure `tg_button_arbitrate()` in
+  `platform/`, shared byte-identically by the panel and the simulator. It was
+  110 lines of decisions in the host layer that `sim/main.c` could not reach:
+  the simulator called `torget_settings_open()` directly during static QA, so
+  it was not the authority for the gesture, the escape, the intent handoff or
+  the asynchronous notice close, against `AGENTS.md` on both counts. Both hosts
+  now read inputs and apply outputs and decide nothing. No behaviour changed —
+  the point of the move is that the behaviour is now provable: the eight
+  invariants behind it, each with a real incident, are pinned as a table of
+  host tests rather than by reading source, including the notice close that
+  fires from `maintenance_ui_task()` with no button event to hang a test on.
+  The simulator drives the real gesture through `poll_keys()` (hold K for
+  three seconds), and the composite state where a notice arrives over an open
+  menu is captured at 480x480 for the first time. The consent model is
+  strengthened rather than restated: the arbitration reaches no service at all
+  and has no output that opens the maintenance window, so the only way there
+  remains a finger on the menu's UPDATE row.
+
 ### Fixed
 
 - `/api/tokens` no longer reports a Codex-only computer's Claude counters as

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,29 @@ point at the backlog item.
 
 ---
 
+## 2026-09-05 · The simulator could not reach the decision it was supposed to be the spec for
+
+**What happened:** a review found KEY3's whole arbitration — 110 lines
+deciding, in order, the Wi-Fi setup window's input ownership, the OTA
+window's escape and hold-to-switch, the SETTINGS menu's exclusion,
+foreground and escape, app-next, panic and the menu-open hold — living in
+`tick_cb` in `main/main.c`. `sim/main.c`'s `poll_keys()` could not reach any
+of it; static QA called `torget_settings_open()` directly instead.
+**Root cause:** the chain grew one branch at a time, each of them small and
+each of them obviously belonging next to the GPIO read. Nothing was ever
+"moved into" the host layer, so no single change looked like the violation it
+added up to. **The rule now:** if the simulator cannot drive it, it is not a
+host detail — it is untested UI behaviour wearing a host's clothes. A
+decision that reads only observable state belongs in `platform/` as a pure
+function the moment a second host exists. **Guards:**
+`platform/button_arbitration.c` (pure: no service call, no lock, no clock),
+`test/test_key3_arbitration.c` pinning all eight invariants as a table —
+including the notice close that fires from `maintenance_ui_task()` with no
+button event to hang a test on, which could not be tested at all before;
+`test_wifi_setup_wiring.py` and `test_settings_design.py` now assert neither
+host names a button action. **Watch for:** the next branch. The chain is one
+`if` in a host away from growing back.
+
 ## 2026-09-04 · The screen was honest, the API was not
 
 **What happened:** once a Codex-only computer could start (entry below), a

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,6 +32,7 @@ idf_component_register(
        "../platform/wifi_status_assets.c"
        "../platform/boot_screen.c"
        "../platform/settings_menu.c"
+       "../platform/button_arbitration.c"
   # ".." ger `#include "secrets.h"` (gitignorad, kopieras ur secrets.h.example)
   INCLUDE_DIRS "." ".." "../platform"
   REQUIRES ${TORGET_MAIN_REQUIRES}

--- a/main/main.c
+++ b/main/main.c
@@ -40,6 +40,7 @@
 
 #include "boot_health.h"
 #include "boot_screen.h"
+#include "button_arbitration.h"
 #include "settings_menu.h"
 #include "button_policy.h"
 #include "agent_monitor.h"
@@ -667,11 +668,6 @@ static void tick_cb(lv_timer_t *t) {
   if (s_touch && lv_indev_get_state(s_touch) == LV_INDEV_STATE_PRESSED)
     s_last_touch_us = now;
 
-  /* KEY3 (GPIO18, aktiv låg): kort tryck = nästa app, tre sekunders håll =
-   * OTA-underhållsfönster. Tidsreglerna bor i den värdtestade knappolicyn;
-   * 10 Hz-ticken pollar vidare medan knappen är nere så hållet avfyras
-   * utan släpp. Körs i LVGL-tasken — därför bara atomära tjänsteanrop här,
-   * aldrig torget_ota_ui_set (som tar UI-låset). */
   /* Bootskärmen tas ner av första datalivet — eller ge-upp-taket när
    * nätet aldrig kommer (45 s: två hämtcykler + marginal; bakom står
    * apparnas ärliga NO DATA). Låset är rekursivt, så stage() från
@@ -687,120 +683,60 @@ static void tick_cb(lv_timer_t *t) {
     }
   }
 
+  /* KEY3 (GPIO18, aktiv låg): kort tryck = nästa app, tre sekunders håll =
+   * SETTINGS. Tidsreglerna bor i den värdtestade knappolicyn; 10 Hz-ticken
+   * pollar vidare medan knappen är nere så hållet avfyras utan släpp.
+   * SKILJEDOMEN — vad handlingen betyder givet vem som äger glaset — bor i
+   * platform/button_arbitration.c och delas byte-identiskt med simulatorn.
+   * Här läses bara läget och verkställs svaret; INGA beslut i värdlagret.
+   * Körs i LVGL-tasken — därför bara atomära tjänsteanrop här, aldrig
+   * torget_ota_ui_set (som tar UI-låset). */
   static tg_button_policy key3;
   bool key3_down = gpio_get_level(GPIO_NUM_18) == 0;
-  tg_button_action key3_action = tg_button_update(&key3, key3_down, now);
   if (key3_down)
     s_last_touch_us = now; /* knappkontakt är aktivitet, precis som touch */
-  /* Menyn är en vägvisare, aldrig en konkurrent: så fort ETT RIKTIGT fönster
-   * äger glaset stänger den sig. Det är det som ger fönstren företräde —
-   * inte lagerordningen, som inte betyder något här (både setupfönstret och
-   * OTA-overlayn lyfter sig själva i sina egna set()).
-   *
-   * Två vägar in som ingen knappgren kan fånga, båda utlösta från ANDRA
-   * tasks medan menyn redan står uppe:
-   *   - notisen annonseras av maintenance_ui_task. Utan detta lade den sig
-   *     över en meny som fortfarande hade open=true, och LATER avslöjade
-   *     den bortglömda menyn.
-   *   - setupfönstret öppnar sig SJÄLVT efter 90 s utan adress. Då blev
-   *     owns_input sant, grenen nedan åt knapphändelsen och stängde ett
-   *     fönster som inte syntes, medan menyn låg kvar överst och lovade
-   *     "KEY3 CLOSES" i foten. Det synliga svarade inte, det osynliga dog.
-   *
-   * Därför FÖRE knappkedjan: stängningen ska hinna ske på den tick då
-   * fönstret tar över, så att nästa tryck landar på det man faktiskt ser.
-   *
-   * Ligger inget fönster på glaset hävdar menyn sitt läge överst i stället.
-   * NO NETWORK-sidan ritar om sin nedräkning varje sekund och lyfter sig då,
-   * så en meny som bara lyftes vid öppning begravdes inom en sekund — i
-   * precis det läge där WIFI-raden behövs mest. Gratis när den redan ligger
-   * överst; LVGL returnerar före invalideringen när indexet stämmer. */
-  if (torget_settings_open_p()) {
-    if (torget_ota_ui_notice_visible() || torget_wifi_setup_owns_input() ||
-        torget_ota_service_maintenance_open())
-      torget_settings_close();
-    else {
-      /* Adressen hålls LEVANDE, inte som ögonblicksbilden den var: utan nät
-       * tar setupfönstret inte över förrän efter 90 s, så menyn hann visa en
-       * adress panelen inte längre hade — med UPDATE kvar valbar. Kopian tas
-       * under spinlocket och avdupliceras i menyn, så en oförändrad adress
-       * kostar ingen omritning. */
-      char ip[16];
-      bool have_ip = ip_text_copy(ip, sizeof ip);
-      torget_settings_set_address(have_ip ? ip : NULL);
-      torget_settings_keep_foreground();
-    }
-  }
 
-  if (torget_wifi_setup_owns_input()) {
-    /* Även STARTING äger knappen. AP/skanning kan ta sekunder och under den
-     * tiden får det utlösande släppet aldrig bli appväxling eller panik.
-     * request_close() ignorerar STARTING men stänger OPEN/JOINING/JOINED/
-     * FAILED, så nödutgången finns kvar när fönstret väl kan stängas. */
-    if (key3_action == TG_BUTTON_NEXT_APP || key3_action == TG_BUTTON_PANIC)
-      torget_wifi_setup_request_close();
-  } else if (torget_ota_service_maintenance_open()) {
-    /* While the update window owns the glass, ANY release closes it — a
-     * short tap or the panic-window hold — so the nödutgången never depends
-     * on out-tapping the panic threshold (a real trap found on hardware
-     * 2026-08-16: a ~2 s press panicked instead of closing, leaving the
-     * window stuck). Ten minutes without an escape once made a healthy
-     * device look hung. No panic fires while the window is up.
+  tg_button_inputs key3_in = {
+      .key = tg_button_update(&key3, key3_down, now),
+      .setup_owns_input = torget_wifi_setup_owns_input(),
+      .maintenance_open = torget_ota_service_maintenance_open(),
+      .notice_visible = torget_ota_ui_notice_visible(),
+      .menu_open = torget_settings_open_p(),
+  };
+  tg_button_outputs key3_out;
+  tg_button_arbitrate(&key3_in, &key3_out);
+
+  /* Verkställandet följer skiljedomens ordning: menyns lyft FÖRE dess
+   * stängning, och båda före knappkedjans utdata. */
+  if (key3_out.menu_foreground) {
+    /* Adressen hålls LEVANDE, inte som ögonblicksbilden den var: utan nät tar
+     * setupfönstret inte över förrän efter 90 s, så menyn hann visa en adress
+     * panelen inte längre hade — med UPDATE kvar valbar. Kopian tas under
+     * spinlocket och avdupliceras i menyn, så en oförändrad adress kostar
+     * ingen omritning. */
+    char ip[16];
+    bool have_ip = ip_text_copy(ip, sizeof ip);
+    torget_settings_set_address(have_ip ? ip : NULL);
+    torget_settings_keep_foreground();
+  }
+  if (key3_out.close_menu) torget_settings_close();
+  if (key3_out.close_setup) torget_wifi_setup_request_close();
+  if (key3_out.close_maintenance) torget_ota_service_close_maintenance();
+  if (key3_out.request_setup_open) torget_wifi_setup_request_open();
+  if (key3_out.next_app) torget_app_next();
+  /* Bara ett köinlägg (atomärt), säkert från LVGL-tasken; en avstängd
+   * svarskanal (ingen enhetsnyckel) gör det till en no-op. */
+  if (key3_out.panic) tk_needs_you_send_panic();
+  if (key3_out.open_menu) {
+    /* ABOUT-raderna tas som ögonblicksbild här: LVGL-tasken äger dem, och
+     * inget av värdena kostar mer än en läsning. Utan IP skickas NULL — menyn
+     * tonar då ner UPDATE, för ett fönster utan adress kan ändå aldrig ta emot
+     * en uppladdning.
      *
-     * Ett NYTT fullt 3 s-håll byter fönster: OTA-fönstret stängs och
-     * setupfönstret öppnar. Det är vägen att nå WIFI SETUP på en panel som
-     * HAR nät (håll–håll: först uppdateringsfönstret, sen nätfönstret) —
-     * utan den kunde ett nytt nät bara läras ut när panelen redan var
-     * strandad. Nödutgången är intakt: varje släpp FÖRE tre sekunder
-     * stänger, bara ett medvetet fullbordat håll byter. */
-    if (key3_action == TG_BUTTON_NEXT_APP || key3_action == TG_BUTTON_PANIC) {
-      torget_ota_service_close_maintenance();
-    } else if (key3_action == TG_BUTTON_OPEN_MAINTENANCE) {
-      /* Bara begäran härifrån: setupvaktens window_open äger överlämningen
-       * av port 80 (stänger OTA-fönstret och väntar ut dess httpd-stopp).
-       * Att stänga HÄR hade gjort portbytet till en kapplöpning mellan två
-       * vakter som pollar var 500:e ms. */
-      torget_wifi_setup_request_open();
-    }
-  } else if (torget_settings_open_p()) {
-    /* Menyn ärver fönstrens nödutgång: VARJE släpp stänger den, kort tryck
-     * som mellanhåll. Ett fullbordat håll stänger också — menyn öppnar
-     * aldrig sig själv igen ovanpå sig själv. Ingen panik avfyras medan
-     * menyn är uppe, exakt som med de två fönstren. */
-    if (key3_action != TG_BUTTON_NONE) torget_settings_close();
-  } else if (key3_action == TG_BUTTON_NEXT_APP) {
-    torget_app_next();
-  } else if (key3_action == TG_BUTTON_PANIC) {
-    /* Mellanhåll-och-släpp med stängt fönster: neka allt Needs You parkerat.
-     * Bara ett köinlägg (atomärt), säkert från LVGL-tasken; en avstängd
-     * svarskanal (ingen enhetsnyckel) gör det till en no-op. */
-    tk_needs_you_send_panic();
-  } else if (key3_action == TG_BUTTON_OPEN_MAINTENANCE &&
-             !torget_ota_ui_notice_visible()) {
-    /* UPDATE READY-takeovern äger glaset utan att vara ett öppet
-     * underhållsfönster, så maintenance_open() ovan säger nej och hållet
-     * nådde ända hit. Menyn öppnades då BAKOM notisen: open=true, inget
-     * syntes, och den dök upp senare när notisen gick bort. Takeovern har
-     * sina egna svar (UPDATE-pillret och LATER, med fingret) — hållet gör
-     * ingenting alls medan den syns. Villkoret sitter på just den här
-     * grenen och inte som ett eget block: ett kort tryck och paniken ska
-     * bete sig precis som förut.
-     *
-     * Hållet öppnar SETTINGS i stället för att gissa vilket av två fönster
-     * användaren menade. Samtyckesmodellen är oförändrad: menyn nås bara
-     * från enheten, så fysisk närvaro krävs fortfarande för UPDATE, och
-     * tokenet och tiominutersfönstret är orörda. Skillnaden är att valet
-     * blir synligt i stället för härlett ur om panelen råkar ha IP.
-     *
-     * ABOUT-raderna tas som ögonblicksbild här: LVGL-tasken äger dem, och
-     * inget av värdena kostar mer än en läsning. Utan IP skickas NULL —
-     * menyn tonar då ner UPDATE, för ett fönster utan adress kan ändå
-     * aldrig ta emot en uppladdning.
-     *
-     * s_data_alive skickas INTE med som en "COMPUTER"-rad: flaggan sätts
-     * en gång och aldrig tillbaka, så raden hade sagt FOUND för alltid
-     * efter en enda lyckad hämtning — även med datorn borta, och även när
-     * siffrorna kom via reläet. */
+     * s_data_alive skickas INTE med som en "COMPUTER"-rad: flaggan sätts en
+     * gång och aldrig tillbaka, så raden hade sagt FOUND för alltid efter en
+     * enda lyckad hämtning — även med datorn borta, och även när siffrorna kom
+     * via reläet. */
     const esp_app_desc_t *desc = esp_app_get_description();
     char ip[16];
     bool have_ip = ip_text_copy(ip, sizeof ip);

--- a/platform/button_arbitration.c
+++ b/platform/button_arbitration.c
@@ -1,0 +1,83 @@
+#include "button_arbitration.h"
+
+void tg_button_arbitrate(const tg_button_inputs *in, tg_button_outputs *out) {
+  const tg_button_outputs none = {0};
+  *out = none;
+
+  /* Menyn är en vägvisare, aldrig en konkurrent: så fort ETT RIKTIGT fönster
+   * äger glaset stänger den sig. Det är det som ger fönstren företräde — inte
+   * lagerordningen, som inte betyder något här (både setupfönstret och
+   * OTA-overlayn lyfter sig själva i sina egna set()).
+   *
+   * Två vägar in som ingen knappgren kan fånga, båda utlösta från ANDRA tasks
+   * medan menyn redan står uppe:
+   *   - notisen annonseras av maintenance_ui_task. Utan detta lade den sig
+   *     över en meny som fortfarande hade open=true, och LATER avslöjade den
+   *     bortglömda menyn.
+   *   - setupfönstret öppnar sig SJÄLVT efter 90 s utan adress. Då blev
+   *     owns_input sant, kedjan nedan åt knapphändelsen och stängde ett
+   *     fönster som inte syntes, medan menyn låg kvar överst och lovade
+   *     "KEY3 CLOSES" i foten. Det synliga svarade inte, det osynliga dog. */
+  const bool window_owns_glass =
+      in->notice_visible || in->setup_owns_input || in->maintenance_open;
+
+  /* FÖRE knappkedjan, och det är hela poängen: stängningen ska hinna ske på
+   * den tick då fönstret tar över, så att nästa tryck landar på det man
+   * faktiskt ser. Kedjan nedan läser därför den STÄNGDA menyn, inte den som
+   * stod uppe när ticken började. */
+  bool menu_open = in->menu_open;
+  if (menu_open) {
+    if (window_owns_glass) {
+      out->close_menu = true;
+      menu_open = false;
+    } else {
+      out->menu_foreground = true;
+    }
+  }
+
+  if (in->setup_owns_input) {
+    /* Även STARTING äger knappen. AP/skanning kan ta sekunder och under den
+     * tiden får det utlösande släppet aldrig bli appväxling eller panik.
+     * request_close() ignorerar STARTING men stänger OPEN/JOINING/JOINED/
+     * FAILED, så nödutgången finns kvar när fönstret väl kan stängas. */
+    if (in->key == TG_BUTTON_NEXT_APP || in->key == TG_BUTTON_PANIC)
+      out->close_setup = true;
+  } else if (in->maintenance_open) {
+    /* Medan underhållsfönstret äger glaset stänger VARJE släpp det — ett kort
+     * tryck som panikhållet — så nödutgången aldrig hänger på att hinna
+     * utanför panikfönstret (en riktig fälla, hittad på hårdvara 2026-08-16:
+     * ett ~2 s tryck panikade i stället för att stänga och fönstret satt
+     * kvar). Tio minuter utan nödutgång fick en frisk enhet att se hängd ut.
+     * Ingen panik avfyras medan fönstret är uppe.
+     *
+     * Ett NYTT fullt 3 s-håll byter fönster: setupfönstret BEGÄRS öppnat.
+     * Det är vägen till WIFI SETUP på en panel som HAR nät (håll–håll) —
+     * utan den kunde ett nytt nät bara läras ut när panelen redan var
+     * strandad. Nödutgången är intakt: varje släpp FÖRE tre sekunder
+     * stänger, bara ett medvetet fullbordat håll byter. */
+    if (in->key == TG_BUTTON_NEXT_APP || in->key == TG_BUTTON_PANIC)
+      out->close_maintenance = true;
+    else if (in->key == TG_BUTTON_OPEN_MAINTENANCE)
+      out->request_setup_open = true;
+  } else if (menu_open) {
+    /* Menyn ärver fönstrens nödutgång: VARJE knapphändelse stänger den, kort
+     * tryck som mellanhåll. Ett fullbordat håll stänger också — menyn öppnar
+     * aldrig sig själv igen ovanpå sig själv. Ingen panik avfyras medan menyn
+     * är uppe, exakt som med de två fönstren. */
+    if (in->key != TG_BUTTON_NONE) out->close_menu = true;
+  } else if (in->key == TG_BUTTON_NEXT_APP) {
+    out->next_app = true;
+  } else if (in->key == TG_BUTTON_PANIC) {
+    /* Mellanhåll-och-släpp med stängt fönster: neka allt Needs You parkerat. */
+    out->panic = true;
+  } else if (in->key == TG_BUTTON_OPEN_MAINTENANCE && !in->notice_visible) {
+    /* UPDATE READY-takeovern äger glaset utan att vara ett öppet
+     * underhållsfönster, så maintenance_open ovan säger nej och hållet nådde
+     * ända hit. Menyn öppnades då BAKOM notisen: open=true, inget syntes, och
+     * den dök upp senare när notisen gick bort. Takeovern har sina egna svar
+     * (UPDATE-pillret och LATER, med fingret) — hållet gör ingenting alls
+     * medan den syns. Villkoret sitter på just den HÄR grenen och inte som ett
+     * eget block: ett kort tryck och paniken ska bete sig precis som förut. */
+    out->open_menu = true;
+  }
+}

--- a/platform/button_arbitration.h
+++ b/platform/button_arbitration.h
@@ -1,0 +1,91 @@
+#ifndef TORGET_BUTTON_ARBITRATION_H
+#define TORGET_BUTTON_ARBITRATION_H
+
+#include <stdbool.h>
+
+#include "button_policy.h"
+
+/*
+ * KEY3:s SKILJEDOM — vem av glasets ägare som får knappen den här ticken.
+ *
+ * `tg_button_update` (components/torget_ota/button_policy.c) avgör VAD fingret
+ * gjorde: kort tryck, mellanhåll-och-släpp, eller ett fullbordat tresekunders
+ * håll. Den här filen avgör VAD DET BETYDER just nu, givet vem som äger
+ * glaset: setupfönstret, underhållsfönstret, UPDATE READY-notisen, SETTINGS
+ * — eller ingen.
+ *
+ * Den bodde i `tick_cb` i main/main.c: 110 rader beslut i värdlagret, som
+ * `sim/main.c` inte kunde nå. Simulatorn kallade `torget_settings_open()`
+ * direkt i sin statiska QA och var därför INTE spec för gesten, nödutgången,
+ * avsiktsöverlämningen eller den asynkrona notisstängningen — tvärtemot
+ * AGENTS.md ("Värdlagren är tunna … UI-beteende hör hemma i appen/platform/,
+ * aldrig i main/main.c eller sim/main.c" och "Simulatorn är specen").
+ * Codex P1 på PR #72.
+ *
+ * REN med flit: inga tjänsteanrop, inga lås, ingen tid, inget globalt
+ * tillstånd. In går ett observerbart läge, ut går vad värden ska göra. Båda
+ * värdarna matar samma funktion och verkställer samma svar, och hela tabellen
+ * — inklusive lägen som bara kan uppstå asynkront från andra tasks — låses i
+ * värdtester (test/test_key3_arbitration.c) i stället för att läsas ur källan.
+ *
+ * VARFÖR EN STRUKT UT OCH INTE EN ENUM: två utdata kan gälla samma tick.
+ * Menyn stängs FÖRE knappkedjan när ett fönster tar över glaset, och samma
+ * tick kan knappen dessutom betyda något för fönstret. En ensam enum hade
+ * tvingat fram en prioritering som originalet inte har — och tyst tappat den
+ * andra halvan.
+ */
+
+typedef struct {
+  /* Vad knappolicyn såg. */
+  tg_button_action key;
+  /* Setupfönstret äger knappen — INKLUSIVE STARTING, medan AP:n kommer upp. */
+  bool setup_owns_input;
+  /* Underhållsfönstret (OTA) står öppet. */
+  bool maintenance_open;
+  /* UPDATE READY-takeovern syns. Ett UI-läge, inte ett öppet fönster: den
+   * annonseras av maintenance_ui_task utan någon knapphändelse att hänga
+   * beslutet på, och det är precis det fallet som bara en ren funktion kan
+   * testas på. */
+  bool notice_visible;
+  /* SETTINGS-menyn står uppe. */
+  bool menu_open;
+} tg_button_inputs;
+
+/*
+ * Vad värden ska göra. Varje fält motsvarar exakt ETT anrop hos värden, så
+ * tabelltestet och verkställandet inte kan glida isär. Flera fält kan vara
+ * sanna samtidigt; alla falska betyder "gör ingenting".
+ *
+ * Här finns MED FLIT inget "öppna underhållsfönstret". Fönstret öppnas bara
+ * av ett tryck på UPDATE-raden inne i menyn (settings-avsikten), aldrig av
+ * skiljedomen och aldrig av ett skript. Samtyckesmodellen är därmed inte
+ * längre en gren att läsa rätt utan en utdata som inte existerar.
+ */
+typedef struct {
+  /* torget_settings_close() */
+  bool close_menu;
+  /* Menyn äger glaset den här ticken: uppdatera adressen och lyft den
+   * överst (torget_settings_set_address() + torget_settings_keep_foreground()).
+   * Måste ske VARJE tick — NO NETWORK-sidan ritar om sin nedräkning varje
+   * sekund och lyfter sig då, så en engångslyftning begravs inom en sekund. */
+  bool menu_foreground;
+  /* torget_wifi_setup_request_close() */
+  bool close_setup;
+  /* torget_ota_service_close_maintenance() */
+  bool close_maintenance;
+  /* torget_wifi_setup_request_open() — en BEGÄRAN. Setupvakten äger
+   * överlämningen av port 80; att stänga OTA-fönstret här hade gjort
+   * portbytet till en kapplöpning mellan två vakter som pollar var 500:e ms. */
+  bool request_setup_open;
+  /* torget_settings_open(version, ip) */
+  bool open_menu;
+  /* torget_app_next() */
+  bool next_app;
+  /* tk_needs_you_send_panic() */
+  bool panic;
+} tg_button_outputs;
+
+/* Ren skiljedom. `out` skrivs alltid helt, oavsett `in`. */
+void tg_button_arbitrate(const tg_button_inputs *in, tg_button_outputs *out);
+
+#endif

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(torget-sim
   ../platform/wifi_status_assets.c
   ../platform/boot_screen.c
   ../platform/settings_menu.c
+  ../platform/button_arbitration.c
   ../main/registry.c
   ../components/app_tokens/app.c
   ../components/app_tokens/tokens_parse.c
@@ -92,6 +93,8 @@ add_executable(torget-sim
   ../components/torget_ota/ota_ui.c
   # Wi-Fi-onboardingen: samma delade LVGL-lager som targetet visar.
   ../components/torget_wifi/wifi_slots.c
+  # KEY3:s tidsregler och skiljedom — samma filer som targetet bygger.
+  ../components/torget_ota/button_policy.c
   ../components/torget_wifi/wifi_qr_payload.c
   ../components/torget_wifi/wifi_setup_ui.c
   ../third_party/cjson/cJSON.c

--- a/sim/main.c
+++ b/sim/main.c
@@ -11,6 +11,14 @@
  * fixtur; T matar VibePulse igen; S cyklar agentstatus; M cyklar Max
  * Tracker-fixturerna; L öppnar launchern (långtryck med
  * musen fungerar också — det är enhetens gest).
+ *
+ * K ÄR KEY3, och den är enhetens knapp på riktigt: nivån pollas rått och
+ * tidsreglerna kommer ur den delade knappolicyn, så ett kort tryck byter app,
+ * ett släpp efter 1,5-3 s panikar och ett håll på tre sekunder öppnar
+ * SETTINGS. Släpp före tre sekunder stänger ett öppet fönster i stället —
+ * nödutgången. U och W är fingrar på menyns UPDATE- och WIFI-rader.
+ * Skiljedomen mellan dem alla bor i platform/button_arbitration.c och delas
+ * byte-identiskt med targetet; bänken har ingen egen kopia.
  */
 #include <SDL.h>
 #include <errno.h>
@@ -38,7 +46,9 @@
 #include "vibepulse_recovery.h"
 #include "usage_screen.h"
 #include "wifi_setup_ui.h"
+#include "button_arbitration.h"
 #include "settings_menu.h"
+#include "wifi_slots.h"
 
 /* VibePulse är det här repots app och ligger ALLTID först i registret, så
  * launchern och den obevakade rundan pekar på samma index oavsett vilka
@@ -574,9 +584,123 @@ static void platform_tour_cb(lv_timer_t *t) {
   lv_timer_set_period(t, 500);
 }
 
+/* ---------------------------------------------------- KEY3, som på enheten */
+
+/*
+ * Bänkens "enhet": exakt samma läsning → dom → verkställ som main/main.c:s
+ * tick_cb, mot samma delade platform/button_arbitration.c. Ingen egen kedja
+ * och inga egna beslut — det var just den kopian som gjorde simulatorn till
+ * något annat än specen (Codex P1 på PR #72). Det som skiljer är bara VAD ett
+ * verkställt beslut betyder här: bänken har inga tjänster, så fönstren är
+ * lager och Needs You-kön är en utskrift.
+ *
+ * Håll K i tre sekunder och SETTINGS öppnas — samma gest som på hyllan, med
+ * samma tidsregler ur den värdtestade knappolicyn. U och W är FINGRAR på
+ * UPDATE- respektive WIFI-raden; de går genom torget_settings_click_row(),
+ * vilket är exakt vad touch-callbacken själv gör, inte en QA-bakdörr.
+ */
+static tg_wifi_setup_phase key3_setup_phase = TG_WIFI_PHASE_IDLE;
+static bool key3_maintenance_open;
+/* Vad värden vet om sig själv när menyn öppnas — motsvarigheten till
+ * esp_app_get_description() och den låsta IP-kopian i main.c. */
+static const char *key3_version = "v0.2.1-16-g9f9af53";
+static const char *key3_address = "192.168.1.42";
+
+static void key3_open_setup_window(void) {
+  /* Setupvakten renderar STARTING innan den skannar; fasen ägs redan då, så
+   * det utlösande släppet inte kan bli appväxling. */
+  key3_setup_phase = TG_WIFI_PHASE_STARTING;
+  torget_wifi_ui_set(TG_WIFI_UI_STARTING, NULL, NULL, NULL, 0);
+}
+
+static void key3_close_setup_window(void) {
+  key3_setup_phase = TG_WIFI_PHASE_IDLE;
+  torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
+}
+
+static void key3_open_maintenance_window(void) {
+  key3_maintenance_open = true;
+  torget_ota_ui_set(TG_OTA_UI_OPEN, 0, 600);
+}
+
+static void key3_close_maintenance_window(void) {
+  key3_maintenance_open = false;
+  torget_ota_ui_set(TG_OTA_UI_HIDDEN, 0, 0);
+}
+
+/* En tick av värdlagret. `down` är knappens råa nivå, `now_us` bänkens klocka. */
+static void key3_tick(bool down, int64_t now_us) {
+  static tg_button_policy policy;
+  const tg_button_inputs in = {
+      .key = tg_button_update(&policy, down, now_us),
+      .setup_owns_input = tg_wifi_setup_owns_input(key3_setup_phase),
+      .maintenance_open = key3_maintenance_open,
+      .notice_visible = torget_ota_ui_notice_visible(),
+      .menu_open = torget_settings_open_p(),
+  };
+  tg_button_outputs out;
+  tg_button_arbitrate(&in, &out);
+
+  if (out.menu_foreground) {
+    torget_settings_set_address(key3_address);
+    torget_settings_keep_foreground();
+  }
+  if (out.close_menu) torget_settings_close();
+  if (out.close_setup) key3_close_setup_window();
+  if (out.close_maintenance) key3_close_maintenance_window();
+  if (out.request_setup_open) key3_open_setup_window();
+  if (out.next_app) torget_app_next();
+  if (out.panic) printf("KEY3: panik — Needs You-kön finns bara på enheten\n");
+  if (out.open_menu) torget_settings_open(key3_version, key3_address);
+
+  /* Menyns val, utfört av den som äger fönsterordningen — samma överlämning
+   * som på enheten, och det är den här halvan som poll_keys aldrig kunde nå. */
+  switch (torget_settings_take_intent()) {
+    case TG_SETTINGS_INTENT_OPEN_UPDATE:
+      key3_open_maintenance_window();
+      break;
+    case TG_SETTINGS_INTENT_OPEN_WIFI:
+      key3_open_setup_window();
+      break;
+    default:
+      break;
+  }
+}
+
+/* Statisk QA driver KEY3 genom SAMMA väg som SDL-pollningen: rå nivå och en
+ * egen mikrosekundsklocka in i key3_tick(). Ingen genväg förbi skiljedomen,
+ * och ingen egen kopia av tidsreglerna — hållet mäts av knappolicyn. */
+static int64_t qa_key3_now_us;
+
+static void qa_key3_poll(bool down, int64_t step_us) {
+  qa_key3_now_us += step_us;
+  key3_tick(down, qa_key3_now_us);
+}
+
+/* En tom tick: det är den som lyfter menyn varje gång, och den som bär den
+ * ASYNKRONA stängningen när ett fönster tar över utan knapphändelse. */
+static void qa_key3_idle(void) { qa_key3_poll(false, 100000); }
+
+/* Ett fullbordat tresekundershåll. Hållet avfyras medan fingret ligger kvar;
+ * släppet efteråt sväljs av policyn, precis som på hyllan. */
+static void qa_key3_hold(void) {
+  qa_key3_idle();
+  qa_key3_poll(true, 100000);
+  qa_key3_poll(true, TG_MAINTENANCE_HOLD_US);
+  qa_key3_poll(false, 100000);
+}
+
+/* Ett kort tryck — nödutgången ur menyn och ur fönstren. */
+static void qa_key3_tap(void) {
+  qa_key3_idle();
+  qa_key3_poll(true, 100000);
+  qa_key3_poll(false, 100000);
+}
+
 /* Tangent 1-4: Solelkollen-fixtur. T: mata VibePulse. S: nästa agentläge.
- * L: launchern. [ och ] bläddrar VibePulse-sidor; N byter app (KEY3).
- * M: nästa Max Tracker-fixtur. G: simulera en ny GitHub-stjärna.
+ * L: launchern. [ och ] bläddrar VibePulse-sidor; N byter app (KEY3:s
+ * appväxling utan gest). M: nästa Max Tracker-fixtur. G: simulera en ny
+ * GitHub-stjärna. K är KEY3 självt, U och W fingrar på menyns rader.
  * LVGL:s SDL-drivrutin
  * pumpar eventen, så ren tangentbordspollning räcker — ingen indev-
  * rördragning för ett bänkverktyg. */
@@ -584,6 +708,13 @@ static void poll_keys(lv_timer_t *t) {
   (void)t;
   static bool held[12];
   const Uint8 *ks = SDL_GetKeyboardState(NULL);
+
+  /* KEY3 pollas RÅTT, inte på flank: hållet är en tidsgest och tidsreglerna
+   * bor i knappolicyn, precis som targetets 10 Hz-tick. Det är det som gör
+   * bänken till spec för gesten — håll K i tre sekunder och SETTINGS öppnas,
+   * släpp före tre sekunder och ett öppet fönster stänger i stället. */
+  key3_tick(ks[SDL_SCANCODE_K] != 0, (int64_t)lv_tick_get() * 1000);
+
   const SDL_Scancode keys[12] = { SDL_SCANCODE_1, SDL_SCANCODE_2,
                                   SDL_SCANCODE_3, SDL_SCANCODE_4,
                                   SDL_SCANCODE_T, SDL_SCANCODE_S,
@@ -591,6 +722,20 @@ static void poll_keys(lv_timer_t *t) {
                                   SDL_SCANCODE_LEFTBRACKET,
                                   SDL_SCANCODE_RIGHTBRACKET,
                                   SDL_SCANCODE_M, SDL_SCANCODE_G };
+  /* Fingrar på menyns rader. click_row() är samma väg touch-callbacken tar,
+   * så avsikten uppstår som den gör på glaset — och konsumeras av key3_tick(),
+   * aldrig här. */
+  static bool row_held[2];
+  const SDL_Scancode rows[2] = { SDL_SCANCODE_U, SDL_SCANCODE_W };
+  const tg_settings_row row_of[2] = { TG_SETTINGS_ROW_UPDATE,
+                                      TG_SETTINGS_ROW_WIFI };
+  for (int i = 0; i < 2; i++) {
+    bool down = ks[rows[i]];
+    if (down && !row_held[i] && torget_settings_open_p())
+      torget_settings_click_row(row_of[i]);
+    row_held[i] = down;
+  }
+
   for (int i = 0; i < 12; i++) {
     bool down = ks[keys[i]];
     if (down && !held[i]) {
@@ -1281,39 +1426,60 @@ static int run_vibepulse_static_qa(void) {
    * NO NETWORK i stället för menyn, vilket är hela poängen med att fånga
    * den: menyn får inte bara vara "öppen", den ska synas — och det här är
    * läget där WIFI-raden behövs mest. */
+  /* NO NETWORK är en SÖKNING, inte setupfönstret: den äger inte knappen, så
+   * menyn får ligga kvar ovanpå den. Hållet, lyftet och ramen är alla
+   * skiljedomens — inget öppnas för hand här. */
+  key3_address = NULL;
   torget_wifi_ui_set(TG_WIFI_UI_SEARCHING, "Niclas iPhone", NULL,
                      "NOT SEEN - 2.4 GHZ ONLY", 24);
-  torget_settings_open("v0.2.1-16-g9f9af53", NULL);
+  qa_key3_hold();
   torget_wifi_ui_set(TG_WIFI_UI_SEARCHING, "Niclas iPhone", NULL,
                      "NOT SEEN - 2.4 GHZ ONLY", 23);
-  torget_settings_keep_foreground();
+  qa_key3_idle();
   dump_overlay_frame("settings-over-wifi-searching");
-  torget_settings_close();
+  qa_key3_tap();
   torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
 
+  /* Det sammansatta läget som PR #72 inte kunde fånga ärligt: notisen kommer
+   * MEDAN menyn står uppe. Den annonseras av maintenance_ui_task utan någon
+   * knapphändelse, så det var bara en källäsning — nu är det en tick genom
+   * skiljedomen, och den ska stänga menyn på exakt den tick notisen tar över.
+   * Ramen är beviset: glaset visar UPDATE READY och INGENTING av menyn.
+   * Buggen den låser ute lade notisen ovanpå en meny som fortfarande hade
+   * open=true, och LATER avslöjade den bortglömda menyn. */
+  key3_address = "192.168.1.42";
+  qa_key3_hold();
+  torget_ota_ui_set(TG_OTA_UI_NOTICE, 0, 0);
+  qa_key3_idle();
+  dump_overlay_frame("settings-notice-takes-over");
+  torget_ota_ui_set(TG_OTA_UI_HIDDEN, 0, 0);
+
   /* SETTINGS: vad ett tresekundershåll på KEY3 öppnar. Menyn och ABOUT i
-   * båda tillstånd som skiljer sig materiellt — hittad dator och inte. */
-  torget_settings_open("v0.2.1-16-g9f9af53", "192.168.1.42");
+   * båda tillstånd som skiljer sig materiellt — hittad dator och inte.
+   * ABOUT nås med ett FINGER på raden, samma väg touch-callbacken tar. */
+  qa_key3_hold();
   dump_overlay_frame("settings-menu");
   torget_settings_click_row(TG_SETTINGS_ROW_ABOUT);
   dump_overlay_frame("settings-about-found");
-  torget_settings_close();
+  qa_key3_tap();
   /* Utan adress: UPDATE tonas ner och ABOUT visar streck. Två frames som
    * skiljer sig materiellt från de ovan, inte samma bild med annan text. */
   /* Adressen försvinner MEDAN menyn står uppe. Ögonblicksbilden lämnade
    * kvar den gamla adressen i över en minut med UPDATE valbar; nu tonas
    * raden ner och ABOUT visar streck utan att menyn stängs. Fångad som
    * egen frame för att det är ett tillståndsBYTE, inte en ny öppning. */
-  torget_settings_open("v0.2.1-16-g9f9af53", "192.168.1.42");
-  torget_settings_set_address(NULL);
+  qa_key3_hold();
+  key3_address = NULL; /* nätet försvinner medan menyn står uppe */
+  qa_key3_idle();      /* och det är den tomma ticken som uppdaterar raden */
   dump_overlay_frame("settings-menu-address-lost");
-  torget_settings_close();
+  qa_key3_tap();
 
-  torget_settings_open("v0.2.1-16-g9f9af53", NULL);
+  qa_key3_hold();
   dump_overlay_frame("settings-menu-no-address");
   torget_settings_click_row(TG_SETTINGS_ROW_ABOUT);
   dump_overlay_frame("settings-about-missing");
-  torget_settings_close();
+  qa_key3_tap();
+  key3_address = "192.168.1.42";
 
   /* Value multiple. Every state the parser can hand the page gets its own
    * raster, because the whole design premise is that a wrong figure here is

--- a/sim/main.c
+++ b/sim/main.c
@@ -606,14 +606,51 @@ static bool key3_maintenance_open;
 static const char *key3_version = "v0.2.1-16-g9f9af53";
 static const char *key3_address = "192.168.1.42";
 
+/* Hur länge bänken låtsas att AP:n startar. Enheten tar sekunder här —
+ * skanning, AP, portal — och exakt hur länge spelar ingen roll; att det tar
+ * MER ÄN NOLL gör det, för STARTING sväljer det utlösande släppet med flit
+ * och den regeln går inte att se i ett läge man passerar på noll tid. */
+#define KEY3_SIM_AP_STARTUP_US (1500000LL)
+
+/* Den här tickens klocka, satt överst i key3_tick(). Bänkens motsvarighet
+ * till att vakten och ticken läser samma esp_timer på enheten. */
+static int64_t key3_now_us;
+static int64_t key3_setup_started_us;
+
+static void key3_close_maintenance_window(void) {
+  key3_maintenance_open = false;
+  torget_ota_ui_set(TG_OTA_UI_HIDDEN, 0, 0);
+}
+
 static void key3_open_setup_window(void) {
-  /* Setupvakten renderar STARTING innan den skannar; fasen ägs redan då, så
-   * det utlösande släppet inte kan bli appväxling. */
+  /* Vaktens ordning, spegelvänd: fasen tas FÖRST och STARTING renderas, så
+   * knappen ägs redan medan AP:n kommer upp och det utlösande släppet inte
+   * kan bli appväxling. */
   key3_setup_phase = TG_WIFI_PHASE_STARTING;
+  key3_setup_started_us = key3_now_us;
   torget_wifi_ui_set(TG_WIFI_UI_STARTING, NULL, NULL, NULL, 0);
+  /* Sedan window_open(), och det FÖRSTA den gör är att stänga ett öppet
+   * OTA-fönster: port 80 kan bara ha en ägare, och ett underhållsfönster utan
+   * nät kan ändå inte ta emot en uppladdning, så nätlagret vinner. Utan det
+   * här steget stod bänkens OTA-lager kvar bakom setupfönstret och avslöjades
+   * när setupfönstret stängdes — falskt bevis för precis den överlämning som
+   * är halva poängen med att simulatorn kan nå avsikten alls. */
+  if (key3_maintenance_open) key3_close_maintenance_window();
+}
+
+/* window_open() har återvänt: AP och portal står, fasen blir OPEN. */
+static void key3_setup_window_ready(void) {
+  key3_setup_phase = TG_WIFI_PHASE_OPEN;
+  torget_wifi_ui_set(TG_WIFI_UI_OPEN, "VibePulse-setup", "A1B2C3D4E5F6",
+                     NULL, 583);
 }
 
 static void key3_close_setup_window(void) {
+  /* request_close() ignorerar STARTING — ett fönster som inte står ännu kan
+   * inte stängas. Bänken använder SAMMA rena regel ur wifi_slots.c i stället
+   * för att stänga rakt av, annars hade den visat en nödutgång enheten inte
+   * har och gjort invariant 3 till en illusion. */
+  if (!tg_wifi_setup_can_close(key3_setup_phase)) return;
   key3_setup_phase = TG_WIFI_PHASE_IDLE;
   torget_wifi_ui_set(TG_WIFI_UI_HIDDEN, NULL, NULL, NULL, 0);
 }
@@ -623,14 +660,20 @@ static void key3_open_maintenance_window(void) {
   torget_ota_ui_set(TG_OTA_UI_OPEN, 0, 600);
 }
 
-static void key3_close_maintenance_window(void) {
-  key3_maintenance_open = false;
-  torget_ota_ui_set(TG_OTA_UI_HIDDEN, 0, 0);
-}
-
 /* En tick av värdlagret. `down` är knappens råa nivå, `now_us` bänkens klocka. */
 static void key3_tick(bool down, int64_t now_us) {
   static tg_button_policy policy;
+  key3_now_us = now_us;
+
+  /* Vakten, före avläsningen — den kör i en egen task på enheten, så dess
+   * arbete är redan gjort när ticken läser tillståndet. Dess enda uppgift här
+   * är att föra STARTING vidare till OPEN när AP:n står. Utan den satt bänken
+   * kvar i STARTING för alltid: setupfönstret gick aldrig att NÅ genom gesten,
+   * och dess riktiga nödutgång gick därför aldrig att pröva. */
+  if (key3_setup_phase == TG_WIFI_PHASE_STARTING &&
+      now_us - key3_setup_started_us >= KEY3_SIM_AP_STARTUP_US)
+    key3_setup_window_ready();
+
   const tg_button_inputs in = {
       .key = tg_button_update(&policy, down, now_us),
       .setup_owns_input = tg_wifi_setup_owns_input(key3_setup_phase),
@@ -688,6 +731,12 @@ static void qa_key3_hold(void) {
   qa_key3_poll(true, 100000);
   qa_key3_poll(true, TG_MAINTENANCE_HOLD_US);
   qa_key3_poll(false, 100000);
+}
+
+/* Vänta ut bänkens AP-start, som att stå kvar framför panelen: tomma tickar
+ * tills vakten fört STARTING vidare till OPEN. */
+static void qa_key3_await_setup_window(void) {
+  for (int i = 0; i < 25; i++) qa_key3_idle();
 }
 
 /* Ett kort tryck — nödutgången ur menyn och ur fönstren. */
@@ -1453,6 +1502,33 @@ static int run_vibepulse_static_qa(void) {
   qa_key3_idle();
   dump_overlay_frame("settings-notice-takes-over");
   torget_ota_ui_set(TG_OTA_UI_HIDDEN, 0, 0);
+
+  /* Avsiktsöverlämningen, hela vägen genom gesten — den halva poll_keys()
+   * aldrig kunde nå. Håll öppnar SETTINGS, ett finger på UPDATE ger avsikten,
+   * värden öppnar underhållsfönstret; ett NYTT fullbordat håll därinne BEGÄR
+   * setupfönstret, och det första vaktens window_open() gör är att stänga
+   * OTA-fönstret — port 80 kan bara ha en ägare. Ramen bevisar att den
+   * stängningen skedde: STARTING står ensamt på glaset. Utan den satt
+   * OTA-lagret kvar bakom och avslöjades när setupfönstret stängdes. */
+  qa_key3_hold();
+  torget_settings_click_row(TG_SETTINGS_ROW_UPDATE);
+  qa_key3_idle();
+  qa_key3_hold();
+  /* Invariant 3 i sin egen rätt, i EN ram som bär två fel på en gång: ett
+   * tryck medan STARTING står får inte stänga något (request_close ignorerar
+   * STARTING), och vakten MÅSTE föra fasen vidare till OPEN. Hade trycket
+   * stängt vore glaset tomt här; hade vakten inte fört fasen vidare stod
+   * STARTING kvar. Bara om båda stämmer syns setupfönstret. */
+  qa_key3_tap();
+  qa_key3_await_setup_window();
+  dump_overlay_frame("settings-wifi-handoff-open");
+  /* Nu FÅR det stängas — nödutgången finns kvar när fönstret väl står. Och
+   * DEN HÄR ramen är den som bevisar överlämningen: OTA-fönstret måste vara
+   * borta, inte gömt. Ett setupfönster täcker hela glaset, så ett kvarglömt
+   * OTA-lager syns inte medan det står — det avslöjas först nu, precis som
+   * det gjorde i verkligheten. Glaset ska vara tomt. */
+  qa_key3_tap();
+  dump_overlay_frame("settings-wifi-handoff-closed");
 
   /* SETTINGS: vad ett tresekundershåll på KEY3 öppnar. Menyn och ABOUT i
    * båda tillstånd som skiljer sig materiellt — hittad dator och inte.

--- a/test/run.sh
+++ b/test/run.sh
@@ -218,6 +218,18 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
   -o /tmp/torget-ota-button-policy-test
 /tmp/torget-ota-button-policy-test
 
+# KEY3:s skiljedom: vem av glasets ägare som får knappen. Ren och delad
+# byte-identiskt mellan main/main.c och sim/main.c. wifi_slots.c länkas med
+# för att STARTING-invarianten ska pinnas mot den DELADE fasregeln i stället
+# för mot en bool testet självt satte.
+cc -std=c11 -Wall -Wextra -Werror -O1 \
+  -I../components/torget_ota \
+  ../platform/button_arbitration.c \
+  ../components/torget_wifi/wifi_slots.c \
+  test_key3_arbitration.c \
+  -o /tmp/torget-key3-arbitration-test
+/tmp/torget-key3-arbitration-test
+
 cc -std=c11 -Wall -Wextra -Werror -O1 \
   ../components/torget_ota/notice_policy.c \
   test_ota_notice_policy.c \

--- a/test/test_key3_arbitration.c
+++ b/test/test_key3_arbitration.c
@@ -1,0 +1,320 @@
+/*
+ * KEY3:s skiljedom som en TABELL, inte som en läsning av källan.
+ *
+ * Åtta invarianter, var och en med en riktig incident bakom sig och var och en
+ * pinnad för sig så att en mutation slår i exakt ett test. Sju av dem gick
+ * tidigare bara att kontrollera genom att läsa `tick_cb` i main/main.c — och
+ * en av dem, den asynkrona notisstängningen, gick inte att testa alls: den
+ * utlöses av maintenance_ui_task utan någon knapphändelse att hänga ett test
+ * på. Det är hela skälet till att skiljedomen är en ren funktion.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../platform/button_arbitration.h"
+#include "../components/torget_wifi/wifi_slots.h"
+
+static int failures;
+
+static void check(const char *what, int condition) {
+  if (!condition) {
+    printf("FAIL %s\n", what);
+    failures++;
+  }
+}
+
+static tg_button_outputs arb(tg_button_action key, bool setup_owns_input,
+                             bool maintenance_open, bool notice_visible,
+                             bool menu_open) {
+  const tg_button_inputs in = {
+      .key = key,
+      .setup_owns_input = setup_owns_input,
+      .maintenance_open = maintenance_open,
+      .notice_visible = notice_visible,
+      .menu_open = menu_open,
+  };
+  /* Skräpfyllt före anropet: en utdata som inte skrivs ska synas som ett fel,
+   * inte ärvas från anroparens stack. */
+  tg_button_outputs out;
+  memset(&out, 0xAA, sizeof out);
+  tg_button_arbitrate(&in, &out);
+  return out;
+}
+
+static bool nothing_at_all(tg_button_outputs o) {
+  return !o.close_menu && !o.menu_foreground && !o.close_setup &&
+         !o.close_maintenance && !o.request_setup_open && !o.open_menu &&
+         !o.next_app && !o.panic;
+}
+
+static const tg_button_action ALL_KEYS[4] = {
+    TG_BUTTON_NONE, TG_BUTTON_NEXT_APP, TG_BUTTON_PANIC,
+    TG_BUTTON_OPEN_MAINTENANCE};
+
+/* ------------------------------------------------------------------------
+ * 1. Underhållsfönstret öppnas BARA från enheten.
+ * ---------------------------------------------------------------------- */
+static void test_no_input_ever_opens_the_maintenance_window(void) {
+  /* Den starkaste formen av regeln: skiljedomen har ingen utdata som öppnar
+   * underhållsfönstret. Fönstret nås enbart genom ett tryck på UPDATE-raden
+   * inne i menyn, och menyn kan bara öppnas av ett FULLBORDAT tresekunders
+   * håll på den fysiska knappen. Svepet nedan bevisar det andra ledet: över
+   * alla 64 möjliga lägen är den ENDA vägen till ett fönster — menyn eller
+   * setupbegäran — en OPEN_MAINTENANCE-handling, alltså ett verkligt håll.
+   * Ingen kombination av tillstånd som ett skript eller en annan task kan
+   * sätta (notis, fönster, meny) öppnar någonting av sig själv. */
+  for (int k = 0; k < 4; k++) {
+    for (int bits = 0; bits < 16; bits++) {
+      tg_button_outputs o =
+          arb(ALL_KEYS[k], bits & 1, bits & 2, bits & 4, bits & 8);
+      if (o.open_menu || o.request_setup_open)
+        check("only a completed physical hold can open anything",
+              ALL_KEYS[k] == TG_BUTTON_OPEN_MAINTENANCE);
+    }
+  }
+  /* Och utan knapphandling händer ingenting alls, hur glaset än ser ut. */
+  for (int bits = 0; bits < 16; bits++) {
+    tg_button_outputs o = arb(TG_BUTTON_NONE, bits & 1, bits & 2, bits & 4,
+                              bits & 8);
+    check("an idle tick never opens a window",
+          !o.open_menu && !o.request_setup_open);
+  }
+}
+
+/* ------------------------------------------------------------------------
+ * 2. Varje släpp FÖRE tre sekunder stänger ett öppet fönster.
+ * ---------------------------------------------------------------------- */
+static void test_every_release_before_three_seconds_closes_the_window(void) {
+  /* Hårdvaruläxan 2026-08-16: ett ~2 s tryck panikade i stället för att
+   * stänga, och underhållsfönstret satt kvar i tio minuter. Nödutgången får
+   * aldrig hänga på att hinna UTANFÖR panikfönstret. */
+  tg_button_outputs mid = arb(TG_BUTTON_PANIC, false, true, false, false);
+  check("a ~2 s release closes the maintenance window", mid.close_maintenance);
+  check("a ~2 s release never panics instead", !mid.panic);
+  check("a ~2 s release never switches app", !mid.next_app);
+
+  tg_button_outputs tap = arb(TG_BUTTON_NEXT_APP, false, true, false, false);
+  check("a short tap closes the maintenance window", tap.close_maintenance);
+  check("a short tap never switches app behind the window", !tap.next_app);
+
+  /* Samma nödutgång i setupfönstret. */
+  tg_button_outputs s_mid = arb(TG_BUTTON_PANIC, true, false, false, false);
+  check("a ~2 s release closes the setup window", s_mid.close_setup);
+  check("a ~2 s release in setup never panics", !s_mid.panic);
+  tg_button_outputs s_tap = arb(TG_BUTTON_NEXT_APP, true, false, false, false);
+  check("a short tap closes the setup window", s_tap.close_setup);
+  check("a short tap in setup never switches app", !s_tap.next_app);
+}
+
+/* ------------------------------------------------------------------------
+ * 3. STARTING äger knappen också.
+ * ---------------------------------------------------------------------- */
+static void test_starting_owns_the_button(void) {
+  /* Första ledet, ur den delade fasregeln: STARTING äger indata. Utan den här
+   * raden vore invarianten bara ett påstående om en bool som testet självt
+   * satte. */
+  check("STARTING owns the button",
+        tg_wifi_setup_owns_input(TG_WIFI_PHASE_STARTING));
+  /* Andra ledet: medan AP:n kommer upp får det UTLÖSANDE släppet aldrig bli
+   * appväxling eller panik. request_close() ignorerar STARTING på tjänstens
+   * sida, så nödutgången finns kvar när fönstret väl kan stängas. */
+  for (int k = 1; k < 3; k++) { /* NEXT_APP och PANIC */
+    tg_button_outputs o = arb(ALL_KEYS[k], true, false, false, false);
+    check("no app switch while the AP is coming up", !o.next_app);
+    check("no panic while the AP is coming up", !o.panic);
+    check("the release asks the setup window to close", o.close_setup);
+  }
+  /* Ett fullbordat håll i setupfönstret gör ingenting alls — fönstret är
+   * redan det man ville nå. */
+  tg_button_outputs hold = arb(TG_BUTTON_OPEN_MAINTENANCE, true, false, false,
+                               false);
+  check("a completed hold inside the setup window does nothing",
+        nothing_at_all(hold));
+}
+
+/* ------------------------------------------------------------------------
+ * 4. Ett fullbordat håll i underhållsfönstret BEGÄR setupfönstret.
+ * ---------------------------------------------------------------------- */
+static void test_completed_hold_requests_the_setup_window(void) {
+  tg_button_outputs o =
+      arb(TG_BUTTON_OPEN_MAINTENANCE, false, true, false, false);
+  check("a completed hold asks for the setup window", o.request_setup_open);
+  /* Överlämningen är en BEGÄRAN: setupvaktens window_open äger port 80 och
+   * väntar ut OTA:ns httpd-stopp. Stängde skiljedomen fönstret här blev
+   * portbytet en kapplöpning mellan två vakter som pollar var 500:e ms. */
+  check("the arbitration never closes the maintenance window itself",
+        !o.close_maintenance);
+  check("the handover opens no menu", !o.open_menu);
+}
+
+/* ------------------------------------------------------------------------
+ * 5. Menyn stänger sig så fort ett riktigt fönster äger glaset — FÖRE kedjan.
+ * ---------------------------------------------------------------------- */
+static void test_menu_yields_to_every_window(void) {
+  /* Alla tre ägarna, var för sig, utan någon knapphändelse: det här är den
+   * ASYNKRONA vägen. Notisen annonseras av maintenance_ui_task och
+   * setupfönstret öppnar sig självt efter 90 s utan adress — ingendera har en
+   * knapphändelse att hänga beslutet på, och ingendera gick att testa alls
+   * innan skiljedomen blev en ren funktion. */
+  tg_button_outputs by_notice = arb(TG_BUTTON_NONE, false, false, true, true);
+  check("an arriving notice closes the menu", by_notice.close_menu);
+  check("a menu under a notice is never held foregrounded",
+        !by_notice.menu_foreground);
+
+  tg_button_outputs by_setup = arb(TG_BUTTON_NONE, true, false, false, true);
+  check("a self-opening setup window closes the menu", by_setup.close_menu);
+  check("a menu under the setup window is never held foregrounded",
+        !by_setup.menu_foreground);
+
+  tg_button_outputs by_maint = arb(TG_BUTTON_NONE, false, true, false, true);
+  check("an open maintenance window closes the menu", by_maint.close_menu);
+  check("a menu under the maintenance window is never held foregrounded",
+        !by_maint.menu_foreground);
+
+  /* ORDNINGEN, och det är den som är svår att se: stängningen sker FÖRE
+   * knappkedjan, så kedjan läser den STÄNGDA menyn. Diskriminanten är att
+   * händelsen går vidare till kedjan i stället för att ätas av menygrenen —
+   * det är precis vad "landa på det man faktiskt ser" betyder. */
+  tg_button_outputs ordered =
+      arb(TG_BUTTON_NEXT_APP, false, false, true, true);
+  check("the close lands on the same tick the notice takes over",
+        ordered.close_menu);
+  check("the key chain sees the already-closed menu, not the open one",
+        ordered.next_app);
+
+  /* Samma sak med setupfönstret: menyn stänger OCH kedjan når fönstret. Före
+   * fixen åt menygrenen händelsen och stängde ett fönster som inte syntes. */
+  tg_button_outputs ordered_setup =
+      arb(TG_BUTTON_NEXT_APP, true, false, false, true);
+  check("the menu closes when the setup window takes over",
+        ordered_setup.close_menu);
+  check("and the same release still reaches the visible window",
+        ordered_setup.close_setup);
+}
+
+/* ------------------------------------------------------------------------
+ * 6. Menyn hävdar sitt läge överst VARJE tick när inget fönster äger glaset.
+ * ---------------------------------------------------------------------- */
+static void test_menu_reasserts_foreground_every_tick(void) {
+  /* NO NETWORK-sidan ritar om sin nedräkning varje sekund och lyfter sig då,
+   * så en meny som bara lyftes vid öppning begravdes inom en sekund — i precis
+   * det läge där WIFI-raden behövs mest. Tio tomma tickar i rad måste alla
+   * lyfta; en engångslyftning skulle bara ge den första. */
+  for (int tick = 0; tick < 10; tick++) {
+    tg_button_outputs o = arb(TG_BUTTON_NONE, false, false, false, true);
+    check("every idle tick re-asserts the menu's foreground",
+          o.menu_foreground);
+    check("an idle tick never closes the menu by itself", !o.close_menu);
+  }
+  /* Och aldrig när menyn är stängd — lyftet är inget att göra i tomma luften. */
+  tg_button_outputs closed = arb(TG_BUTTON_NONE, false, false, false, false);
+  check("a closed menu is never foregrounded", !closed.menu_foreground);
+  check("a closed menu on an idle tick does nothing at all",
+        nothing_at_all(closed));
+}
+
+/* ------------------------------------------------------------------------
+ * 7. Hållet gör ingenting alls medan UPDATE READY syns.
+ * ---------------------------------------------------------------------- */
+static void test_hold_does_nothing_under_the_notice(void) {
+  /* Takeovern äger glaset utan att vara ett öppet underhållsfönster, så hållet
+   * nådde ända fram och öppnade menyn BAKOM notisen: open=true, inget syntes,
+   * och den dök upp senare när notisen gick bort. */
+  tg_button_outputs o =
+      arb(TG_BUTTON_OPEN_MAINTENANCE, false, false, true, false);
+  check("a completed hold under the notice does nothing at all",
+        nothing_at_all(o));
+
+  /* Villkoret sitter på just DEN grenen: kort tryck och panik ska bete sig
+   * precis som förut medan notisen syns. Notisen har sina egna svar
+   * (UPDATE-pillret och LATER, med fingret). */
+  tg_button_outputs tap = arb(TG_BUTTON_NEXT_APP, false, false, true, false);
+  check("a short tap still switches app under the notice", tap.next_app);
+  tg_button_outputs mid = arb(TG_BUTTON_PANIC, false, false, true, false);
+  check("a mid-hold release still panics under the notice", mid.panic);
+}
+
+/* ------------------------------------------------------------------------
+ * 8. VARJE KEY3-händelse stänger menyn.
+ * ---------------------------------------------------------------------- */
+static void test_any_key_event_closes_the_menu(void) {
+  /* Menyn ärver fönstrens nödutgång. Svepet täcker alla åtta fönsterlägen så
+   * att ingen kombination kan lämna menyn kvar med en händelse i handen. */
+  for (int k = 1; k < 4; k++) { /* allt utom NONE */
+    for (int bits = 0; bits < 8; bits++) {
+      tg_button_outputs o =
+          arb(ALL_KEYS[k], bits & 1, bits & 2, bits & 4, true);
+      check("any KEY3 event closes the open menu", o.close_menu);
+    }
+  }
+  /* Inga sidoeffekter av att stänga menyn på egen hand: ingen panik och ingen
+   * appväxling bakom den, exakt som med de två fönstren. Och menyn öppnar
+   * aldrig sig själv igen ovanpå sig själv. */
+  for (int k = 1; k < 4; k++) {
+    tg_button_outputs o = arb(ALL_KEYS[k], false, false, false, true);
+    check("no panic fires while the menu is up", !o.panic);
+    check("no app switch happens behind the menu", !o.next_app);
+    check("the menu never reopens on top of itself", !o.open_menu);
+  }
+  /* En tom tick lämnar den däremot i fred. */
+  tg_button_outputs idle = arb(TG_BUTTON_NONE, false, false, false, true);
+  check("an idle tick leaves the menu open", !idle.close_menu);
+}
+
+/* ------------------------------------------------------------------------
+ * Kedjans två vanliga fall, så en mutation som bryter dem inte kan gömma sig
+ * bakom att alla invarianttester råkar handla om fönster.
+ * ---------------------------------------------------------------------- */
+static void test_plain_glass(void) {
+  tg_button_outputs tap = arb(TG_BUTTON_NEXT_APP, false, false, false, false);
+  check("a short tap on plain glass switches app", tap.next_app);
+  check("a short tap on plain glass does nothing else",
+        !tap.panic && !tap.open_menu && !tap.close_menu);
+
+  tg_button_outputs mid = arb(TG_BUTTON_PANIC, false, false, false, false);
+  check("a mid-hold release on plain glass panics", mid.panic);
+  check("a mid-hold release on plain glass does nothing else",
+        !mid.next_app && !mid.open_menu);
+
+  tg_button_outputs hold =
+      arb(TG_BUTTON_OPEN_MAINTENANCE, false, false, false, false);
+  check("a completed hold on plain glass opens the menu", hold.open_menu);
+  check("a completed hold on plain glass does nothing else",
+        !hold.next_app && !hold.panic && !hold.request_setup_open);
+}
+
+static void test_outputs_are_always_fully_written(void) {
+  /* Anroparen får aldrig läsa skräp: varje fält skrivs varje gång. Svepet ser
+   * hela tabellen, så ett tidigt return skulle synas här. */
+  for (int k = 0; k < 4; k++) {
+    for (int bits = 0; bits < 16; bits++) {
+      tg_button_outputs o =
+          arb(ALL_KEYS[k], bits & 1, bits & 2, bits & 4, bits & 8);
+      /* Bool-fälten är antingen 0 eller 1 — aldrig 0xAA. */
+      check("every output field is written",
+            (o.close_menu | o.menu_foreground | o.close_setup |
+             o.close_maintenance | o.request_setup_open | o.open_menu |
+             o.next_app | o.panic) <= 1);
+    }
+  }
+}
+
+int main(void) {
+  test_no_input_ever_opens_the_maintenance_window();
+  test_every_release_before_three_seconds_closes_the_window();
+  test_starting_owns_the_button();
+  test_completed_hold_requests_the_setup_window();
+  test_menu_yields_to_every_window();
+  test_menu_reasserts_foreground_every_tick();
+  test_hold_does_nothing_under_the_notice();
+  test_any_key_event_closes_the_menu();
+  test_plain_glass();
+  test_outputs_are_always_fully_written();
+  if (failures) {
+    printf("%d FAILED\n", failures);
+    return 1;
+  }
+  printf("OK: KEY3:s skiljedom håller alla åtta invarianterna\n");
+  return 0;
+}

--- a/test/test_preview_ui.py
+++ b/test/test_preview_ui.py
@@ -84,6 +84,7 @@ EXPECTED_BMPS = {
     "torget-wifi-failed-password.bmp",
     "torget-settings-menu.bmp",
     "torget-settings-over-wifi-searching.bmp",
+    "torget-settings-notice-takes-over.bmp",
     "torget-settings-menu-no-address.bmp",
     "torget-settings-menu-address-lost.bmp",
     "torget-settings-about-found.bmp",

--- a/test/test_preview_ui.py
+++ b/test/test_preview_ui.py
@@ -85,6 +85,8 @@ EXPECTED_BMPS = {
     "torget-settings-menu.bmp",
     "torget-settings-over-wifi-searching.bmp",
     "torget-settings-notice-takes-over.bmp",
+    "torget-settings-wifi-handoff-closed.bmp",
+    "torget-settings-wifi-handoff-open.bmp",
     "torget-settings-menu-no-address.bmp",
     "torget-settings-menu-address-lost.bmp",
     "torget-settings-about-found.bmp",

--- a/test/test_settings_design.py
+++ b/test/test_settings_design.py
@@ -20,6 +20,12 @@ DESIGN_PATH = ROOT / "design/vibepulse/settings-design.json"
 SOURCE_PATH = ROOT / "platform/settings_menu.c"
 HEADER_PATH = ROOT / "platform/settings_menu.h"
 MAIN_PATH = ROOT / "main/main.c"
+# The KEY3 arbitration left main/main.c for shared, pure platform code, so
+# the structural assertions below follow it there. What each rule DOES is
+# pinned as a table of cases in test/test_key3_arbitration.c; what is checked
+# here is that the rule still lives in one shared place and in the right
+# order, and that the hosts only apply it.
+ARBITRATION_PATH = ROOT / "platform/button_arbitration.c"
 
 CANVAS = 480
 # Clipped corners: content that reaches the edge loses characters.
@@ -198,16 +204,24 @@ class SettingsDesignTests(unittest.TestCase):
           and closed a window nobody could see, while the menu stayed on
           top promising "KEY3 CLOSES". The visible thing did not answer and
           the invisible one died."""
-        main = without_comments(MAIN_PATH.read_text(encoding="utf-8"))
-        block = main.split("if (torget_settings_open_p()) {\n    if (", 1)
+        arb = without_comments(ARBITRATION_PATH.read_text(encoding="utf-8"))
+        owners = arb.split("const bool window_owns_glass =", 1)
+        self.assertEqual(len(owners), 2, "the window-ownership test moved")
+        owners = owners[1].split(";", 1)[0]
+        for owner in ("in->notice_visible",
+                      "in->setup_owns_input",
+                      "in->maintenance_open"):
+            self.assertIn(owner, owners, owner)
+        block = arb.split("if (menu_open) {", 1)
         self.assertEqual(len(block), 2, "the exclusion block moved")
         block = block[1].split("\n  }", 1)[0]
-        for owner in ("torget_ota_ui_notice_visible()",
-                      "torget_wifi_setup_owns_input()",
-                      "torget_ota_service_maintenance_open()"):
-            self.assertIn(owner, block, owner)
-        self.assertIn("torget_settings_close()", block)
-        self.assertIn("torget_settings_keep_foreground()", block)
+        self.assertIn("window_owns_glass", block)
+        self.assertIn("out->close_menu = true;", block)
+        self.assertIn("out->menu_foreground = true;", block)
+        # Both hosts feed the same function; neither keeps a copy of the rule.
+        for host in (MAIN_PATH, ROOT / "sim/main.c"):
+            self.assertIn("tg_button_arbitrate(",
+                          host.read_text(encoding="utf-8"), str(host))
 
     def test_the_address_stays_live_while_the_menu_is_open(self):
         """A snapshot taken at open goes stale, and the honesty rules bite
@@ -230,7 +244,7 @@ class SettingsDesignTests(unittest.TestCase):
         # the menu on top — i.e. exactly when no window owns the glass.
         main = without_comments(MAIN_PATH.read_text(encoding="utf-8"))
         block = main.split("torget_settings_keep_foreground();", 1)[0]
-        block = block.rsplit("else {", 1)[1]
+        block = block.rsplit("if (key3_out.menu_foreground) {", 1)[1]
         self.assertIn("ip_text_copy(ip, sizeof ip)", block)
         self.assertIn("torget_settings_set_address(have_ip ? ip : NULL)", block)
 
@@ -239,11 +253,15 @@ class SettingsDesignTests(unittest.TestCase):
         tick the window takes over, so the next press acts on what the user
         actually sees. Behind the chain instead, that press would still be
         eaten by the setup branch."""
-        main = without_comments(MAIN_PATH.read_text(encoding="utf-8"))
-        exclusion = main.index("if (torget_settings_open_p()) {\n    if (")
-        chain = main.index("if (torget_wifi_setup_owns_input()) {\n")
+        arb = without_comments(ARBITRATION_PATH.read_text(encoding="utf-8"))
+        exclusion = arb.index("if (menu_open) {")
+        chain = arb.index("if (in->setup_owns_input) {")
         self.assertLess(exclusion, chain,
                         "the exclusion must run before the KEY3 chain")
+        # And the chain must read the CLOSED menu, not the input: the local is
+        # cleared by the exclusion, which is what makes the ordering visible.
+        self.assertIn("menu_open = false;", arb)
+        self.assertIn("} else if (menu_open) {", arb)
 
     def test_update_is_refused_without_an_address(self):
         """An OTA window with no address can never receive an upload, so the
@@ -267,25 +285,27 @@ class SettingsDesignTests(unittest.TestCase):
 
     def test_main_keeps_the_consent_model_and_the_escape(self):
         main = MAIN_PATH.read_text(encoding="utf-8")
-        # The hold opens the menu; it must not reach past it into a window.
-        # Two branches carry this action: the hold-hold path inside the OTA
-        # window (unchanged, and still the way to reach Wi-Fi from there) and
-        # the one that opens the menu. Only the latter carries the takeover
-        # guard, so that condition names it unambiguously.
-        block = main.split(
-            "} else if (key3_action == TG_BUTTON_OPEN_MAINTENANCE &&", 1)
+        arb = without_comments(ARBITRATION_PATH.read_text(encoding="utf-8"))
+        # The hold reaches a MENU and nothing else. The arbitration cannot
+        # reach past it even in principle: it has no output that opens the
+        # maintenance window, and it calls no service at all.
+        block = arb.split(
+            "} else if (in->key == TG_BUTTON_OPEN_MAINTENANCE &&", 1)
         self.assertEqual(len(block), 2, "the KEY3 hold branch moved")
         opened = block[1].split("\n  }", 1)[0]
-        self.assertIn("torget_settings_open(", opened)
-        self.assertNotIn("torget_ota_service_open_maintenance", opened)
+        self.assertIn("out->open_menu = true;", opened)
+        self.assertNotIn("torget_ota_service_open_maintenance", arb)
+        # The host applies that output by opening the menu, and the window is
+        # opened in exactly one place: the menu's own intent.
+        self.assertIn("if (key3_out.open_menu) {", main)
+        self.assertEqual(main.count("torget_ota_service_open_maintenance();"), 1)
+        self.assertIn("torget_settings_take_intent()", main)
         # Any release closes the menu: the same escape the two windows have,
         # found on hardware when a ~2 s press once left a window stuck.
-        escape = main.split("} else if (torget_settings_open_p()) {", 1)[1]
+        escape = arb.split("} else if (menu_open) {", 1)[1]
         escape = escape.split("} else if", 1)[0]
-        self.assertIn("torget_settings_close();", escape)
+        self.assertIn("out->close_menu = true;", escape)
         self.assertIn("TG_BUTTON_NONE", escape)
-        # The menu's choice is executed by whoever owns the window order.
-        self.assertIn("torget_settings_take_intent()", main)
 
     def test_the_hold_does_nothing_while_update_ready_owns_the_glass(self):
         """The takeover is a UI state, not an open maintenance window, so
@@ -295,12 +315,12 @@ class SettingsDesignTests(unittest.TestCase):
         glass, and the menu surfacing later when the notice went away. The
         guard belongs on that one branch — a short tap and the panic hold
         must behave exactly as before."""
-        main = without_comments(MAIN_PATH.read_text(encoding="utf-8"))
+        arb = without_comments(ARBITRATION_PATH.read_text(encoding="utf-8"))
         self.assertIn(
-            "key3_action == TG_BUTTON_OPEN_MAINTENANCE &&\n"
-            "             !torget_ota_ui_notice_visible()", main)
+            "in->key == TG_BUTTON_OPEN_MAINTENANCE && !in->notice_visible",
+            arb)
         # Not a block of its own: NEXT_APP and PANIC keep their own branches.
-        self.assertNotIn("} else if (torget_ota_ui_notice_visible()) {", main)
+        self.assertNotIn("} else if (in->notice_visible) {", arb)
 
     def test_the_address_is_copied_under_the_lock_not_aliased(self):
         """Writing the string before publishing the event bit only ordered

--- a/test/test_vibepulse_visual_landmarks.py
+++ b/test/test_vibepulse_visual_landmarks.py
@@ -220,6 +220,8 @@ EXPECTED = {
     "torget-settings-menu.bmp",
     "torget-settings-over-wifi-searching.bmp",
     "torget-settings-notice-takes-over.bmp",
+    "torget-settings-wifi-handoff-closed.bmp",
+    "torget-settings-wifi-handoff-open.bmp",
     "torget-settings-menu-no-address.bmp",
     "torget-settings-menu-address-lost.bmp",
     "torget-settings-about-found.bmp",
@@ -679,6 +681,41 @@ class VibePulseVisualLandmarkTests(unittest.TestCase):
             sum(p == (255, 255, 255)
                 for p in headline.get_flattened_data()), 300,
             "the notice must own the glass it took")
+
+    def test_the_wifi_handoff_leaves_no_ota_window_behind(self):
+        """The intent handoff, driven end to end through the gesture: hold
+        opens SETTINGS, a finger on UPDATE opens the maintenance window, and a
+        second completed hold inside it REQUESTS the setup window. The setup
+        guard's window_open() closes the maintenance window first, because
+        port 80 has one owner.
+
+        Both frames are needed, and the second one is the one that bites. A
+        setup window covers the whole glass, so a forgotten OTA layer is
+        INVISIBLE while it stands — it is revealed only when the setup window
+        closes, which is exactly how it behaved in reality. Asserting on the
+        handoff moment alone would pass with the bug still in."""
+        opened = self.image("torget-settings-wifi-handoff-open.bmp")
+        # Frame one carries two failures at once. It is taken after a tap
+        # DURING STARTING and after the guard has had time to finish:
+        #   * had the tap closed the window, the glass would be empty here
+        #     (request_close ignores STARTING — a window that is not up yet
+        #     cannot be closed, and the bench must not invent an escape the
+        #     device does not have);
+        #   * had the guard never advanced the phase, STARTING would still be
+        #     standing and the setup window would be unreachable by gesture.
+        # Only if both hold does the setup window itself appear.
+        self.assertEqual(opened.tobytes(),
+                         self.image("torget-wifi-setup-open.bmp").tobytes(),
+                         "the gesture must reach the real setup window")
+        self.assertNotEqual(opened.tobytes(),
+                            self.image("torget-wifi-starting.bmp").tobytes(),
+                            "the guard never advanced past STARTING")
+
+        # Frame two: the setup window closed. Nothing may be left underneath.
+        closed = self.image("torget-settings-wifi-handoff-closed.bmp")
+        self.assertEqual(
+            set(closed.get_flattened_data()), {(0, 0, 0)},
+            "a stale window was revealed when the setup window closed")
 
     def test_losing_the_address_remutes_update_without_closing(self):
         """The address is live, not a snapshot. When Wi-Fi drops while the

--- a/test/test_vibepulse_visual_landmarks.py
+++ b/test/test_vibepulse_visual_landmarks.py
@@ -219,6 +219,7 @@ EXPECTED = {
     "torget-wifi-failed-password.bmp",
     "torget-settings-menu.bmp",
     "torget-settings-over-wifi-searching.bmp",
+    "torget-settings-notice-takes-over.bmp",
     "torget-settings-menu-no-address.bmp",
     "torget-settings-menu-address-lost.bmp",
     "torget-settings-about-found.bmp",
@@ -642,6 +643,42 @@ class VibePulseVisualLandmarkTests(unittest.TestCase):
             self.assertTrue(
                 all(p == (0, 0, 0) for p in column.get_flattened_data()),
                 "NO NETWORK's wide headline is showing through")
+
+    def test_the_notice_takes_the_glass_from_an_open_menu(self):
+        """The composite this repository could not honestly capture before the
+        arbitration became a callable function: the UPDATE READY notice is
+        announced by maintenance_ui_task, with no button event to hang a test
+        on, WHILE the menu is up. The frame is taken after one arbitration
+        tick, and the claim it proves is an absence — the menu must be GONE,
+        not layered underneath. The bug it locks out put the notice over a menu
+        that still held open=true, and LATER revealed the forgotten menu."""
+        composite = self.image("torget-settings-notice-takes-over.bmp")
+        notice = self.image("torget-ota-ring-notice.bmp")
+        # Pixel-identical to the notice that never had a menu behind it: the
+        # menu left no trace at all, on any layer.
+        self.assertEqual(composite.tobytes(), notice.tobytes(),
+                         "the menu must be gone, not hidden behind the notice")
+        # Independent of that equality, so it cannot pass by both frames being
+        # blank: the menu's "KEY3 CLOSES" footer sits in a band the notice
+        # leaves entirely black, so it is the one piece of menu ink no part of
+        # the takeover can imitate. (The row outlines cannot serve here — the
+        # notice's own LATER pill is drawn in the same muted colour.)
+        footer = composite.crop((100, 440, 380, 478))
+        self.assertEqual(
+            sum(p != (0, 0, 0) for p in footer.get_flattened_data()), 0,
+            "the menu's KEY3 CLOSES footer is still on the glass")
+        self.assertGreater(
+            sum(p != (0, 0, 0) for p in
+                self.image("torget-settings-menu.bmp")
+                    .crop((100, 440, 380, 478)).get_flattened_data()), 500,
+            "the footer band must actually carry menu ink, or it proves nothing")
+        # And the notice itself is really there — UPDATE READY is a wide white
+        # headline, so this frame is not simply an empty screen.
+        headline = composite.crop((34, 24, 446, 110))
+        self.assertGreater(
+            sum(p == (255, 255, 255)
+                for p in headline.get_flattened_data()), 300,
+            "the notice must own the glass it took")
 
     def test_losing_the_address_remutes_update_without_closing(self):
         """The address is live, not a snapshot. When Wi-Fi drops while the

--- a/test/test_wifi_setup_wiring.py
+++ b/test/test_wifi_setup_wiring.py
@@ -56,31 +56,67 @@ assert len(expected) >= 8, "a derived AP password below 8 chars cannot be a WPA2
 
 # --- The consent model ------------------------------------------------------
 # docs/ota.md promises the OTA maintenance window opens ONLY from the device.
-# The hold now opens SETTINGS instead of deriving the window from network
-# state, so the assertion moved with it — but the promise it protects did
-# not. What must stay true: the hold reaches a menu and nothing else, the
-# window is opened only by acting on that menu's intent, and a panel with no
-# address is never offered an update it could not receive.
-assert "torget_wifi_setup_request_open()" in main_c
-hold_branch = main_c.split(
-    "} else if (key3_action == TG_BUTTON_OPEN_MAINTENANCE &&", 1)
-assert len(hold_branch) == 2, "the KEY3 hold branch that opens SETTINGS moved"
-hold_branch = hold_branch[1].split("\n  }", 1)[0]
-assert "torget_settings_open(" in hold_branch, (
-    "the KEY3 hold must open SETTINGS"
+# The decision chain moved out of main/main.c into the pure, shared
+# platform/button_arbitration.c — so the assertions moved with the mechanism
+# again, and got stricter, because the arbitration can now be checked for what
+# it CANNOT do rather than for the shape of an if/else.
+arb_c = (root / "platform/button_arbitration.c").read_text(encoding="utf-8")
+arb_h = (root / "platform/button_arbitration.h").read_text(encoding="utf-8")
+
+# Purity is the guarantee, not a comment about one: the arbitration reaches no
+# service at all. A decision that cannot call anything cannot be tricked into
+# opening a window, and both hosts feed the same function.
+for forbidden in ("torget_ota_service", "torget_wifi_setup_request",
+                  "torget_settings_", "torget_app_next", "tk_needs_you"):
+    assert forbidden not in arb_c, (
+        f"the arbitration must stay pure; it calls {forbidden}"
+    )
+# There is no output that opens the maintenance window. The window is reachable
+# only through the menu's UPDATE row, which needs a finger on the glass.
+assert "open_maintenance" not in arb_h, (
+    "the arbitration must expose no output that opens the maintenance window"
 )
-assert "torget_ota_service_open_maintenance" not in hold_branch, (
+assert "request_setup_open" in arb_h and "open_menu" in arb_h
+
+# Neither host decides anything: they read inputs and apply outputs. If a host
+# names a button ACTION it is deciding again, which is the violation this whole
+# module exists to end (AGENTS.md: "UI-beteende hör hemma i appen/platform/,
+# aldrig i main/main.c eller sim/main.c").
+sim_c = (root / "sim/main.c").read_text(encoding="utf-8")
+for host_name, host in (("main/main.c", main_c), ("sim/main.c", sim_c)):
+    assert "tg_button_arbitrate(" in host, (
+        f"{host_name} must route KEY3 through the shared arbitration"
+    )
+    assert "TG_BUTTON_" not in host, (
+        f"{host_name} must not branch on button actions; that is a decision"
+    )
+
+# The hold reaches a menu and nothing else. main.c applies open_menu; the OTA
+# window is opened in exactly one place, and only from the menu's intent.
+hold_apply = main_c.split("if (key3_out.open_menu) {", 1)
+assert len(hold_apply) == 2, "the KEY3 hold must apply the arbitration's open_menu"
+hold_apply = hold_apply[1].split("\n  }", 1)[0]
+assert "torget_settings_open(" in hold_apply, "the KEY3 hold must open SETTINGS"
+assert "torget_ota_service_open_maintenance" not in hold_apply, (
     "the hold must not reach past the menu into the OTA window"
+)
+assert main_c.count("torget_ota_service_open_maintenance();") == 1, (
+    "the maintenance window may be opened from exactly one place"
+)
+intent_switch = main_c.split("switch (torget_settings_take_intent())", 1)
+assert len(intent_switch) == 2, "the settings intent switch moved"
+assert "torget_ota_service_open_maintenance();" in intent_switch[1].split("\n  }", 1)[0], (
+    "that one place must be the menu's UPDATE intent"
 )
 # The no-IP protection survives as a menu that cannot offer UPDATE: main.c
 # passes NULL for the address, and the menu refuses the row on that.
-assert re.search(r"have_ip\s*\?\s*ip\s*:\s*NULL", hold_branch), (
+assert re.search(r"have_ip\s*\?\s*ip\s*:\s*NULL", hold_apply), (
     "a panel without an address must be told so, not handed a stale one"
 )
 # ...and the address is COPIED under the spinlock, never read in place: the
 # string is rewritten by the event loop on a renewed lease or a changed
 # address, on another core, with no disconnect in between.
-assert "ip_text_copy(ip, sizeof ip)" in hold_branch, (
+assert "ip_text_copy(ip, sizeof ip)" in hold_apply, (
     "the menu must take its own copy of the address, not alias the writer's"
 )
 settings_c = (root / "platform/settings_menu.c").read_text(encoding="utf-8")
@@ -89,20 +125,21 @@ assert "if (!ui.ip[0]) break;" in settings_c, (
 )
 
 # The double hold: a second full hold while the OTA window is open must
-# REQUEST the setup window, never close-and-open from the LVGL task — the
-# port-80 handover belongs to the setup guard's window_open().  Two request
-# sites total: the no-IP route and the switch route.
+# REQUEST the setup window, never close-and-open — the port-80 handover belongs
+# to the setup guard's window_open().  Two request sites in main.c: the
+# arbitration's request_setup_open and the menu's WIFI intent.
 assert main_c.count("torget_wifi_setup_request_open();") == 2, (
-    "expected exactly the no-IP route and the hold-again switch route"
+    "expected exactly the arbitration's request and the menu's WIFI intent"
 )
-maintenance_branch = main_c.split("torget_ota_service_maintenance_open()) {")[1]
-# Skär vid nästa YTTRE gren (appväxlaren) — den inre else-if-kedjan för
-# knapphändelserna hör till branchen och får inte klippa bort växlingsvägen.
-maintenance_branch = maintenance_branch.split("torget_app_next()")[0]
-assert "torget_wifi_setup_request_open();" in maintenance_branch, (
+maintenance_branch = arb_c.split("} else if (in->maintenance_open) {")[1]
+maintenance_branch = maintenance_branch.split("} else if (menu_open) {")[0]
+assert "out->request_setup_open = true;" in maintenance_branch, (
     "the hold-again switch must live inside the maintenance-open branch"
 )
-assert "torget_ota_service_close_maintenance();\n      torget_wifi_setup_request_open" not in main_c, (
+# The switch arm itself must produce ONLY the request: split at the hold arm
+# and assert the close is not part of it.
+switch_arm = maintenance_branch.split("TG_BUTTON_OPEN_MAINTENANCE)", 1)[1]
+assert "close_maintenance" not in switch_arm, (
     "the LVGL task must not close the OTA window itself when switching"
 )
 
@@ -137,10 +174,10 @@ assert 0 <= starting_render < slow_open, (
     "STARTING must be rendered before scanning, APSTA and portal startup"
 )
 
-ownership_branch = main_c.find("if (torget_wifi_setup_owns_input())")
-ota_branch = main_c.find("else if (torget_ota_service_maintenance_open())")
-app_switch = main_c.find("torget_app_next();", ota_branch)
-panic = main_c.find("tk_needs_you_send_panic();", ota_branch)
+ownership_branch = arb_c.find("if (in->setup_owns_input) {")
+ota_branch = arb_c.find("} else if (in->maintenance_open) {")
+app_switch = arb_c.find("out->next_app = true;", ota_branch)
+panic = arb_c.find("out->panic = true;", ota_branch)
 assert 0 <= ownership_branch < ota_branch < app_switch < panic, (
     "setup input ownership must be checked before OTA, app switching and panic"
 )

--- a/tools/preview-ui.sh
+++ b/tools/preview-ui.sh
@@ -152,6 +152,8 @@ expected_names = {
     "torget-settings-menu.bmp",
     "torget-settings-over-wifi-searching.bmp",
     "torget-settings-notice-takes-over.bmp",
+    "torget-settings-wifi-handoff-closed.bmp",
+    "torget-settings-wifi-handoff-open.bmp",
     "torget-settings-menu-no-address.bmp",
     "torget-settings-menu-address-lost.bmp",
     "torget-settings-about-found.bmp",

--- a/tools/preview-ui.sh
+++ b/tools/preview-ui.sh
@@ -151,6 +151,7 @@ expected_names = {
     "torget-wifi-failed-password.bmp",
     "torget-settings-menu.bmp",
     "torget-settings-over-wifi-searching.bmp",
+    "torget-settings-notice-takes-over.bmp",
     "torget-settings-menu-no-address.bmp",
     "torget-settings-menu-address-lost.bmp",
     "torget-settings-about-found.bmp",


### PR DESCRIPTION
## Outcome

Nothing changes for the user. KEY3's arbitration — which of the glass's owners gets the button on a given tick — moved out of `main/main.c` into a pure `tg_button_arbitrate()` in `platform/`, shared byte-identically by the panel and the simulator.

```
                     ┌─ platform/button_arbitration.c ─┐
main/main.c ────────▶│  observable state in            │────▶ outputs applied
sim/main.c  ────────▶│  no service call, no lock       │      by each host
                     └─────────────────────────────────┘
```

**Please read the base-branch note first.** This is stacked on #72, not on `main`.

## ⚠️ Base branch: this targets #72, not `main`

The task said to branch off latest `main`. I did not, and here is why, because it is the one decision in this PR that is the maintainer's rather than mine.

#72 is still **open**. Latest `main` (`2e77275`) has no SETTINGS menu — and four of the eight invariants this change must preserve (5–8: the menu's exclusion, its per-tick foreground, the notice guard, the KEY3 escape) exist only on #72's branch, as do both deferred asks (the composite capture and the sim driving the escape and the intent handoff). On `main` alone the work is not merely smaller, it is a different change, and it would collide with #72 head-on.

`origin/claude/chat-not-working-qeh7ph` sits directly on latest `main` (`git merge-base` is exactly `origin/main`), so this branch **is** latest `main` + #72 + this change. When #72 merges, GitHub retargets this PR to `main` and the diff below is what remains.

If you would rather this waited for #72 to land, or be cut down to only the pre-existing `main` half, say so and I will redo it.

## Root cause / rationale

The chain was 110 lines in `tick_cb` deciding, in order: the Wi-Fi setup window's input ownership, the OTA maintenance window's escape and hold-to-switch, the SETTINGS menu's exclusion, foreground and escape, app-next, panic, and the menu-open hold. `sim/main.c`'s `poll_keys()` could reach none of it — static QA called `torget_settings_open()` and `torget_settings_click_row()` directly — so the simulator was not the authority for the gesture, the escape, the intent handoff or the asynchronous notice close. Both halves of `AGENTS.md` were broken at once: *"Värdlagren är tunna … UI-beteende hör hemma i appen/platform/, aldrig i main/main.c eller sim/main.c"* and *"Simulatorn är specen"*.

Codex raised it as a P1 on #72 and it was scoped out there: the chain predates that PR, so extracting only the SETTINGS half would have split the button path across two files — worse than either extreme.

**Three decisions worth review:**

- **It returns a struct, not the single enum sketched on the thread.** That is not decoration. Two outputs provably co-occur on one tick: the menu closes *before* the key chain when a window takes over, and that same tick's key still means something to the window; and a menu that owns the glass is lifted and closed on the same tick when a key arrives. One enum would have forced a priority the original does not have, and silently dropped the other half. The struct's fields map 1:1 to host calls so the table test and the application cannot drift.
- **The consent model is strengthened, not restated.** The arbitration calls no service at all and has **no output that opens the maintenance window**. The only way there is a finger on the menu's UPDATE row. A rule that cannot be expressed is better than one that must be read correctly.
- **The exclusion clears a local, and the chain reads it.** That is what makes "before the key chain" observable rather than a comment — and it is what the ordering test discriminates on.

The behaviour is byte-for-byte the original, including the subtle consequence of the ordering: when a notice arrives over an open menu and the same tick carries a short tap, the menu closes *and* the tap reaches the chain. That was true before; it is now written down and tested.

## Verification

- [x] Relevant focused tests pass. New `test/test_key3_arbitration.c` pins all eight invariants as a table of cases, including 64-case exhaustive sweeps for the consent rule and the menu escape, and invariant 3 linked to the **shared** phase rule in `wifi_slots.c` rather than to a bool the test set itself.
- [x] **Mutation-checked.** Nine mutations on the arbitration (invariant 5 split into its ordering half and its coverage half); each failed the matching test, and the restored file is byte-identical:

  | Mutation | Failing check |
  |---|---|
  | 1 · an idle tick opens the menu | `an idle tick never opens a window` (+2) |
  | 2 · a ~2 s release no longer closes the window | `a ~2 s release closes the maintenance window` |
  | 3 · STARTING no longer owns the button | `no app switch while the AP is coming up` (+9) |
  | 4 · the handover closes instead of requesting | `a completed hold asks for the setup window` (+1) |
  | 5a · the exclusion no longer runs before the chain | `the key chain sees the already-closed menu, not the open one` |
  | 5b · an arriving notice no longer closes the menu | `an arriving notice closes the menu` (+2) |
  | 6 · the menu is lifted only on a key event | `every idle tick re-asserts the menu's foreground` (×10) |
  | 7 · the hold works under UPDATE READY | `a completed hold under the notice does nothing at all` |
  | 8 · only a short tap closes the menu | `any KEY3 event closes the open menu` (×2) |

  Three more on the simulator's stand-in after the review round below, all failing `test_the_wifi_handoff_leaves_no_ota_window_behind`: dropping the OTA close, dropping the `can_close` rule, freezing the guard. Two of the three additionally corrupt 22 later captures, since a stuck overlay pollutes every frame after it.

- [ ] `./test/run.sh` passes except `test_interaction_relay_vectors.py`, which needs ESP-IDF's bundled Mbed TLS and fails identically on a clean checkout in this container — not a regression. Every step after it was run and is green.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior: a `### Changed` entry in `CHANGELOG.md`, an entry in `docs/lessons.md` ("the simulator could not reach the decision it was supposed to be the spec for"), and the simulator's own header documents K, U and W.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass. **No panel was flashed.**
- [x] No Windows-specific path is touched.

### Hardware / UI

- [x] **Exact 480×480 simulator evidence.** Three new captures, all registered in `tools/preview-ui.sh`, `test/test_preview_ui.py` and `test/test_vibepulse_visual_landmarks.py`:
  - `settings-notice-takes-over` — the notice arriving over an open menu;
  - `settings-wifi-handoff-open` — the setup window reached through the gesture;
  - `settings-wifi-handoff-closed` — the glass after that window closes.

  Every pre-existing settings capture is now produced by the real gesture rather than by reaching into the menu, and all of them are unchanged pixel-for-pixel.
- [x] **No physical flash was requested or performed**, and none is authorized by this PR.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

**The deferred composite, and what makes it honest.** The notice is announced by `maintenance_ui_task()` with no button event to hang a test on, so #72 could only pin its close by reading source. `settings-notice-takes-over` is taken after one arbitration tick with the menu up and the notice arriving. Its claim is an *absence*: pixel-identical to the plain `ota-ring-notice`, with the menu's "KEY3 CLOSES" footer band carrying zero ink. The menu is gone, not layered underneath. The footer band is the discriminator rather than the row outlines, because the notice's own LATER pill is drawn in the same muted colour; the test asserts the band really does carry menu ink on `settings-menu`, so it cannot pass vacuously.

**The simulator drives the real gesture.** K is KEY3, polled *raw* at 50 ms so the hold is measured by the shared button policy exactly as the panel's 10 Hz tick measures it. U and W are fingers on the menu's rows, through the same `torget_settings_click_row()` the touch callback itself calls, and the intent is consumed by the sim's tick — the half `poll_keys()` could never reach.

## Review round: two Codex P2s, and a third defect they uncovered

Both were correct and both were in code this PR added. Fixed in `f38b46f`; threads replied to and resolved.

The simulator's setup window was a stand-in that did not stand in for anything. It took the STARTING phase and stopped there, so the bench could never reach the setup window through the gesture at all — meaning the escape this PR claims the simulator exercises was not actually exercisable. `key3_close_setup_window()` also closed regardless of phase, inventing an escape the device does not have (`request_close()` returns early unless `tg_wifi_setup_can_close()` says the window is up). And `window_open()` closes an open maintenance window before taking port 80, which the stand-in skipped.

**The pinning attempt that failed is the part worth reading.** My first guard was a frame at the handoff moment — and it *passed with the missing OTA close still in*. A setup window covers all 480×480, so the forgotten OTA layer is invisible while it stands; it is revealed only when the setup window closes, exactly as it behaved in reality. Mutation-checking caught that the test I had written for the defect did not catch the defect. Hence `settings-wifi-handoff-closed`, asserted entirely black.

## Not tested / remaining risk

- **No physical panel has seen this.** Simulator and host-test evidence only. The behaviour is unchanged by construction and by test, but this is the consent-critical input path — the one where a low GPIO18 read at boot once opened a maintenance window by itself — so the static physical review is still the next gate and needs an authorized flash.
- **The sim's window model is still a stand-in**, and I flagged this boundary as "where a future divergence could hide" in the first version of this description — then shipped three divergences in it, which the review found. It is better now: the phase lifecycle, the `can_close` rule and the port-80 handover all follow the target, and three frames pin them. What remains genuinely different is that the bench has no OTA service and no radio, so `key3_open_maintenance_window()` is a layer and panic is a `printf`. Shared byte-identically: the arbitration and the button policy. Each host's *application* of an output is still its own, and that is still where divergence would hide — this round is evidence the concern was real rather than that it is now closed.
- **A Windows CI job failed once on an earlier commit** (`test_mcp_recovers_after_absolute_drip_deadline`, `0.719 not less than 0.6`) and passed on the next. Not this PR's — that test bounds wall-clock time around a subprocess launch, so Python interpreter startup on a loaded runner sits inside the limit. The test two above it already solved this by measuring from the server's recorded request times ("Measure the transport deadline, not unrelated Python process startup"). Out of scope here; raised separately rather than widening this PR.
- **The two P1 threads still open on #72 are untouched here** — the persistent SETTINGS layer's memory measurement (needs the board) and the README's SETTINGS section. Neither is affected by this change, and neither is resolved by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013swaSCnQiRvCARZHTP2Hpp