### PR TITLE
feat(setup): name the saved Codex mode that hides permission cards

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
+import re
 import sys
 
 from loopback import get_json, strict_json_loads
@@ -16,6 +18,13 @@ HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
 EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+CODEX_CONFIG_MAX_BYTES = 64 * 1024
+# Only the three top-level string settings that decide whether a permission
+# card can reach a user at all. Anchored and quote-matched so a value inside
+# a table further down the file cannot be read as a top-level one.
+_CODEX_STRING_SETTING = re.compile(
+    r'^[ \t]*(approval_policy|approvals_reviewer|sandbox_mode)[ \t]*='
+    r'[ \t]*(["\'])([^"\']*)\2[ \t]*(?:#.*)?$')
 CONTEXT = (
     "For short, non-secret, single-choice 2–3 option questions or "
     "recommendations, use mcp__vibepulse__ask. Mark at most one option "
@@ -129,7 +138,66 @@ def classify_startup_health(root, tokens):
             f"recent direct panel polling is confirmed.{risk}")
 
 
+def _saved_codex_permission_fix():
+    """Name a saved Codex mode that silently prevents approvals reaching the
+    panel — the failure that looks exactly like a broken panel.
+
+    A user in this state sees the bridge green, the panel polling and no
+    APPROVE / DENY ever arriving, with nothing anywhere saying why. The
+    setting is on their computer and the panel cannot see it, so the hook is
+    the only place that can.
+
+    Reads NOTHING but the three mode names: never the prompts, the history,
+    or any other key. Returns a message or None; an unreadable or absent
+    config is not a failure, because plenty of working installs have no
+    config.toml at all.
+    """
+    codex_home = os.environ.get("CODEX_HOME")
+    config_path = ((Path(codex_home) if codex_home else Path.home() / ".codex")
+                   / "config.toml")
+    try:
+        raw = config_path.read_bytes()
+        if len(raw) > CODEX_CONFIG_MAX_BYTES:
+            raise ValueError("oversized config")
+        text = raw.decode("utf-8", errors="strict")
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeError, ValueError):
+        return ("VibePulse startup health: FIX - saved Codex config is "
+                "unreadable; verify /permissions on this computer.")
+
+    config = {}
+    for line in text.splitlines():
+        # Stop at the first table header: below it these names would belong
+        # to that table, not to the top level.
+        if line.lstrip().startswith("["):
+            break
+        match = _CODEX_STRING_SETTING.fullmatch(line)
+        if match is not None:
+            config[match.group(1)] = match.group(3)
+
+    if config.get("approval_policy") == "never":
+        return ("VibePulse startup health: FIX - Codex approval_policy is "
+                "never, so no permission card can reach the panel. Use "
+                "on-request and start a new task.")
+    if config.get("approvals_reviewer") == "auto_review":
+        return ("VibePulse startup health: FIX - Codex approvals are routed "
+                "to auto_review instead of the user. Use the user reviewer "
+                "and start a new task.")
+    if config.get("sandbox_mode") == "danger-full-access":
+        return ("VibePulse startup health: FIX - Codex sandbox_mode is "
+                "danger-full-access, so workspace permission boundaries are "
+                "bypassed. Use workspace-write and start a new task.")
+    return None
+
+
 def _startup_health():
+    # Before any HTTP: a suppressed approval mode makes every downstream
+    # reading look healthy, so reporting the reachable service first would
+    # tell the user everything is fine while nothing can reach them.
+    permission_fix = _saved_codex_permission_fix()
+    if permission_fix is not None:
+        return permission_fix
     port = _port()
     if port is None:
         return classify_startup_health(None, None)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- **`doctor` and Codex startup health now name a saved Codex mode that
