### PR TITLE
feat(obs): every permanent overlay reports what it costs, on every boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- **Every permanent overlay now reports what it costs, on every boot.** The
+  three top-layer overlays — Wi-Fi setup, SETTINGS and the OTA ring — are
+  built once at start and kept for the whole run, and the AMOLED rule
+  forbids that without a measured memory budget. The measurement is now
+  automatic rather than remembered: each create is bracketed and logs
+  `overlaykostnad <name>: LVGL-pool +N B …, internt ±N B …`. Two numbers
+  because they answer different questions. LVGL's allocator pool is TLSF in
+  **PSRAM** (moved there as the 2026-08-16 freeze fix), so object trees come
+  out of its 256 KiB rather than internal RAM; the internal figure is the
+  control that shows whether a create takes internal memory anyway. A zero
+  delta retires the starvation worry for that layer with evidence instead of
+  argument, and a non-zero one puts the cost in the log.
+
 - A **SETTINGS** menu on a 3 s KEY3 hold. The hold used to derive which window
   you wanted from whether the panel had an IP; it now opens a menu with
   UPDATE, WIFI and ABOUT and lets you say. The consent model is unchanged —

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -280,6 +280,7 @@ Verbatim strings worth grepping for, and what they mean:
 | `agentstatus avvisad: transportfel ESP_FAIL` | fw `agent-net` | always literally `ESP_FAIL` — the real cause is discarded before logging (OBS-12). Only says "agent feed unhappy". |
 | `agentstatus kunde inte skapa HTTP-klient` | fw `agent-net` | agent feed **dead until reboot**; screen shows a frozen header meanwhile (OBS-12). |
 | `heap: internt … DMA största …` | fw `torget` | every 10 s. Watch the DMA largest block: its collapse predicted the 2026-08-06 panel freeze. Nothing alerts on it yet (OBS-27). |
