### PR TITLE
test(setup): budget the Windows taskkill spawn inside a timed bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,17 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   windows-latest it did not: `test_unicode_decision_is_emitted_as_utf8` timed
   out and passed on a second run of the same commit. It is now a named
   `SCRIPT_HANG_TIMEOUT_SECONDS = 30`, still verified to catch a wedged script.
+- `test_production_process_timeout_kills_reaps_and_recovers` no longer bounds a
+  Windows-only subprocess spawn it never budgeted for. A sweep of every timed
+  assertion CI runs on windows-latest found it: `_terminate_process_tree()`
+  spawns `taskkill` there, and with the production
+  `PIPE_JOIN_TIMEOUT_SECONDS = 1` the permitted worst case was 0.1 + 1 + 1 =
+  2.1 s against a 2 s bound — the assertion could have lost to a slow runner
+  rather than to the bug. It now caps that constant at 0.25 s the way the two
+  POSIX siblings already did and asserts under 4 s; it runs in ~0.1 s and
+  still turns red at 5.1 s if the deadline is lengthened. The sweep found
+  nothing else: the other three process tests are POSIX-only, and every timed
+  bound in the tokenserver modules is in-process.
 - `/api/tokens` no longer reports a Codex-only computer's Claude counters as
   measured zeros. A new additive `claudeSourcePresent` flag says when the
   Claude directory is absent, so the zeros are not mistaken for a day with no

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -44,11 +44,18 @@ layer down: `run_script`'s 4 s `subprocess.run` timeout timed out
 a second run of the same commit. That one is a hang guard, not an assertion —
 nothing overrides it and no test asserts it fires — so it is now a named
 `SCRIPT_HANG_TIMEOUT_SECONDS = 30`, still proven to fire on a wedged script.
-**Watch for:** every fixed budget in this file that a subprocess spawn sits
-inside. `run_mcp`/`run_script` start an interpreter each call, so both the
-assertion and the guard around them measure the runner unless said otherwise.
-The in-process timing tests (`loopback.post_json`, `setup._invoke`) are fine as
-they stand — the ones that do spawn say so in a comment and budget for it.
+A sweep for the fourth corrected why the `setup._invoke` tests were called
+safe: they do spawn, but Popen returns before the child boots, so startup
+overlaps the mocked wait rather than serialising into it (elapsed = that
+timeout + <=53 ms). The serial spawn is Windows-only —
+`_terminate_process_tree()` runs `taskkill` — and
+`test_production_process_timeout_kills_reaps_and_recovers` is the only one of
+them on windows-latest: at `PIPE_JOIN_TIMEOUT_SECONDS = 1` it permitted
+0.1 + 1 + 1 = 2.1 s against a 2 s bound. It now mocks that to 0.25 as its
+POSIX siblings did and bounds at 4 s. **Watch for:** every fixed budget with a
+spawn inside — but only a *serial* one counts. `run_mcp`/`run_script` start an
+interpreter per call; a killed child's `taskkill` is serial too, and invisible
+on Linux. `loopback.post_json` and the tokenserver bounds spawn nothing.
 
 ## 2026-09-05 · The simulator could not reach the decision it was supposed to be the spec for
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -3999,10 +3999,24 @@ class RelaySetupTests(unittest.TestCase):
     def test_production_process_timeout_kills_reaps_and_recovers(self):
         setup = load_setup()
         sleeping = [sys.executable, "-c", "import time; time.sleep(10)"]
-        with mock.patch.object(setup, "COMMAND_TIMEOUT_SECONDS", 0.1):
+        # The only one of these process tests that runs on Windows, and there
+        # `_terminate_process_tree()` spawns `taskkill` — a real CreateProcess
+        # inside the bound, followed by two `PIPE_JOIN_TIMEOUT_SECONDS` waits
+        # and up to two rounds of drain-thread joins.  Left at the production
+        # 1 s that is 0.1 + 1 + 1 = 2.1 s of permitted worst case against a
+        # 2 s bound: the assertion could lose to a slow runner rather than to
+        # the bug.  Cap the joins the way the two POSIX siblings already do,
+        # so the worst case is 0.1 + 6 x 0.25 = 1.6 s.  A real `taskkill`
+        # still runs; if a loaded runner ever exceeds 0.25 s the documented
+        # `process.kill()` fallback reaps this single child anyway.
+        with mock.patch.object(setup, "COMMAND_TIMEOUT_SECONDS", 0.1), \
+                mock.patch.object(
+                    setup, "PIPE_JOIN_TIMEOUT_SECONDS", 0.25):
             started = time.monotonic()
             self.assertIsNone(setup._invoke(sleeping, setup._AUTO))
-            self.assertLess(time.monotonic() - started, 2)
+            # Bounds the deadline, not the runner: it fires in ~0.1 s here and
+            # the failure it catches is waiting out the child's 10 s sleep.
+            self.assertLess(time.monotonic() - started, 4)
         completed = setup._invoke(
             [sys.executable, "-c", "print('recovered')"], setup._AUTO)
         self.assertIsNotNone(completed)


### PR DESCRIPTION
## Outcome