+  silently prevents approvals from reaching the panel.** This is the failure
+  that looks exactly like a broken panel: the bridge is green, the panel
+  polls, and **APPROVE / DENY** never arrives — because `approval_policy =
+  "never"`, `approvals_reviewer = "auto_review"` or `sandbox_mode =
+  "danger-full-access"` means no permission event is ever created. The panel
+  cannot see a setting on the user's computer, so the host is the only place
+  that can say so, and the startup check now says it *before* reporting a
+  reachable service healthy. Reads the three mode names and nothing else in
+  the file, stops at the first table header so a value under `[profiles.x]`
+  is never read as a top-level one, and stays quiet when there is no
+  `config.toml` — most working installs have none, and a check that cries
+  wolf is skipped like any other. Rescued from
+  `niclas/wip/wifi-dma-calibration-20260904` before that branch is deleted.
+
 - **The KEY3 flow is tested as a journey, not only as a table.**
   `test/test_key3_arbitration.c` pins eight invariants separately, which is
   the right shape for them — but every cell in that table is set up by hand,

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -355,6 +355,29 @@ legacy alias for Claude only. Current installations should use the setup tool.
 
 ### 3. Review hooks instead of bypassing trust
 
+Codex must be allowed to create interactive permission requests before a
+permission card can reach VibePulse at all. Keep the user-controlled global
+switches explicit in `~/.codex/config.toml`:
+
+```toml
+approval_policy = "on-request"
+approvals_reviewer = "user"
+sandbox_mode = "workspace-write"
+```
+
+`approval_policy = "never"` suppresses every approval prompt, and
+`sandbox_mode = "danger-full-access"` removes the normal workspace boundary.
+Either one produces the confusing failure this section exists to prevent: the
+panel, bridge, plugin and MCP are all healthy, and **APPROVE / DENY** simply
+never happens, because no permission event was ever created. `doctor` and the
+Codex `SessionStart` health check both read these three names — and nothing
+else in the file — so the state is reported rather than guessed at.
+
+The VibePulse installer never edits these settings. They are global Codex
+security controls that happen to gate this feature; changing them on a user's
+behalf is not ours to do. After changing them yourself, fully restart Codex
+before reviewing the hooks below.
+
 For Codex, open Codex and run `/hooks`. Review the VibePulse `SessionStart` and
 `PermissionRequest` command hooks and explicitly trust them. Then **Start a new
 Codex task** so the newly trusted hooks, skill, and MCP tool are loaded. Run
@@ -457,6 +480,7 @@ workflow, consent model and troubleshooting live in [ota.md](ota.md).
 | Screen boots, everything is dashes, forever | `DIN-MAC` never replaced in `secrets.h`, the Windows LAN IP changed, or the `TK_*` defines were removed | Set the reachable host (Bonjour on macOS; reserved LAN IPv4 on Windows), rebuild, reflash |
 | Dashes, and the computer's URL is set | tokenserver not running, computer asleep, or firewall | Start it; check `curl localhost:8737/` |
 | Dashes only for Claude, Codex fine (or vice versa) | That provider's source is unavailable | Check `claudeProbe`; the other half working is by design |
+| Panel polls, bridge is green, but Codex never shows APPROVE / DENY | Codex has `approval_policy = "never"`, `approvals_reviewer = "auto_review"`, or `sandbox_mode = "danger-full-access"`, so no user permission event is created at all | Restore `on-request` / `user` / `workspace-write`, fully restart Codex, review `/hooks` in the interactive CLI, start a new task, then `python3 tools/vibepulse_setup.py doctor` |
 | Never joins WiFi | Network is 5 GHz | 2.4 GHz only. iPhone hotspot: enable "Maximize Compatibility". The glass names the reason itself after 60 s |
 | Moved to a new place; panel finds nothing | The new network was never taught to it | It raises `VibePulse-setup` after 90 s (or a 3 s KEY3 hold → WIFI). Run `tools/wifi-here.sh` on the Mac, or join the AP from a phone. Remembered afterwards — [docs/wifi.md](wifi.md) |
 | `wifi-here.sh` cannot join the setup AP | The window is closed, or `TG_OTA_TOKEN` is missing so the password is random | Check the glass says WIFI SETUP; without a token run `TG_AP_PASS=<what the glass shows> tools/wifi-here.sh` |

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -460,6 +460,34 @@ physical review dated 2026-08-27, plugin documentation assertions, and the
 hardware registry. **Watch for:** treating a successful build, a visible
 waiting screen, silence, or computer fallback as an end-to-end pass.
 
