### PR TITLE
test: stop timing Python interpreter startup in the Codex plugin suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   did. The bound is tighter than before, not looser: the two request/response
   cycles run in ~0.13 s and the assertion trips at 0.4 s, so a lengthened or
   removed drip deadline still turns it red.
+- The same file's `run_script()` no longer times a Codex plugin script out
+  after 4 seconds on a loaded CI runner. The budget is a hang guard, not a
+  speed assertion — nothing overrides it and no test asserts that it fires —
+  but it had to cover a fresh Python interpreter's startup, and on
+  windows-latest it did not: `test_unicode_decision_is_emitted_as_utf8` timed
+  out and passed on a second run of the same commit. It is now a named
+  `SCRIPT_HANG_TIMEOUT_SECONDS = 30`, still verified to catch a wedged script.
 - `/api/tokens` no longer reports a Codex-only computer's Claude counters as
   measured zeros. A new additive `claudeSourcePresent` flag says when the
   Claude directory is absent, so the zeros are not mistaken for a day with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- `test_mcp_recovers_after_absolute_drip_deadline` no longer flakes on the
+  Windows CI runner. It bounded wall clock taken around `run_mcp()`, which
+  spawns a Python subprocess, so interpreter startup counted against a budget
+  meant for the transport deadline alone — 0.719 s against a 0.6 s bound on a
+  loaded runner, green again on the next commit. It now measures from the stub
+  server's own recorded request time, as the sibling deadline test already
+  did. The bound is tighter than before, not looser: the two request/response
+  cycles run in ~0.13 s and the assertion trips at 0.4 s, so a lengthened or
+  removed drip deadline still turns it red.
 - `/api/tokens` no longer reports a Codex-only computer's Claude counters as
   measured zeros. A new additive `claudeSourcePresent` flag says when the
   Claude directory is absent, so the zeros are not mistaken for a day with no

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -38,9 +38,16 @@ request/response cycles and nothing else. **Guards:** the test now measures
 `finished - server.httpd.request_times[0]` and asserts `< 0.4` — it runs at
 ~0.13 s (the 0.12 s deadline plus overhead), fails at 0.49 s if the deadline
 is merely quadrupled, and at 2.83 s if it is removed and the byte-at-a-time
-drip runs to completion. **Watch for:** the third one. `run_mcp` spawns an
-interpreter every time, so a bound taken around it measures the runner. The
-in-process timing tests (`loopback.post_json`, `setup._invoke`) are fine as
+drip runs to completion. The same PR's own CI then found the third one, one
+layer down: `run_script`'s 4 s `subprocess.run` timeout timed out
+`test_unicode_decision_is_emitted_as_utf8` on the Windows runner and passed on
+a second run of the same commit. That one is a hang guard, not an assertion —
+nothing overrides it and no test asserts it fires — so it is now a named
+`SCRIPT_HANG_TIMEOUT_SECONDS = 30`, still proven to fire on a wedged script.
+**Watch for:** every fixed budget in this file that a subprocess spawn sits
+inside. `run_mcp`/`run_script` start an interpreter each call, so both the
+assertion and the guard around them measure the runner unless said otherwise.
+The in-process timing tests (`loopback.post_json`, `setup._invoke`) are fine as
 they stand — the ones that do spawn say so in a comment and budget for it.
 
 ## 2026-09-05 · The simulator could not reach the decision it was supposed to be the spec for

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,28 @@ point at the backlog item.
 
 ---
 
+## 2026-09-05 · A timing bound that measured the CI runner, not the deadline
+
+**What happened:** `test_mcp_recovers_after_absolute_drip_deadline` went red
+on `Tokenserver tests (windows-latest)` at 0.719 s against a 0.6 s bound, then
+passed on the next commit with no relevant change. **Root cause:** the test
+took `time.monotonic()` around the whole `run_mcp(...)` call, and `run_mcp`
+spawns a Python subprocess — so interpreter startup sat inside a bound that
+was only ever meant to cover the transport deadline. On a loaded Windows
+runner that startup ate most of the budget. The sibling test one screen up,
+`test_held_response_timeout_returns_computer_fallback_quickly`, had already
+been fixed this exact way; this one was simply missed. **The rule now:** a
+timing assertion starts at a clock the code under test controls. Here that is
+the server's own `httpd.request_times[0]`, so the bound covers the two
+request/response cycles and nothing else. **Guards:** the test now measures
+`finished - server.httpd.request_times[0]` and asserts `< 0.4` — it runs at
+~0.13 s (the 0.12 s deadline plus overhead), fails at 0.49 s if the deadline
+is merely quadrupled, and at 2.83 s if it is removed and the byte-at-a-time
+drip runs to completion. **Watch for:** the third one. `run_mcp` spawns an
+interpreter every time, so a bound taken around it measures the runner. The
+in-process timing tests (`loopback.post_json`, `setup._invoke`) are fine as
+they stand — the ones that do spawn say so in a comment and budget for it.
+
 ## 2026-09-05 · The simulator could not reach the decision it was supposed to be the spec for
 
 **What happened:** a review found KEY3's whole arbitration — 110 lines

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -178,7 +178,17 @@ def closed_port():
     return port
 
 
