### PR TITLE
docs(ota): the hold is not an option while the takeover owns the glass

### DIFF
--- a/docs/ota.md
+++ b/docs/ota.md
@@ -16,9 +16,11 @@ short version; this is the reference.
 │                          │          │     takeover on the glass   │
 │ tools/ota-flash.sh waits │          │                             │
 │  for the window...       │          │  YOU consent:               │
-│                          │          │   · tap UPDATE pill, or     │
-│                          │          │   · hold KEY3 ~3 s, then    │
-│                          │          │     pick UPDATE in SETTINGS │
+│                          │          │  takeover up? tap UPDATE    │
+│                          │          │   (KEY3 does nothing)       │
+│                          │          │  otherwise: hold KEY3       │
+│                          │          │   ~3 s, pick UPDATE in      │
+│                          │          │   SETTINGS                  │
 │  └─ POST firmware ─────────────────►│  window open 10 min         │
 │     (token + SHA-256)    │          │  RECEIVING → VERIFYING →    │
 │                          │          │  RESTARTING → reboot into   │

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -18,6 +18,17 @@ than instructions: CHANGELOG.md, whose released entries describe what
 shipped at the time, and docs/superpowers/plans/, which are implementation
 plans for work already done. Rewriting either to match today's behaviour
 would be falsifying the record, which is the opposite of the point.
+
+Also deliberately NOT guarded, after trying: the neighbouring failure where
+a doc offers the hold *while the UPDATE READY takeover is up*, which the
+firmware ignores. The ota.md diagram shipped that way ("tap UPDATE pill, or
+hold KEY3 ~3 s, then pick UPDATE in SETTINGS", directly under "mismatch:
+UPDATE READY takeover"). A rule flagging passages that mention both a hold
+and the takeover fires on three CORRECT ones, which list the two routes for
+two different states — and the wrong version is textually identical to them,
+"or" and all. A guard that flags correct prose trains people to sprinkle
+appeasing words instead of thinking, which is worse than no guard. That
+class needs a reader.
 """
 
 import re


### PR DESCRIPTION
## Outcome

The loop diagram at the top of `docs/ota.md` no longer offers an action the firmware refuses.

It listed the consent options directly under *"mismatch: UPDATE READY takeover on the glass"*:

```
· tap UPDATE pill, or
· hold KEY3 ~3 s, then pick UPDATE in SETTINGS
```

Both read as available in that state. `tg_button_arbitrate()` ignores a completed hold while `notice_visible`, so the second is impossible exactly there — a reader following it holds the button and sees nothing happen. The options are now scoped to the states they belong to, and the diagram says outright that KEY3 does nothing while the takeover is up.

## Root cause / rationale

Found by Codex on #72 at 09:06; #72 merged at 09:09, so the fix missed it by three minutes. This is that fix, on a fresh branch, since a merged PR cannot carry new work.

**The gesture-docs guard did not catch it, and I could not make it.** `test_ota_gesture_docs.py` asks whether a passage naming a KEY3 hold and the update window also names the SETTINGS step. This passage *does* name SETTINGS — it is a different falsehood: the right step, offered in a state where the gesture is inert.

I tried a second rule — flag any passage mentioning both the takeover and a hold unless it says the hold is inert — and it fired on **three correct passages** that list the two routes for two different states. The wrong version is textually identical to those, "or" and all. A guard that flags correct prose teaches people to sprinkle appeasing words instead of thinking, so I removed it and wrote the attempt and its failure into the test file's docstring instead, so nobody re-tries it blindly. That class needs a reader.

## Verification

- [x] Relevant focused tests pass — `test_ota_gesture_docs.py` (3 tests) still green, and its first rule is still verified in both directions against the sentences that actually shipped wrong.
- [x] `./test/run.sh` passes except its ESP-IDF step, which fails identically on a clean checkout in this container (missing toolchain, not a regression). Every step after it was run individually and passes; CI runs the whole gate.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior. No changelog entry: this corrects documentation of already-released behaviour rather than changing behaviour.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass.
- [x] No Windows-affecting change.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed — documentation only.
- [x] No physical flash was requested, performed, or authorized.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

## Not tested / remaining risk

- **The box art is hand-aligned.** The three replacement rows were generated against the measured column widths (26 / 10 / 29) rather than typed, and the rendered block is in the diff, but nothing tests ASCII alignment — a future edit can still knock it out of true.
- **The neighbouring class stays unguarded**, deliberately, for the reason above. A doc can still offer the hold during the takeover and only a reader will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE)_