+## 2026-08-26 · A ready sender did not mean a listening panel
+
+**What happened:** Claude's hook parked and encrypted an approval correctly,
+but the panel never answered; after 120 seconds the request fell back to the
+computer. **Root cause:** every health signal stopped on the Mac side. A
+running tokenserver, ready relay, configured hooks and an enumerated ESP32
+proved four separate components, not the end-to-end receive loop; the matching
+firmware relay block was missing too. **The rule:** readiness requires evidence
+from the CONSUMER, and setup checks must compose dependent sub-checks instead
+of making the user know which second doctor to run. **Guards:** the short-lived
+two-poll panel proof in `GET /` (`_panel_health_snapshot`), Codex startup
+health, and the general doctor's relay pairing report. **Watch for:**
+relay-only panels stay honestly unprovable until the relay has a
+privacy-reviewed panel heartbeat.
+
+## 2026-08-26 · A background warmup still blocked the listening socket
+
+**What happened:** launchd reported the tokenserver running while port 8737
+stayed closed and one core scanned histories. **Root cause:** the first usage
+scan was threaded, but the numbers publisher synchronously called the same
+producer before the HTTP server bound, and waited on the scan's cache lock.
+**The rule:** every startup dependency before `bind()` must have a bounded
+cost; moving work to one thread does not help if another startup step joins it
+through a lock. **Guard:** the publisher's first pass is asynchronous
+(`publisher.py`), and a blocking-producer test requires `start()` to return
+immediately. **Watch for:** new startup publishers or probes that call payload
+producers synchronously.
+
 ## 2026-08-26 · Logged in did not mean the exported usage token was fresh
 
 **What happened:** Claude kept working all evening while Fable alone became

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -808,6 +808,107 @@ class SessionStartTests(unittest.TestCase):
         self.assertIn("VibePulse startup health: SERVER UNAVAILABLE", context)
         self.assertNotIn(str(ROOT), context)
 