-def run_script(name, stdin=b"", *, port=None, env=None, timeout=4):
+# A hang guard, not a speed assertion: it exists so a wedged script cannot
+# wedge the suite, and no test asserts that it fires.  It has to clear a fresh
+# interpreter's startup on a contended CI runner, which a 4 s budget did not —
+# `test_unicode_decision_is_emitted_as_utf8` timed out on windows-latest and
+# passed on a second run of the same commit.  Every script here answers in
+# well under a second when it answers at all, so a wedge is still caught.
+SCRIPT_HANG_TIMEOUT_SECONDS = 30
+
+
+def run_script(name, stdin=b"", *, port=None, env=None,
+               timeout=SCRIPT_HANG_TIMEOUT_SECONDS):
     process_env = os.environ.copy()
     for key in tuple(process_env):
         if key.lower().endswith("_proxy") or key.lower() == "no_proxy":

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1147,14 +1147,19 @@ class McpServerTests(unittest.TestCase):
                 {"raw_chunks": slow_chunks, "raw_delay": 0.04},
                 {"body": compact(answered).encode()},
         ]) as server:
-            started = time.monotonic()
             _, responses = run_mcp([
                 rpc("tools/call", 1, {"name": "ask", "arguments": QUESTION}),
                 rpc("tools/call", 2, {"name": "ask", "arguments": QUESTION}),
             ], port=server.port,
                env={"_VIBEPULSE_TEST_READ_TIMEOUT": "0.12"})
-            elapsed = time.monotonic() - started
-        self.assertLess(elapsed, 0.6)
+            finished = time.monotonic()
+            self.assertEqual(len(server.httpd.request_times), 2)
+            requests_elapsed = finished - server.httpd.request_times[0]
+        # Measure both request/response cycles, not unrelated Python process
+        # startup. Without the absolute drip deadline the first call rides the
+        # byte-at-a-time drip to the end (69 bytes x 0.04 s = 2.8 s), since no
+        # single read ever exceeds the 0.12 s read timeout.
+        self.assertLess(requests_elapsed, 0.4)
         self.assertEqual(responses[0]["result"]["structuredContent"]["status"],
                          "computer")
         self.assertEqual(responses[1]["result"]["structuredContent"], answered)


### PR DESCRIPTION
## Outcome

Two fixed budgets in `test/test_vibepulse_codex_plugin.py` no longer have a
Python subprocess spawn inside them, so neither flakes on a loaded
`Tokenserver tests (windows-latest)` runner. No firmware, plugin, or
tokenserver behavior changes — this is test measurement only, plus the
changelog and lessons entries that go with it.

1. **`test_mcp_recovers_after_absolute_drip_deadline`** — a timing assertion.
   Now measured from the stub server's own clock. The bound is **tighter**
   than before, not looser.
2. **`run_script()`'s subprocess timeout** — a hang guard, found by this PR's
   own CI while the first fix was under review.

Both are confirmed on the runner that produced them: `windows-latest` is green
on `4cad9f4` in both the push and `pull_request` runs.

## Root cause / rationale

Both are the same mistake at different layers: a fixed wall budget that a
fresh interpreter's startup has to fit inside.

### 1. The timing assertion

```python
started = time.monotonic()
_, responses = run_mcp([...], port=server.port, env={"_VIBEPULSE_TEST_READ_TIMEOUT": "0.12"})
elapsed = time.monotonic() - started
self.assertLess(elapsed, 0.6)
```

`run_mcp` spawns a Python subprocess, so interpreter startup sat inside a
budget that only ever meant to cover the transport deadline — that two
sequential requests recover after the absolute drip deadline instead of each
waiting out the drip. The observed failure was
`0.7189999999999941 not less than 0.6`, green again on the next commit with no
relevant change.