`test_production_process_timeout_kills_reaps_and_recovers` no longer bounds a Windows-only subprocess spawn it never budgeted for. Nothing about the product changes — this closes the last instance of the flake class that `Tokenserver tests (windows-latest)` has now hit twice.

The requested fix to `test_mcp_recovers_after_absolute_drip_deadline` was already on `main` (12f1ad4, PR #75). I re-verified it rather than redoing it: `python test/test_vibepulse_codex_plugin.py` is 134 tests OK, and lengthening the absolute drip deadline 100x turns it red at 2.83 s against its 0.4 s bound. This PR is the follow-up sweep for the rest of the pattern.

## Root cause / rationale

The lesson entry left by those two fixes said the remaining `setup._invoke` timing tests were "in-process ... fine as they stand". They are not in-process — each spawns a real interpreter. They *are* fine, but for a different reason: `Popen` returns before the child boots, so startup overlaps the mocked wait instead of serialising into it. Measured across three runs, elapsed is the mocked timeout plus at most 53 ms (0.152/0.15, 0.553/0.5, 0.102/0.1, 0.503/0.5).

Reasoning from the wrong premise hid the fourth instance, because what *does* serialise is invisible on Linux. On Windows `_terminate_process_tree()` reaps the child with `taskkill` — a real `CreateProcess`, bounded by `PIPE_JOIN_TIMEOUT_SECONDS` and followed by a second wait on the same budget. `test_production_process_timeout_kills_reaps_and_recovers` is the only one of the four that runs on windows-latest (the other three are POSIX-only), and it mocked `COMMAND_TIMEOUT_SECONDS` to 0.1 while leaving `PIPE_JOIN_TIMEOUT_SECONDS` at its production 1 s. Permitted worst case 0.1 + 1 + 1 = 2.1 s against a 2 s bound, before counting either `CreateProcess` or the drain-thread joins — the assertion could have lost to a loaded runner rather than to the bug.

It now caps `PIPE_JOIN_TIMEOUT_SECONDS` at 0.25 s, which is what its two POSIX siblings already do, putting the worst case at 0.1 + 6 × 0.25 = 1.6 s, and bounds at 4 s. A real `taskkill` still runs; if a loaded runner ever exceeds 0.25 s the documented `process.kill()` fallback reaps this single child anyway.

The rest of the sweep came back clean, and the lesson now records that so the next reader does not re-derive it: `run_mcp`/`run_script` are covered by the two earlier fixes and no caller overrides either budget; `loopback.post_json` spawns nothing; and every timed bound in the tokenserver modules — which CI also runs on windows-latest — is in-process.

## Verification

- [x] Relevant focused tests pass.
- [ ] `./test/run.sh` passes, or the exact omission and reason are stated. **Stated:** the script stops at `test_interaction_relay_vectors.py` on a machine without ESP-IDF, so every step after that line was run individually. All pass except three that fail on container gaps unrelated to this change, each reproduced on a clean tree: `test_preview_ui`, `test_vibepulse_visual_landmarks` and `tools.agent_assets.test_build_agent_images` (`No module named 'PIL'`), and `test_agent_status_body_capacity` plus the three relay-crypto tokenserver modules (`pyo3_runtime.PanicException` out of `cryptography`). CI installs `requirements-dev.txt`, which covers both.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior.

Focused results: `test/test_vibepulse_codex_plugin.py` 134 tests OK (40.9 s); the tokenserver suite minus the three uninstallable relay-crypto modules, 776 tests OK (82 s).

The bound stays an assertion, not a guard, and this was checked in both directions: it runs at ~0.1 s, and lengthening the process deadline by 5 s turns it red at 5.10 s against the 4 s bound. Disabling the deadline outright makes it red at 10.06 s — exactly the child's `time.sleep(10)`, the failure the bound exists to catch.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass. No claim here rests on a real host or panel; the Windows behaviour described is read from `tools/vibepulse_setup.py`, not observed on a Windows machine in this session.
- [x] Windows-affecting changes follow `docs/windows-validation.md` — this changes no Windows runtime code, only the budget of a test that exercises it.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed.
- [x] A physical flash was separately and explicitly authorized — n/a, none performed or requested.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval — n/a, no consent path touched.

## Not tested / remaining risk

The 2.1 s worst case was derived by reading `_bounded_thread_process()` and `_terminate_process_tree()`, not observed — this container is Linux, where `taskkill` never runs and the measured cost is 0.102 s. The Windows path is exercised only by CI on this PR. The two `CreateProcess` costs are still inside the bound and unmeasured; they are now budgeted against 4 s rather than 2 s, with the variable joins capped, which is what makes the margin real rather than assumed.

`PIPE_JOIN_TIMEOUT_SECONDS = 0.25` slightly narrows what the Windows run proves: if a loaded runner takes longer than that, the test exercises the `process.kill()` fallback instead of the `taskkill` happy path. The child still dies and the test still passes either way, and `taskkill`'s argv and its `timeout <= 2` are asserted separately in `test_process_interrupt_terminates_tree_and_windows_uses_taskkill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAMJW1MEqb5gZTyGvQWXur

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAMJW1MEqb5gZTyGvQWXur)_