+    def test_startup_health_names_saved_codex_modes_that_hide_cards(self):
+        """The failure that looks exactly like a broken panel.
+
+        Bridge green, panel polling, and APPROVE / DENY never arriving —
+        because a setting on the user's computer suppressed it. The panel
+        cannot see that setting, so the hook is the only place that can say
+        so, and it must say so BEFORE reporting a reachable service healthy.
+        """
+        payload = {"hook_event_name": "SessionStart", "session_id": "s"}
+        root = {
+            "service": "torget-tokenserver",
+            "srcFingerprint": HOST_SOURCE_FINGERPRINT,
+            "interactions": {"codex": True,
+                             "panel": {"status": "ready", "ageS": 1}},
+        }
+        routes = {"/": {"body": compact(root).encode()},
+                  "/api/tokens": {"body": compact({}).encode()}}
+        cases = (
+            ('approval_policy = "never"\n'
+             'sandbox_mode = "workspace-write"\n',
+             "approval_policy is never"),
+            ('approval_policy = "on-request"\n'
+             'approvals_reviewer = "auto_review"\n'
+             'sandbox_mode = "workspace-write"\n',
+             "routed to auto_review"),
+            ('approval_policy = "on-request"\n'
+             'approvals_reviewer = "user"\n'
+             'sandbox_mode = "danger-full-access"\n',
+             "sandbox_mode is danger-full-access"),
+        )
+        for saved, expected in cases:
+            with self.subTest(expected=expected), \
+                    tempfile.TemporaryDirectory() as tmp:
+                Path(tmp, "config.toml").write_text(saved, encoding="utf-8")
+                with LocalServer(routes=routes) as server:
+                    completed = run_script(
+                        "session_start.py", compact(payload).encode(),
+                        port=server.port, env={"CODEX_HOME": tmp})
+                context = json.loads(completed.stdout)["hookSpecificOutput"][
+                    "additionalContext"]
+                self.assertIn("startup health: FIX", context)
+                self.assertIn(expected, context)
+
+    def test_startup_health_does_not_invent_a_codex_approval_problem(self):
+        """A healthy saved mode, and an absent config, must both stay quiet.
+
+        Most working installs have no config.toml at all, so treating its
+        absence as a fault would make the check noise people learn to skip —
+        the same cost as a false green, paid the other way round."""
+        payload = {"hook_event_name": "SessionStart", "session_id": "s"}
+        root = {
+            "service": "torget-tokenserver",
+            "srcFingerprint": HOST_SOURCE_FINGERPRINT,
+            "interactions": {"codex": True,
+                             "panel": {"status": "ready", "ageS": 1}},
+        }
+        routes = {"/": {"body": compact(root).encode()},
+                  "/api/tokens": {"body": compact({}).encode()}}
+        healthy = ('approval_policy = "on-request"\n'
+                   'approvals_reviewer = "user"\n'
+                   'sandbox_mode = "workspace-write"\n')
+        for label, write in (("healthy", healthy), ("absent", None)):
+            with self.subTest(config=label), \
+                    tempfile.TemporaryDirectory() as tmp:
+                if write is not None:
+                    Path(tmp, "config.toml").write_text(write,
+                                                        encoding="utf-8")
+                with LocalServer(routes=routes) as server:
+                    completed = run_script(
+                        "session_start.py", compact(payload).encode(),
+                        port=server.port, env={"CODEX_HOME": tmp})
+                context = json.loads(completed.stdout)["hookSpecificOutput"][
+                    "additionalContext"]
+                self.assertNotIn("approval_policy", context)
+                self.assertNotIn("sandbox_mode", context)
+
+    def test_a_table_header_ends_the_top_level_scan(self):
+        """`approval_policy` under a [table] belongs to that table, not to
+        the top level. Reading it anyway would invent a fault from a file
+        that is perfectly fine."""
+        payload = {"hook_event_name": "SessionStart", "session_id": "s"}
+        root = {
+            "service": "torget-tokenserver",
+            "srcFingerprint": HOST_SOURCE_FINGERPRINT,
+            "interactions": {"codex": True,
+                             "panel": {"status": "ready", "ageS": 1}},
+        }
+        routes = {"/": {"body": compact(root).encode()},
+                  "/api/tokens": {"body": compact({}).encode()}}
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "config.toml").write_text(
+                '[profiles.other]\napproval_policy = "never"\n',
+                encoding="utf-8")
+            with LocalServer(routes=routes) as server:
+                completed = run_script(
+                    "session_start.py", compact(payload).encode(),
+                    port=server.port, env={"CODEX_HOME": tmp})
+            context = json.loads(completed.stdout)["hookSpecificOutput"][
+                "additionalContext"]
+            self.assertNotIn("approval_policy is never", context)
+
     def test_startup_health_separates_device_path_from_provider_stale(self):
         payload = {"hook_event_name": "SessionStart", "session_id": "s"}
         root = {

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -47,6 +47,13 @@ TOKEN_SERVER_URL = "http://127.0.0.1:8737/"
 MAX_DIAGNOSTIC_BYTES = 16 * 1024
 MAX_COMMAND_OUTPUT_BYTES = 16 * 1024
 COMMAND_TIMEOUT_SECONDS = 15
+CODEX_CONFIG_MAX_BYTES = 64 * 1024
+# Only the three top-level string settings that decide whether a permission
+# card can reach a user at all. Anchored and quote-matched, so a value inside
+# a table further down the file is never read as a top-level one.
+_CODEX_STRING_SETTING = re.compile(
+    r'^[ \t]*(approval_policy|approvals_reviewer|sandbox_mode)[ \t]*='
+    r'[ \t]*(["\'])([^"\']*)\2[ \t]*(?:#.*)?$')
 NETWORK_TIMEOUT_SECONDS = 2
 PIPE_JOIN_TIMEOUT_SECONDS = 1
 _AUTO = object()
@@ -95,6 +102,69 @@ def default_config_path() -> Path:
         return base / "VibePulse" / "config.json"
     return (Path.home() / "Library" / "Application Support" / "VibePulse" /
             "config.json")
+
+
+def default_codex_config_path() -> Path:
+    """The saved Codex configuration, without ever writing to it."""
+    codex_home = os.environ.get("CODEX_HOME")
+    return ((Path(codex_home) if codex_home else Path.home() / ".codex") /
+            "config.toml")
+
+
+def _codex_permission_config_status(path: Path) -> tuple[bool | None, str]:
+    """Say whether saved Codex settings can surface a permission card.
+
+    This is the failure that looks exactly like a broken panel: the bridge
+    is green, the panel polls, and APPROVE / DENY never arrives, because a
+    setting on the user's computer suppressed it. The panel cannot see that
+    setting, so the doctor is the only place that can say so.
+
+    Reads NOTHING but the three mode names. Returns True (fine), False
+    (a named problem) or None (cannot tell) — the middle value matters,
+    because plenty of working installs have no config.toml at all and
+    guessing green there would be the same dishonesty in reverse.
+    """
+    try:
+        raw = Path(path).read_bytes()
+        if len(raw) > CODEX_CONFIG_MAX_BYTES:
+            raise ValueError("oversized config")
+        text = raw.decode("utf-8", errors="strict")
+    except FileNotFoundError:
+        return (None, "CHECK Codex approvals: no saved config.toml; verify "
+                "that /permissions is interactive")
+    except (OSError, UnicodeError, ValueError):
+        return (False, "FIX Codex approvals: saved config.toml is unreadable")
+
+    config = {}
+    for line in text.splitlines():
+        if line.lstrip().startswith("["):
+            break
+        match = _CODEX_STRING_SETTING.fullmatch(line)
+        if match is not None:
+            config[match.group(1)] = match.group(3)
+
+    if config.get("approval_policy") == "never":
+        return (False, "FIX Codex approvals: approval_policy=never prevents "
+                "permission cards; use on-request")
+    if config.get("approvals_reviewer") == "auto_review":
+        return (False, "FIX Codex approvals: approvals_reviewer=auto_review "
+                "routes decisions away from the user; use user")
+    if config.get("sandbox_mode") == "danger-full-access":
+        return (False, "FIX Codex approvals: sandbox_mode=danger-full-access "
+                "bypasses workspace permission boundaries; use "
+                "workspace-write")
+
+    policy = config.get("approval_policy")
+    reviewer = config.get("approvals_reviewer")
+    sandbox = config.get("sandbox_mode")
+    if (isinstance(policy, str) and policy in {"on-request", "untrusted"} and
+            (reviewer is None or reviewer == "user") and
+            isinstance(sandbox, str) and
+            sandbox in {"workspace-write", "read-only"}):
+        return (True, "PASS Codex approvals: saved policy can surface "
+                "permission cards")
+    return (None, "CHECK Codex approvals: verify the active mode with "
+            "/permissions")
 
 
 def plan_codex_install(
@@ -1440,6 +1510,7 @@ def _doctor(
         config: VibePulseConfig, *, python: Path | None, codex: Path | None,
         repo_root: Path, run: Callable[..., object],
         urlopen: Callable[..., object], stdout,
+        codex_config_path: Path | None = None,
         ) -> bool:
     fixes = False
 
@@ -1511,6 +1582,12 @@ def _doctor(
             fixes = True
 
     if config.codex_interactions:
+        approval_ok, approval_message = _codex_permission_config_status(
+            default_codex_config_path() if codex_config_path is None
+            else codex_config_path)
+        print(approval_message, file=stdout)
+        if approval_ok is False:
+            fixes = True
         print("FIX hooks: open /hooks and review VibePulse; trust status is "
               "not machine-readable", file=stdout)
         fixes = True


### PR DESCRIPTION
## Outcome

`doctor` and the Codex `SessionStart` health check now name the saved Codex setting that silently prevents approvals from ever reaching the panel.

Rescued from `niclas/wip/wifi-dma-calibration-20260904` before the branch audit recommends deleting it. The spec's hygiene snapshot named this as one of two things on that branch that never reached `main` — it was right, and it is worth more than the branch.

## Root cause / rationale

**The failure looks exactly like a broken panel.** The bridge is green, the panel polls, **APPROVE / DENY** never arrives — because `approval_policy = "never"`, `approvals_reviewer = "auto_review"` or `sandbox_mode = "danger-full-access"` means no permission event is created at all. Every component reports healthy because every component *is* healthy. The setting lives on the user's computer where the panel cannot see it, so the host is the only place that can say so.

The startup check runs it **before any HTTP**, deliberately: a suppressed approval mode makes every downstream reading look fine, so reporting a reachable service first would tell the user everything is well while nothing can reach them.

Three restraints worth reviewing:

- **It reads three names and nothing else** — never prompts, never history. This is someone's config file.
- **It stops at the first table header,** so `approval_policy` under `[profiles.other]` is not read as a top-level setting. Without that, a perfectly fine file invents a fault.
- **An absent `config.toml` stays quiet.** Most working installs have none, and a check that cries wolf gets skipped like any other — which costs the same as a false green, paid the other way round.

## What was deliberately left behind

Two `docs/lessons.md` entries come along — *"A ready sender did not mean a listening panel"* and *"A background warmup still blocked the listening socket"* — because I verified their guards are on `main`: `_panel_health_snapshot` in `GET /`, and the publisher's asynchronous first pass at `publisher.py:190`.

**The branch's third 2026-08-26 entry stays behind.** *"Cloud repair was neither a local command nor a warm deploy"* credits a 60-second cloud-only bound and `deploy --secrets-file`, and neither exists on `main` — I checked. A lesson describing a guard nobody has is exactly the documentation defect this repository keeps fixing, so it waits on the WIP branch until its guard lands. **That is a reason not to delete that branch yet**, and it is in the audit.

## Verification

- [x] Relevant focused tests pass — three new tests in `test/test_vibepulse_codex_plugin.py` (137 total, green): the three suppressing modes are each named; a healthy mode *and* an absent config both stay silent; and a value under a table header does not trigger it.
- [x] **Mutation-checked**: removing the startup call fails three tests; dropping the table-header `break` fails the one written for it. Restored, green.
- [x] `./test/run.sh` passes except its ESP-IDF step, which fails identically on a clean checkout here (missing toolchain, not a regression). Post-cutoff steps run separately with the exit code checked: 0.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included. The check reads three enum-like values and reports the *names*, never any content.
- [x] Documentation and changelog match the behavior — `docs/agent-setup.md` gains the prerequisite and a troubleshooting row; `CHANGELOG.md` and `docs/lessons.md` updated.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass.
- [x] No Windows-specific path is touched — `CODEX_HOME` and `~/.codex` behave the same everywhere.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed. Host-side only; nothing is drawn and no firmware source is touched.
- [x] No physical flash was requested, performed, or authorized.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

## Not tested / remaining risk

- **The mode names are read from a TOML file with a regex, not a TOML parser.** That is deliberate — the hook must stay dependency-free and bounded — but it means exotic-but-valid TOML (multi-line strings, inline tables, `approval_policy` spelled with a dotted key) is not understood. It fails *quiet*, never loud: an unparsed line simply is not read, so the worst case is the check saying nothing rather than saying something wrong.
- **Never run against a real Codex install in these modes.** The three cases are covered by fixtures written from the documented setting names; nobody has watched a real panel stay silent and then seen this line appear.
- **`approvals_reviewer` may not be a current Codex setting name.** It came with the salvaged code and I kept it, but I could not confirm it against current Codex documentation from here. Harmless if obsolete — an absent key is simply never matched — but worth a glance from someone with Codex in front of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE)_