The sibling test one screen up,
`test_held_response_timeout_returns_computer_fallback_quickly`, had already
been fixed exactly this way; this one was simply missed. It now measures from
`server.httpd.request_times[0]` to a finish stamp taken while the server is
still up, so the bound covers the two request/response cycles and nothing else.

### 2. The hang guard

The first fix's push run then failed windows-latest on a *different* test:

```
ERROR: test_unicode_decision_is_emitted_as_utf8
subprocess.TimeoutExpired: [...permission_hook.py] timed out after 4 seconds
```

The `pull_request` run passed all 7 checks on the same commit `12f1ad4`, and
the Windows job ran the 134 tests in 67 s where a Linux container runs them in
41 s — a loaded runner, not a wedged script.

`run_script`'s `timeout=4` is a hang guard, not a speed assertion: no caller
overrides it, no test asserts that it fires, and its only job is to stop a
wedged script from wedging the suite. Raising it weakens no assertion. It is
now a named `SCRIPT_HANG_TIMEOUT_SECONDS = 30` carrying the reason, so the next
reader does not have to rediscover which kind of number it is.

## Verification

- [x] Relevant focused tests pass. `python test/test_vibepulse_codex_plugin.py`
      → 134 tests, OK, in 40.8 s — unchanged from before, so the raised guard
      costs nothing on the passing path.
- [x] The drip-deadline assertion still catches a regression, verified by
      temporarily widening the absolute deadline in `loopback.post_json` and
      restoring it:
      | deadline | measured | result |
      | --- | --- | --- |
      | as shipped (`read_timeout`, 0.12 s) | 0.132–0.134 s over 5 runs | pass |
      | `read_timeout * 4` | 0.495 s | **fail** |
      | `read_timeout * 100` (effectively removed) | 2.834 s | **fail** |
      No single read exceeds the 0.12 s read timeout — drip bytes land every
      0.04 s — so only the absolute deadline can stop the first call. Removing
      it lets the 69-byte drip run to completion at 2.8 s.
- [x] The hang guard still fires. Pointed `permission_hook.py` at a server
      holding its headers for 5 s and passed an explicit 1.5 s: raised
      `TimeoutExpired` after 1.50 s. The mechanism is unchanged; only the
      default value and its name.
- [x] `./test/run.sh` passes. CI's `Host gate (./test/run.sh)` is green on
      `4cad9f4`, which covers the whole gate including the two steps a Linux
      container without ESP-IDF or SDL cannot run
      (`test_interaction_relay_vectors.py`, `test_vibepulse_visual_landmarks.py`).
      Locally the gate was run with `--skip-js` and every other step passed,
      with the steps after each blocker run individually — including the full
      814-test tokenserver suite.
- [x] No secret, credential, raw session content, production payload, or
      `torget.bin` is included.
- [x] Documentation and changelog match the behavior. `CHANGELOG.md` gains two
      `Fixed` entries under `Unreleased`; `docs/lessons.md` gains one entry
      covering all three instances — the same mistake has now been paid for
      three times, which is what that file exists to prevent.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a
      real-host or physical-panel pass. The `windows-latest` pass below is
      evidence that two tests stopped flaking on a CI runner, and nothing more.
- [x] Windows-affecting changes follow `docs/windows-validation.md`. No Windows
      behavior changes — only how two tests that run on the Windows runner
      budget themselves.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed.
- [x] No physical flash was performed or requested.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were
      not treated as approval. The drip test's own subject is the computer
      fallback after a stalled response; that assertion is unchanged.

## Not tested / remaining risk

The residual risk on the assertion is its threshold: 0.4 s against a ~0.13 s
measurement is 3x headroom with process spawn no longer inside it, so the
remaining noise is the stub server's own scheduling. If a runner ever needs
more than 0.4 s for two loopback cycles whose only deliberate wait is 0.12 s,
that is worth knowing about rather than absorbing into a wider bound.

The residual risk on the guard is the opposite one: a script that wedges is now
caught 26 s later than before. That cost is paid only in the failing case, and
no test relies on the guard to fail fast.

Neither flake is *proven* gone — a flake that reproduces once in many runs
cannot be disproven by one green run. What is established is that the two
budgets no longer contain a process spawn, so runner load can no longer be what
trips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LncBZHmMJeSYyrHhjXw1TQ