+| `overlaykostnad <namn>: LVGL-pool +N B …, internt ±N B …` | fw `torget` | three lines, once at boot: what each permanent top-layer overlay (wifi-setup, settings, ota) costs. The pool figure is PSRAM (LVGL's TLSF pool lives there since the 2026-08-16 freeze fix); the internal figure is the control — a zero delta means that overlay does not touch internal RAM at all. This is the measured budget the AMOLED rule requires for a persistent layer, so read it after any flash that adds or grows one. |
 | `Guru Meditation` / `abort()` / backtrace | fw | panic. Capture the whole backtrace *now* — it will not survive the reboot (OBS-02). |
 | `Task watchdog got triggered` | fw | a task starved IDLE — the only hang ever seen on hardware surfaced this way. |
 | `omstartsorsak PANIK` / `TASKVAKTHUND` / `BROWNOUT` | fw boot banner | the previous run died and this line is the only witness. BROWNOUT → suspect the power supply first. |

--- a/main/main.c
+++ b/main/main.c
@@ -803,6 +803,54 @@ static void rounder_event_cb(lv_event_t *e) {
   area->y2 = ((area->y2 >> 1) << 1) + 1;
 }
 
+/* ---------------------------------------- overlayernas minnesbudget
+ *
+ * De tre topplageroverlayerna byggs EN gång vid start och lever sedan hela
+ * körningen. AMOLED-skillen kräver en MÄTT budget för ett sådant lager, och
+ * #72 landade utan en — den kunde inte mätas härifrån, bara på enheten.
+ * Det här gör mätningen automatisk: varje flash svarar på frågan i loggen,
+ * utan att någon behöver komma ihåg att mäta.
+ *
+ * TVÅ siffror, för de svarar på olika saker:
+ *
+ *   LVGL-poolen är TLSF i PSRAM (LV_MEM_POOL_ALLOC i main/lv_psram_pool.h,
+ *   flytten dit var frysfixen 2026-08-16). Objektträden bor alltså i PSRAM,
+ *   och det är poolens 256 KiB de tär på — inte det interna minnet.
+ *
+ *   Internt fritt mäts ändå, och det är den viktiga kontrollen: den visar
+ *   om ett create ÄNDÅ tar internt minne (stilar, buffertar, något LVGL
+ *   lägger utanför poolen). Är deltat noll är den interna svältoron
+ *   obefogad för det lagret; är det inte noll står siffran där svart på
+ *   vitt. Ingen behöver gissa åt någotdera hållet.
+ *
+ * Kostar en loggrad per overlay vid boot och ingenting därefter. */
+static size_t s_cost_pool_used;
+static size_t s_cost_internal_free;
+
+static void overlay_cost_mark(void) {
+  lv_mem_monitor_t mon;
+  lv_mem_monitor(&mon);
+  s_cost_pool_used = mon.total_size - mon.free_size;
+  s_cost_internal_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+}
+
+static void overlay_cost_report(const char *name) {
+  lv_mem_monitor_t mon;
+  lv_mem_monitor(&mon);
+  size_t pool_used = mon.total_size - mon.free_size;
+  size_t internal_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+  /* Signerat: internt kan gå åt båda håll, och en negativ siffra är data,
+   * inte ett fel. */
+  long pool_delta = (long)pool_used - (long)s_cost_pool_used;
+  long internal_delta =
+      (long)s_cost_internal_free - (long)internal_free;
+  ESP_LOGI(TAG,
+           "overlaykostnad %s: LVGL-pool +%ld B (pool %u/%u använt), "
+           "internt %+ld B (kvar %u)",
+           name, pool_delta, (unsigned)pool_used, (unsigned)mon.total_size,
+           internal_delta, (unsigned)internal_free);
+}
+
 static void display_start(void) {
   esp_lv_adapter_config_t adapter_cfg = ESP_LV_ADAPTER_DEFAULT_CONFIG();
   /* 16 KB: appröttarna gör trädet djupare än defaultens 8 KB klarade. */
@@ -985,17 +1033,23 @@ void app_main(void) {
    * och hämtar sig längst fram i sin egen set(), så skapelseordningen
    * avgör vem som vinner när båda vill synas. READY-ringen ska alltid
    * vinna — den skapas därför sist. */
+  overlay_cost_mark();
   torget_wifi_ui_create();
+  overlay_cost_report("wifi-setup");
   /* SETTINGS på samma topplager. Skapelseordningen bestämmer dock INTE
    * företrädet här: menyn hävdar sitt läge överst varje tick, för annars
    * begraver NO NETWORK-sidan den inom en sekund (den ritar om sin
    * nedräkning och lyfter sig själv). Att en väntande uppdatering ändå
    * alltid vinner vilar på att menyn och notisen aldrig är uppe samtidigt
    * — se tick_cb — inte på vem som skapades sist. */
+  overlay_cost_mark();
   torget_settings_create();
+  overlay_cost_report("settings");
   /* OTA-overlayn EFTER det delade UI:t, på topplagret, dold tills KEY3-
    * hållet öppnar underhållsfönstret — appträdet rörs aldrig. */
+  overlay_cost_mark();
   torget_ota_ui_create();
+  overlay_cost_report("ota");
   lv_timer_create(tick_cb, TICK_EVERY_MS, NULL);
   torget_ui_unlock();
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -292,6 +292,7 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_buddy_opt_in.py
 "$PYTHON_BIN" test_lvgl_layer_safety.py
 "$PYTHON_BIN" test_lvgl_memory_config.py
+"$PYTHON_BIN" test_overlay_memory_budget.py
 "$PYTHON_BIN" test_lvgl_qrcode_config.py
 "$PYTHON_BIN" test_wifi_onboarding_design.py
 "$PYTHON_BIN" test_vibepulse_layout_wiring.py

--- a/test/test_overlay_memory_budget.py
+++ b/test/test_overlay_memory_budget.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""The three permanent overlays must report what they cost, on every boot.
+
+Background, and it is a real gap rather than a hypothesis. #72 shipped a
+SETTINGS overlay built once at boot and kept for the whole run. The AMOLED
+skill forbids adding a persistent UI layer "without approval and a measured
+memory budget", and that PR had no measurement — it could not have one from
+a container, only from the panel. The question then sat open, which is the
+worst outcome: a rule everyone agrees with and nobody can answer.
+
+So the measurement is automatic instead of remembered. Each of the three
+top-layer overlays is bracketed at creation, and the delta is logged. Any
+flash answers the question; nobody has to think to ask it.
+
+WHY TWO NUMBERS. LVGL's allocator pool is TLSF in PSRAM here — see
+`LV_MEM_POOL_ALLOC` in `main/lv_psram_pool.h`, moved there as the 2026-08-16
+freeze fix because the pool in internal BSS pushed the largest contiguous
+DMA-capable block under the panel flush's 11 520 B. Object trees therefore
+come out of that 256 KiB PSRAM pool, not internal RAM. The internal figure is
+the *control*: it shows whether a create takes internal memory anyway. A zero
+delta retires the starvation worry for that layer with evidence; a non-zero
+one puts the cost in the log. Either way nobody guesses.
+
+This test cannot run the firmware. It pins the instrumentation's presence and
+shape, which is what a host test can honestly do.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN = ROOT / "main/main.c"
+POOL_HEADER = ROOT / "main/lv_psram_pool.h"
+
+# Every overlay that is created once and kept for the run.
+PERSISTENT_OVERLAYS = ("wifi-setup", "settings", "ota")
+
+
+def without_comments(source):
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+class OverlayMemoryBudgetTests(unittest.TestCase):
+    def setUp(self):
+        self.source = without_comments(MAIN.read_text(encoding="utf-8"))
+
+    def test_every_persistent_overlay_is_bracketed(self):
+        """Each create sits between a mark and a report, and reports under
+        its own name — otherwise three costs arrive as one number and the
+        menu's share is unknowable again."""
+        for overlay, create in (
+            ("wifi-setup", "torget_wifi_ui_create()"),
+            ("settings", "torget_settings_create()"),
+            ("ota", "torget_ota_ui_create()"),
+        ):
+            with self.subTest(overlay=overlay):
+                idx = self.source.index(create)
+                before = self.source[:idx]
+                after = self.source[idx:]
+                self.assertTrue(
+                    before.rstrip().endswith("overlay_cost_mark();"),
+                    f"{create} must be preceded by overlay_cost_mark()")
+                report = f'overlay_cost_report("{overlay}")'
+                # The report must be the next cost call, not a later one.
+                nxt = after.index("overlay_cost_report(")
+                self.assertTrue(after[nxt:].startswith(report),
+                                f"{create} must report as {overlay!r}")
+
+    def test_both_pools_are_measured(self):
+        """The PSRAM pool answers 'what did it cost', the internal heap
+        answers 'did it touch the memory the rule is actually about'. One
+        without the other cannot settle the question."""
+        self.assertIn("lv_mem_monitor(&mon)", self.source)
+        self.assertIn("heap_caps_get_free_size(MALLOC_CAP_INTERNAL)",
+                      self.source)
+
+    def test_the_internal_delta_is_signed(self):
+        """Internal free can move either way around a create, and a negative
+        number is data rather than an error. An unsigned subtraction would
+        wrap and print a plausible-looking enormous value — a fabricated
+        figure, which is exactly what this repository refuses to display."""
+        self.assertIn("long internal_delta", self.source)
+        self.assertIn("%+ld", MAIN.read_text(encoding="utf-8"))
+
+    def test_the_pool_is_still_in_psram(self):
+        """The whole reading of these numbers depends on it. If someone
+        moves the pool back to internal BSS, the interpretation written into
+        main.c's comment silently becomes wrong — and so does the 2026-08-16
+        freeze fix."""
+        pool = POOL_HEADER.read_text(encoding="utf-8")
+        self.assertIn("MALLOC_CAP_SPIRAM", pool)
+        self.assertNotIn("MALLOC_CAP_DMA", pool.split("#define")[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Three new lines in the boot log, one per permanent top-layer overlay:

```
overlaykostnad wifi-setup: LVGL-pool +N B (pool U/T använt), internt ±N B (kvar F)
overlaykostnad settings:   LVGL-pool +N B (pool U/T använt), internt ±N B (kvar F)
overlaykostnad ota:        LVGL-pool +N B (pool U/T använt), internt ±N B (kvar F)
```

This is the **measured memory budget** the AMOLED rule requires for a persistent UI layer. It answers a question that has been open since #72 and closes the P1 raised there — as far as anything can be closed from a container.

## Root cause / rationale

#72 shipped a SETTINGS overlay built once at boot and kept for the whole run. The AMOLED skill forbids adding a persistent UI layer *"without approval and a measured memory budget"*, and that PR had no measurement — it could not have one from here, only from the panel. The question then sat open, which is the worst outcome available: a rule everyone agrees with and nobody can answer.

So the measurement is automatic rather than remembered. Any flash answers it; nobody has to think to ask. All three overlays are instrumented, not just the new one, so the menu's share is its own number rather than something inferred from a total — and the "the other two are already permanent, this is a third of the same kind" argument becomes data instead of rhetoric.

**Two figures, because they answer different questions — and this is the part worth reviewing:**

LVGL's allocator pool is TLSF in **PSRAM** here. `LV_MEM_POOL_ALLOC` in `main/lv_psram_pool.h` is `heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)`, moved there as the 2026-08-16 freeze fix, because the pool in internal BSS pushed the largest contiguous DMA-capable block under the panel flush's 11 520 B and every flush died in `NO_MEM`. Object trees therefore come out of that 256 KiB PSRAM pool, **not internal RAM**.

That materially reframes the original finding, which worried about internal starvation. But "by construction" is not a measurement, so the internal figure is the *control*: it shows whether a create takes internal memory anyway — styles, buffers, anything LVGL puts outside the pool. A zero delta retires the worry for that layer with evidence; a non-zero one puts the cost in the log next to the periodic heap line. Nobody has to guess in either direction.

The internal delta is **signed** on purpose. It can move either way around a create, and an unsigned subtraction would wrap and print a plausible enormous number — a fabricated figure, which is the one thing this display is not allowed to do.

## Verification

- [x] Relevant focused tests pass — new `test/test_overlay_memory_budget.py` (4 tests, wired into `test/run.sh`): every create is bracketed and reports under its own name, both pools are measured, the delta is signed, and the pool is still in PSRAM. That last one matters because the *reading* of these numbers depends on it — moving the pool back to internal BSS would silently invalidate both the interpretation written into `main.c` and the freeze fix itself.
- [x] **Mutation-checked**: dropping the settings bracket fails the suite; moving the pool out of PSRAM fails it. Restored, green.
- [x] `./test/run.sh` passes except its ESP-IDF step, which fails identically on a clean checkout in this container (missing toolchain, not a regression). Every step after it was run individually and passes; CI runs the whole gate including the firmware build.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior — `CHANGELOG.md`, and `docs/observability.md`, which maps every log the system emits and now carries this one with how to read it.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass.
- [x] No Windows-affecting change.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behaviour changed — logging only. Nothing is drawn, no layer is added or removed, no timing changes: `lv_mem_monitor()` and `heap_caps_get_free_size()` are called six times at boot and never again.
- [x] No physical flash was requested, performed, or authorized.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

## Not tested / remaining risk

- **This does not produce the number.** It makes the number appear on the next flash, which is still yours to authorize. Until then the budget is instrumented, not known — and I would rather say that plainly than let an instrumented-but-unread gauge read as an answered question.
- **Not run on hardware at all.** `lv_mem_monitor()` reports zeros under the simulator's `LV_STDLIB_CLIB` allocator, so the sim cannot exercise this meaningfully and I did not pretend otherwise by adding it there. CI proves it compiles; only the panel proves the figures are sane.
- **Boot-time only.** An overlay that grew *after* creation would not show up here. All three are static trees today, so this is the right measurement for what exists — but it is not a running budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE)_