### PR TITLE
test(docs): check the README's screenshots against what the panel draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,18 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 - **The screenshots in `docs/img/` are checked against the simulator.**
   `test/test_docs_frame_drift.py` compares every checked-in 480 × 480 frame
-  with what this build actually renders. It found that sixteen of the
-  twenty-nine still show the *previous* Wi-Fi indicator — a thick white fan
-  where the panel now draws a thin grey one — so README, `docs/wifi.md` and
-  the release bodies have been showing a screen this firmware cannot
-  produce. Five frames the simulator reproduces exactly are now pinned
-  byte-for-byte; the sixteen stale ones are quarantined by name *and* by a
-  digest of the file, so a frame cannot be waved into the quarantine by
-  adding a filename, and one already in it cannot quietly change.
-  Re-capturing them is a separate, deliberate documentation change.
+  with what this build actually renders, and the answer is blunt: of
+  twenty-nine frames it can verify **four**. The Wi-Fi indicator was redrawn
+  in `d5be82d` — a thick white fan became a thin grey one — and most frames
+  still show the old glyph, so README, `docs/wifi.md` and the release bodies
+  have been showing a screen this firmware cannot produce. The four the
+  simulator reproduces exactly are pinned byte-for-byte and rejected if they
+  gain a colour profile or EXIF orientation, which would change what a
+  browser paints without changing a pixel. The other twenty-five are
+  quarantined by name *and* by a digest of the file — including eight whose
+  indicator box is simply blank, which proves nothing either way and had
+  been passing silently. Re-capturing them is a separate, deliberate
+  documentation change.
 - **`doctor` and Codex startup health now name a saved Codex mode that
   silently prevents approvals from reaching the panel.** This is the failure
   that looks exactly like a broken panel: the bridge is green, the panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- **The screenshots in `docs/img/` are checked against the simulator.**
+  `test/test_docs_frame_drift.py` compares every checked-in 480 × 480 frame
+  with what this build actually renders. It found that sixteen of the
+  twenty-nine still show the *previous* Wi-Fi indicator — a thick white fan
+  where the panel now draws a thin grey one — so README, `docs/wifi.md` and
+  the release bodies have been showing a screen this firmware cannot
+  produce. Five frames the simulator reproduces exactly are now pinned
+  byte-for-byte; the sixteen stale ones are named in a list that may shrink
+  but never grow, so no new frame can drift in unnoticed. Re-capturing them
+  is a separate, deliberate documentation change.
 - **The KEY3 flow is tested as a journey, not only as a table.**
   `test/test_key3_arbitration.c` pins eight invariants separately, which is
   the right shape for them — but every cell in that table is set up by hand,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   where the panel now draws a thin grey one — so README, `docs/wifi.md` and
   the release bodies have been showing a screen this firmware cannot
   produce. Five frames the simulator reproduces exactly are now pinned
-  byte-for-byte; the sixteen stale ones are named in a list that may shrink
-  but never grow, so no new frame can drift in unnoticed. Re-capturing them
-  is a separate, deliberate documentation change.
+  byte-for-byte; the sixteen stale ones are quarantined by name *and* by a
+  digest of the file, so a frame cannot be waved into the quarantine by
+  adding a filename, and one already in it cannot quietly change.
+  Re-capturing them is a separate, deliberate documentation change.
 - **`doctor` and Codex startup health now name a saved Codex mode that
   silently prevents approvals from reaching the panel.** This is the failure
   that looks exactly like a broken panel: the bridge is green, the panel

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,33 @@ point at the backlog item.
 
 ---
 
+## 2026-09-05 · Pinning a screenshot's size did not pin its content
+
+**What happened:** the global Wi-Fi indicator was redrawn — a thick,
+bright-white fan became a thin, muted-grey one, from a different asset at a
+different offset — and sixteen of the twenty-nine simulator frames checked
+into `docs/img/` kept showing the old glyph. README, `docs/wifi.md` and the
+release bodies have shown a panel this firmware cannot draw ever since.
+**Root cause:** the only guard those files had
+(`test/test_wifi_setup_wiring.py`) asserted they exist, are PNG, are
+480 × 480 and are referenced from the README. All four stayed true through
+the redraw. A picture's dimensions are not its content, and nothing looked
+at a pixel. **The rule now:** a checked-in frame is either reproduced
+byte-for-byte by a capture the simulator still produces, or its name is on a
+list of frames that are not — and that list may shrink, never grow.
+**Guards:** `test/test_docs_frame_drift.py`. `PINNED` compares five frames
+byte-for-byte against a named capture; for the rest, the indicator's own
+20 × 18 rectangle — the one region the firmware decides alone, identical
+across 114 captures — must match a rendering the QA sets still produce, and
+`STALE_CHROME` names the sixteen that do not. Mutation-checked: a one-pixel
+edit, the old glyph pasted into a clean frame, a name struck off the list, a
+phantom name added, and both QA modes producing nothing each fail it.
+**Watch for:** the sixteen are still stale. Re-capturing one changes what
+the README *shows* — a different fixture tells a different story on the
+glass — so it is a documentation decision, not a test fix.
+
+---
+
 ## 2026-09-05 · A QR code that outlived its access point
 
 **What happened:** the WiFi setup window's QR stayed on screen after the

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -37,8 +37,12 @@ release bodies have shown a panel this firmware cannot draw ever since.
 480 × 480 and are referenced from the README. All four stayed true through
 the redraw. A picture's dimensions are not its content, and nothing looked
 at a pixel. **The rule now:** a checked-in frame is either reproduced
-byte-for-byte by a capture the simulator still produces, or its name is on a
-list of frames that are not — and that list may shrink, never grow.
+byte-for-byte by a capture the simulator still produces, or it is quarantined
+by name *and* by a digest of its file. The first version quarantined by name
+alone, and Codex was right that this enforced nothing — adding a filename was
+enough to wave a new stale frame through. No test can stop someone editing a
+constant; the digest makes the edit cost a 64-character hash a reviewer sees,
+and freezes what is already quarantined.
 **Guards:** `test/test_docs_frame_drift.py`. `PINNED` compares five frames
 byte-for-byte against a named capture; for the rest, the indicator's own
 20 × 18 rectangle — the one region the firmware decides alone, identical

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -43,16 +43,19 @@ alone, and Codex was right that this enforced nothing — adding a filename was
 enough to wave a new stale frame through. No test can stop someone editing a
 constant; the digest makes the edit cost a 64-character hash a reviewer sees,
 and freezes what is already quarantined.
-**Guards:** `test/test_docs_frame_drift.py`. `PINNED` compares five frames
-byte-for-byte against a named capture; for the rest, the indicator's own
-20 × 18 rectangle — the one region the firmware decides alone, identical
-across 114 captures — must match a rendering the QA sets still produce, and
-`STALE_CHROME` names the sixteen that do not. Mutation-checked: a one-pixel
-edit, the old glyph pasted into a clean frame, a name struck off the list, a
-phantom name added, and both QA modes producing nothing each fail it.
-**Watch for:** the sixteen are still stale. Re-capturing one changes what
-the README *shows* — a different fixture tells a different story on the
-glass — so it is a documentation decision, not a test fix.
+**Guards:** `test/test_docs_frame_drift.py`. `PINNED` compares four frames
+byte-for-byte against a named capture; every other frame's Wi-Fi indicator
+box must match a rendering the simulator still draws, and `STALE_CHROME`
+names the twenty-five that cannot be confirmed. Two further traps found by
+review and worth remembering: a **blank** indicator box proves nothing on an
+unpinned frame (a takeover hides the header, and so does a capture predating
+the indicator), and `--vibepulse-pulse-qa` / `--vibepulse-completion-qa`
+never set the status to `NORMAL`, so every capture they write is blank — the
+same tag has 56 indicator pixels under static QA and 0 under completion QA.
+Feeding those modes into the allowed set imports blanks the panel never
+draws. **Watch for:** twenty-five frames still unverified. Re-capturing one
+changes what the README *shows* — a different fixture tells a different
+story on the glass — so it is a documentation decision, not a test fix.
 
 ---
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -23,10 +23,14 @@ point at the backlog item.
 
 ## 2026-09-05 · Pinning a screenshot's size did not pin its content
 
-**What happened:** the global Wi-Fi indicator was redrawn — a thick,
-bright-white fan became a thin, muted-grey one, from a different asset at a
-different offset — and sixteen of the twenty-nine simulator frames checked
-into `docs/img/` kept showing the old glyph. README, `docs/wifi.md` and the
+**What happened:** the global Wi-Fi indicator was redrawn in `d5be82d`
+(2026-08-22), which deleted the Font Awesome glyph font
+`platform/fonts/torget_wifi_22.c` and replaced it with the generated
+`platform/wifi_status_assets.c` — a thick, bright-white fan became a thin,
+muted-grey one at a different offset — and `be29dba` the same day made it
+two-state. Sixteen of the twenty-nine simulator frames checked into
+`docs/img/` still show the old glyph; the two Wi-Fi onboarding images date
+from `1b6ba3a`, the day before. README, `docs/wifi.md` and the
 release bodies have shown a panel this firmware cannot draw ever since.
 **Root cause:** the only guard those files had
 (`test/test_wifi_setup_wiring.py`) asserted they exist, are PNG, are

--- a/test/run.sh
+++ b/test/run.sh
@@ -328,6 +328,7 @@ cd ..
 "$PYTHON_BIN" tools/vibepulse_studio/design.py --check
 "$PYTHON_BIN" test/test_vibepulse_studio_wiring.py
 "$PYTHON_BIN" test/test_vibepulse_visual_landmarks.py
+"$PYTHON_BIN" test/test_docs_frame_drift.py
 "$PYTHON_BIN" test/test_shared_amoled_skill.py
 "$PYTHON_BIN" test/test_token_body_capacity.py
 "$PYTHON_BIN" test/test_agent_status_body_capacity.py

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -180,6 +180,21 @@ STALE_CHROME = {
 DISPLAY_METADATA = ("icc_profile", "exif", "gamma", "srgb", "chromaticity")
 
 
+# The images under docs/img that are NOT panel captures, each named with the
+# reason. Anything else must be 480x480: an earlier version simply skipped
+# whatever was not, which Codex pointed out is a hole rather than a filter —
+# a new README screenshot at the wrong size would vanish from every test in
+# this file and CI would stay green. Named, a stray file fails; skipped, it
+# is invisible. The distinction is the whole difference between a filter and
+# a blind spot.
+NOT_FRAMES = {
+    "github/glass-live.png": "a photograph of the physical panel",
+    "hero.png": "the README banner, a composed graphic",
+    "qr-repo.png": "a QR code, not a screen",
+    "social-preview.png": "the repository's social card",
+}
+
+
 def docs_frames():
     """Every checked-in 480x480 simulator capture, by path under docs/img.
 
@@ -191,12 +206,10 @@ def docs_frames():
     img = ROOT / "docs/img"
     for path in sorted(img.rglob("*.png")):
         rel = path.relative_to(img)
-        if rel.parts[0] == "mockups":
+        name = rel.as_posix()
+        if rel.parts[0] == "mockups" or name in NOT_FRAMES:
             continue
-        with Image.open(path) as im:
-            if im.size != (480, 480):
-                continue
-        yield rel.as_posix(), path
+        yield name, path
 
 
 def indicator(image):
@@ -386,6 +399,38 @@ class DocsFrameDriftTests(unittest.TestCase):
         """A frame cannot be both reproduced exactly and unverifiable; if it
         ever is, one of the two lists is lying."""
         self.assertEqual(sorted(set(PINNED) & set(STALE_CHROME)), [])
+
+    def test_every_image_is_a_frame_or_a_named_exception(self):
+        """The filter that was a hole. Skipping anything not 480x480 meant a
+        new README screenshot at the wrong size joined no list, faced no
+        check, and left CI green — the failure mode this whole file exists to
+        prevent, reintroduced by the function that gathers its inputs.
+
+        Now the four non-captures are named with reasons and everything else
+        must be panel-sized. A stray graphic fails here instead of vanishing.
+        """
+        img = ROOT / "docs/img"
+        wrong = []
+        for path in sorted(img.rglob("*.png")):
+            rel = path.relative_to(img)
+            name = rel.as_posix()
+            if rel.parts[0] == "mockups" or name in NOT_FRAMES:
+                continue
+            with Image.open(path) as im:
+                if im.size != (480, 480):
+                    wrong.append(f"{name} is {im.size[0]}x{im.size[1]}")
+        self.assertEqual(wrong, [], "\n".join(
+            ["not a 480x480 panel capture. If it is not a screenshot, add it "
+             "to NOT_FRAMES with the reason; if it is, re-capture it:"]
+            + wrong))
+
+    def test_the_named_exceptions_all_exist(self):
+        """A renamed or deleted exception would silently widen NOT_FRAMES
+        into a place to park anything."""
+        for name in sorted(NOT_FRAMES):
+            with self.subTest(name=name):
+                self.assertTrue((ROOT / "docs/img" / name).is_file(),
+                                f"NOT_FRAMES names {name}, which is not there")
 
     def test_every_frame_is_accounted_for(self):
         """No third category. A frame that is neither pinned nor quarantined

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -199,6 +199,29 @@ NOT_FRAMES = {
 }
 
 
+def docs_images():
+    """EVERY file under docs/img except the concept art, whatever it is.
+
+    Not rglob("*.png"), which was the previous version and a hole of exactly
+    the shape this file keeps finding: a capture saved as JPEG, WebP or —
+    trivially, on a case-sensitive filesystem — `.PNG` matched no glob, so it
+    could be linked from the README at any size with any content while every
+    test here stayed green. A discovery pass that decides what to look at by
+    file extension is choosing what it is willing to find.
+
+    So the extension is not a filter here; it is something to CHECK. Anything
+    that is not a lowercase .png fails below, by name, instead of vanishing.
+    """
+    img = ROOT / "docs/img"
+    for path in sorted(img.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(img)
+        if rel.parts[0] == "mockups":
+            continue
+        yield rel.as_posix(), path
+
+
 def docs_frames():
     """Every checked-in 480x480 simulator capture, by path under docs/img.
 
@@ -207,11 +230,8 @@ def docs_frames():
     needs-you/vibepulse-needs-you-none.png joined the quarantine after being
     missed by hand.
     """
-    img = ROOT / "docs/img"
-    for path in sorted(img.rglob("*.png")):
-        rel = path.relative_to(img)
-        name = rel.as_posix()
-        if rel.parts[0] == "mockups" or name in NOT_FRAMES:
+    for name, path in docs_images():
+        if name in NOT_FRAMES or path.suffix != ".png":
             continue
         yield name, path
 
@@ -427,6 +447,30 @@ class DocsFrameDriftTests(unittest.TestCase):
         ever is, one of the two lists is lying."""
         self.assertEqual(sorted(set(PINNED) & set(STALE_CHROME)), [])
 
+    def test_every_file_under_docs_img_is_a_png_or_a_named_exception(self):
+        """The extension check that used to be an extension filter.
+
+        A panel capture is a lossless PNG: the simulator writes one, the
+        comparisons above are byte-exact, and a JPEG could never satisfy them
+        even when it looks identical. So a non-PNG here is either a mistake or
+        something that is not a capture — and either way it must say so out
+        loud rather than slip past a glob.
+
+        `.PNG` in capitals is the cheap case and the one that makes this more
+        than theory: it is a different string to a glob and the same file to
+        every browser.
+        """
+        wrong = []
+        for name, path in docs_images():
+            if name in NOT_FRAMES:
+                continue
+            if path.suffix != ".png":
+                wrong.append(f"{name} is {path.suffix or 'extensionless'}")
+        self.assertEqual(wrong, [], "\n".join(
+            ["panel captures must be lowercase-.png. If this is not a "
+             "capture, name it in NOT_FRAMES with the reason:"]
+            + wrong))
+
     def test_every_image_is_a_frame_or_a_named_exception(self):
         """The filter that was a hole. Skipping anything not 480x480 meant a
         new README screenshot at the wrong size joined no list, faced no
@@ -436,13 +480,10 @@ class DocsFrameDriftTests(unittest.TestCase):
         Now the four non-captures are named with reasons and everything else
         must be panel-sized. A stray graphic fails here instead of vanishing.
         """
-        img = ROOT / "docs/img"
         wrong = []
-        for path in sorted(img.rglob("*.png")):
-            rel = path.relative_to(img)
-            name = rel.as_posix()
-            if rel.parts[0] == "mockups" or name in NOT_FRAMES:
-                continue
+        for name, path in docs_images():
+            if name in NOT_FRAMES or path.suffix != ".png":
+                continue  # a non-PNG is reported by its own test above
             with Image.open(path) as im:
                 if im.size != (480, 480):
                     wrong.append(f"{name} is {im.size[0]}x{im.size[1]}")

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""The frames in docs/img must still be frames this firmware renders.
+
+README.md, docs/wifi.md and the release bodies show 480x480 simulator
+captures. Nothing checked that they still resemble the panel. They drifted,
+and the drift is the invisible kind: the picture stays plausible, so nobody
+re-reads it, and a reader ends up trusting a screenshot of a build that no
+longer exists.
+
+WHAT ACTUALLY HAPPENED, since a guard written from a hypothesis is worth
+little. The global Wi-Fi indicator (platform/torget_ui.c, `wifi_status_*`)
+was redrawn: a thick bright-white fan became a thin muted-grey one, drawn
+from a different asset at a different offset. Fifteen of the twenty-three
+checked-in simulator frames still show the old glyph — including the three
+Wi-Fi onboarding images that test_wifi_setup_wiring.py already pins by size
+and by their presence in the README. Pinning a picture's dimensions does not
+pin its content, and the redraw walked straight through that gap.
+
+TWO CHECKS, because one is exact and the other is possible.
+
+PINNED — a frame the current simulator reproduces byte for byte is compared
+byte for byte. That is the whole guard for those, and it is total: any
+future change to the page shell, the fonts, the palette or the layout breaks
+it. Only five frames qualify today.
+
+CHROME — the other eighteen were captured from ad-hoc simulator states (a
+different fixture, a different tile, a different signal strength) that no
+pinned capture set reproduces, so there is no image to compare them against.
+What CAN be compared is the one rectangle whose content is decided by the
+firmware alone and not by the fixture: the Wi-Fi indicator's own 20x18 box.
+Across the 153 captures the QA sets produce, that rectangle takes exactly
+six renderings; a checked-in frame showing something else is showing a panel
+this build cannot draw.
+
+THE QUARANTINE SHRINKS, NEVER GROWS. STALE_CHROME lists the frames that fail
+CHROME today, and the test asserts the failures are exactly that list. So a
+NEW stale frame fails, and re-capturing an old one also fails until its name
+is struck off — which is the point: the list is the outstanding work, and it
+has to be spent deliberately rather than left to rot quietly.
+
+Deliberately NOT covered: docs/img/mockups/, which are concept art from
+tools/mockups/gen_concept_mockups.py and never claimed to be captures, and
+docs/img/github/glass-live.png, a photograph of the physical panel.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from PIL import Image, ImageChops
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The QA modes that between them produce every capture a docs frame is
+# compared against. --vibepulse-pulse-qa is here for one frame only
+# (vibepulse-needs-you.png is its t0 bright tick), which is exactly why it
+# has to be named: without it that frame silently drops to "unpinned".
+QA_MODES = ("--vibepulse-static-qa", "--vibepulse-pulse-qa")
+
+# platform/torget_ui.c: wifi_status_create() places the group at (426, 28)
+# and sizes it 20x18. The rectangle holds the glyph and nothing else — all
+# 114 ordinary app captures render it identically — so a mismatch is the
+# indicator, not the page behind it.
+WIFI_BOX = (426, 28, 426 + 20, 28 + 18)
+
+# Frames the simulator reproduces exactly. Byte-for-byte or the test fails.
+PINNED = {
+    "vibepulse-settings-menu.png": "torget-settings-menu.bmp",
+    "vibepulse-settings-about.png": "torget-settings-about-found.bmp",
+    "vibepulse-settings-no-address.png": "torget-settings-menu-no-address.bmp",
+    "vibepulse-wifi-setup.png": "torget-wifi-setup-open.bmp",
+    "vibepulse-needs-you.png": "torget-vibepulse-pulse-t0-bright.bmp",
+}
+
+# Frames still showing the pre-redraw Wi-Fi indicator. Re-capturing one is a
+# documentation change with a visible result — a different fixture tells a
+# different story on the glass — so it is the maintainer's call which capture
+# replaces which, not this test's. Strike a name off when its frame is
+# re-captured; never add one to make a red run go green.
+STALE_CHROME = {
+    "github/sim-cached.png",
+    "github/sim-live.png",
+    "github/sim-missing.png",
+    "needs-you/vibepulse-needs-you-none.png",
+    "vibepulse-agent-working.png",
+    "vibepulse-burn-rate.png",
+    "vibepulse-claude-week.png",
+    "vibepulse-codex-week.png",
+    "vibepulse-max-tracker-claude.png",
+    "vibepulse-max-tracker.png",
+    "vibepulse-needs-you-codex-approval.png",
+    "vibepulse-needs-you-codex-question.png",
+    "vibepulse-no-data.png",
+    "vibepulse-value-ahead.png",
+    "vibepulse-wifi-searching.png",
+    "vibepulse-wifi-signal.png",
+}
+
+
+def docs_frames():
+    """Every checked-in 480x480 simulator capture, by path under docs/img.
+
+    Discovered rather than listed: a frame added to the README tomorrow must
+    face this guard without anyone remembering to enrol it.
+    """
+    img = ROOT / "docs/img"
+    for path in sorted(img.rglob("*.png")):
+        rel = path.relative_to(img)
+        if rel.parts[0] == "mockups":
+            continue
+        with Image.open(path) as im:
+            if im.size != (480, 480):
+                continue
+        yield rel.as_posix(), path
+
+
+class DocsFrameDriftTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="vibepulse-docs-frames-")
+        cls.capture_dir = Path(cls.temp.name)
+        for argv in (["cmake", "-S", "sim", "-B", "sim/build", "-G", "Ninja"],
+                     ["cmake", "--build", "sim/build"]):
+            subprocess.run(argv, cwd=ROOT, check=True, text=True,
+                           capture_output=True)
+        for mode in QA_MODES:
+            subprocess.run(
+                [str(ROOT / "sim/build/torget-sim"), mode],
+                cwd=ROOT,
+                env={**os.environ, "TORGET_CAPTURE_DIR": str(cls.capture_dir)},
+                check=True, text=True, capture_output=True)
+        cls.captures = sorted(cls.capture_dir.glob("*.bmp"))
+        cls.frames = list(docs_frames())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temp.cleanup()
+
+    def test_the_capture_sets_actually_ran(self):
+        """Both QA modes writing nothing would make every other test in this
+        file pass vacuously — an empty allowed-set rejects nothing only if
+        the tests below are written to notice, so notice here instead."""
+        self.assertGreater(len(self.captures), 100,
+                           "the QA modes produced almost no captures")
+        self.assertTrue(self.frames, "found no 480x480 frames under docs/img")
+
+    def test_pinned_frames_are_byte_identical_to_their_capture(self):
+        names = {path.name for path in self.captures}
+        for frame, capture in sorted(PINNED.items()):
+            with self.subTest(frame=frame):
+                self.assertIn(capture, names,
+                              f"{frame} is pinned to a capture the QA modes "
+                              f"no longer produce: {capture}")
+                with Image.open(ROOT / "docs/img" / frame) as a, \
+                        Image.open(self.capture_dir / capture) as b:
+                    diff = ImageChops.difference(a.convert("RGB"),
+                                                 b.convert("RGB"))
+                    self.assertIsNone(
+                        diff.getbbox(),
+                        f"{frame} no longer matches {capture}. The panel "
+                        f"changed and the documentation did not: re-capture "
+                        f"the frame in the same commit as the change.")
+
+    def test_every_frame_shows_a_wifi_indicator_this_build_can_draw(self):
+        allowed = set()
+        for path in self.captures:
+            with Image.open(path) as im:
+                allowed.add(im.convert("RGB").crop(WIFI_BOX).tobytes())
+        self.assertTrue(allowed)
+
+        stale = set()
+        for frame, path in self.frames:
+            with Image.open(path) as im:
+                if im.convert("RGB").crop(WIFI_BOX).tobytes() not in allowed:
+                    stale.add(frame)
+
+        new = sorted(stale - STALE_CHROME)
+        fixed = sorted(STALE_CHROME - stale)
+        self.assertEqual(stale, STALE_CHROME, "\n".join(
+            [""]
+            + [f"  NEW stale frame: {n} — it shows a Wi-Fi indicator this "
+               f"build does not draw. Re-capture it." for n in new]
+            + [f"  no longer stale: {f} — remove it from STALE_CHROME."
+               for f in fixed]))
+
+    def test_the_quarantine_names_only_real_frames(self):
+        """A typo, or a frame someone deleted, would park a name in
+        STALE_CHROME forever and quietly shrink what the guard covers."""
+        known = {frame for frame, _ in self.frames}
+        self.assertEqual(sorted(STALE_CHROME - known), [])
+        self.assertEqual(sorted(set(PINNED) - known), [])
+
+    def test_pinned_and_quarantined_do_not_overlap(self):
+        """A frame cannot be both reproduced exactly and drawing obsolete
+        chrome; if it ever is, one of the two lists is lying."""
+        self.assertEqual(sorted(set(PINNED) & STALE_CHROME), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -179,6 +179,10 @@ STALE_CHROME = {
 # README rendered the picture differently.
 DISPLAY_METADATA = ("icc_profile", "exif", "gamma", "srgb", "chromaticity")
 
+# Animation lives outside DISPLAY_METADATA because it is not a chunk that
+# recolours a still: it means the comparison examined one frame of several.
+# Guarded separately, and for every frame rather than only the pinned ones.
+
 
 # The images under docs/img that are NOT panel captures, each named with the
 # reason. Anything else must be 480x480: an earlier version simply skipped
@@ -292,6 +296,29 @@ class DocsFrameDriftTests(unittest.TestCase):
                         f"{frame} has transparent pixels. A panel capture is "
                         f"opaque; alpha here would be dropped unnoticed by "
                         f"the comparisons below.")
+
+    def test_no_frame_is_animated(self):
+        """Third of the same family, after alpha and colour metadata: the
+        comparison sees less than a renderer does.
+
+        Image.open() stays on frame zero, so an APNG whose first frame
+        matches the capture passes while every later frame — the ones a
+        browser actually plays — is never looked at. n_frames is also not a
+        chunk the metadata check knows about, so nothing else caught it.
+
+        Applied to every frame, not only the pinned ones: a quarantined
+        frame's digest would catch it changing, but a NEW frame arriving
+        animated should fail on what it is rather than on a hash nobody has
+        recorded yet. And a panel capture is one still image by definition —
+        the simulator writes single-frame BMPs.
+        """
+        for frame, path in self.frames:
+            with self.subTest(frame=frame):
+                with Image.open(path) as im:
+                    self.assertEqual(
+                        getattr(im, "n_frames", 1), 1,
+                        f"{frame} is animated. Only its first frame would be "
+                        f"compared, so the rest ships unchecked.")
 
     def test_pinned_frames_carry_no_display_affecting_metadata(self):
         """Scoped to PINNED because that is where the word "exact" is used.

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -32,11 +32,22 @@ Across the 153 captures the QA sets produce, that rectangle takes exactly
 six renderings; a checked-in frame showing something else is showing a panel
 this build cannot draw.
 
-THE QUARANTINE SHRINKS, NEVER GROWS. STALE_CHROME lists the frames that fail
-CHROME today, and the test asserts the failures are exactly that list. So a
-NEW stale frame fails, and re-capturing an old one also fails until its name
-is struck off — which is the point: the list is the outstanding work, and it
-has to be spent deliberately rather than left to rot quietly.
+THE QUARANTINE, AND WHAT IT ACTUALLY GUARANTEES. STALE_CHROME maps each
+frame that fails CHROME today to a digest of its file, and the test asserts
+both that the failures are exactly those frames and that each is still the
+file that was reviewed. A NEW stale frame fails, and re-capturing an old one
+fails until its entry is struck off.
+
+The first version of this list held filenames only, and the honest reading —
+Codex's, on the PR — is that it did not enforce the rule it advertised: add
+the new frame's name and everything passes again. Nothing in a repository
+can stop someone editing a constant, and claiming otherwise is the mistake
+AGENTS.md records about a merge block that was never there. What the digest
+changes is the price: quarantining a new frame now costs a filename AND a
+64-character hash of that exact file, which a reviewer sees. And it freezes
+what is already here — a quarantined frame cannot quietly become different
+stale art, and re-capturing one has exactly one correct resolution, which is
+to delete its entry rather than update its hash.
 
 Deliberately NOT covered: docs/img/mockups/, which are concept art from
 tools/mockups/gen_concept_mockups.py and never claimed to be captures, and
@@ -45,6 +56,7 @@ docs/img/github/glass-live.png, a photograph of the physical panel.
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 import subprocess
@@ -77,28 +89,59 @@ PINNED = {
     "vibepulse-needs-you.png": "torget-vibepulse-pulse-t0-bright.bmp",
 }
 
-# Frames still showing the pre-redraw Wi-Fi indicator. Re-capturing one is a
-# documentation change with a visible result — a different fixture tells a
-# different story on the glass — so it is the maintainer's call which capture
-# replaces which, not this test's. Strike a name off when its frame is
-# re-captured; never add one to make a red run go green.
+# Frames still showing the pre-redraw Wi-Fi indicator, each frozen at the
+# exact bytes that were reviewed.
+#
+# A NAME ALONE WOULD NOT BE A RATCHET. This started as a set of filenames,
+# and Codex was right to call that out: a contributor who adds a new stale
+# frame could add its name here and every test would pass again, so the
+# "may shrink, never grow" rule was a comment, not a check — the same shape
+# of mistake AGENTS.md records about promising a merge block that did not
+# exist. Nothing in a repository can stop someone editing a constant. What a
+# digest buys is that quarantining a NEW frame now costs a filename *and* a
+# 64-character hash of that specific file, which is a visible, deliberate
+# act in a diff rather than a one-word addition to a list.
+#
+# It also freezes what is quarantined. A frame here cannot be swapped for
+# different stale art, and re-capturing one breaks its digest — which is the
+# intended exit: the fix is to delete the entry, not to update the hash.
+#
+# Re-capturing is a documentation change with a visible result — a different
+# fixture tells a different story on the glass — so which capture replaces
+# which is the maintainer's call, not this test's.
 STALE_CHROME = {
-    "github/sim-cached.png",
-    "github/sim-live.png",
-    "github/sim-missing.png",
-    "needs-you/vibepulse-needs-you-none.png",
-    "vibepulse-agent-working.png",
-    "vibepulse-burn-rate.png",
-    "vibepulse-claude-week.png",
-    "vibepulse-codex-week.png",
-    "vibepulse-max-tracker-claude.png",
-    "vibepulse-max-tracker.png",
-    "vibepulse-needs-you-codex-approval.png",
-    "vibepulse-needs-you-codex-question.png",
-    "vibepulse-no-data.png",
-    "vibepulse-value-ahead.png",
-    "vibepulse-wifi-searching.png",
-    "vibepulse-wifi-signal.png",
+    "github/sim-cached.png":
+        "371cfc2168bf7d6f85a3e8a83ac6848cdb12ce1a79a2b19a2d634087696ad7dc",
+    "github/sim-live.png":
+        "19a106e5ff938dbbe1314ef7e93208f1d12c384b78cd441dc7c05d38d202f351",
+    "github/sim-missing.png":
+        "709d96c2c720510ceced9bca4dd41d615c21bfbd26e217605dbe6db934ada342",
+    "needs-you/vibepulse-needs-you-none.png":
+        "ba8b6cae7e893909b5fefb38029133a314ad9e5c68534a96957de5992fd1805a",
+    "vibepulse-agent-working.png":
+        "3f2adbdf5020050c307120ce26d4af0a94af06defcc630fe91b57efeae6841b4",
+    "vibepulse-burn-rate.png":
+        "ced77198dbb1086e5fb68d04a85b980c08e7e71a9ad2f97ead524ccf70dfc0b3",
+    "vibepulse-claude-week.png":
+        "f5e0f17b4d437b864c79e0674e17f35860699c9e7ff8465e28328873ddd4bc65",
+    "vibepulse-codex-week.png":
+        "91be52589635e467cad6dbc62266676e958c94e81d891dedb99ba9ff946080c4",
+    "vibepulse-max-tracker-claude.png":
+        "fc07fcd17951e668d6d6014878e65367f7c38e58a9393ba6a250732b389e3c84",
+    "vibepulse-max-tracker.png":
+        "bbc2f49fb7a7f7afd4e8fafe96dadd881df6168ae34bc765da9a6719ab48d637",
+    "vibepulse-needs-you-codex-approval.png":
+        "7f661a322aca5cea0f2645feffed6deba6a326936af9072ff2c97196105f78c0",
+    "vibepulse-needs-you-codex-question.png":
+        "4fd9fd20759c51bf29a8e6fb336033f43db27cd6b1ca0532df712c41f96e2406",
+    "vibepulse-no-data.png":
+        "a70d4683b44819d3c3a40f34a74ef2ec69b125b668c254a2e469fc7794e241fb",
+    "vibepulse-value-ahead.png":
+        "5e82b9c09c39f03bddcd1091b19bba91f092ac25acf8f8155a4764698b5dfc91",
+    "vibepulse-wifi-searching.png":
+        "7f250af04f810ae0966f27be9a29e0bfdb275d097a3757b6f30360aa9aaa532c",
+    "vibepulse-wifi-signal.png":
+        "fd1fff6f8e42157a2143cd3c3fb66ae4ed125ffc72426e0d21f01dfc365ea66b",
 }
 
 
@@ -179,26 +222,60 @@ class DocsFrameDriftTests(unittest.TestCase):
                 if im.convert("RGB").crop(WIFI_BOX).tobytes() not in allowed:
                     stale.add(frame)
 
-        new = sorted(stale - STALE_CHROME)
-        fixed = sorted(STALE_CHROME - stale)
-        self.assertEqual(stale, STALE_CHROME, "\n".join(
+        new = sorted(stale - set(STALE_CHROME))
+        fixed = sorted(set(STALE_CHROME) - stale)
+        self.assertEqual(stale, set(STALE_CHROME), "\n".join(
             [""]
             + [f"  NEW stale frame: {n} — it shows a Wi-Fi indicator this "
                f"build does not draw. Re-capture it." for n in new]
             + [f"  no longer stale: {f} — remove it from STALE_CHROME."
                for f in fixed]))
 
+    def test_each_quarantined_frame_is_frozen_at_the_reviewed_bytes(self):
+        """The half that makes the quarantine cost something.
+
+        Without it, STALE_CHROME is a list of filenames and adding one entry
+        is enough to wave a brand-new stale frame past every check — the rule
+        would live in a comment instead of in the run. With it, quarantining
+        a frame costs its digest too, and a quarantined frame is pinned as
+        hard as a PINNED one: it cannot be swapped for different stale art,
+        and re-capturing it fails here. That failure has ONE correct answer —
+        delete the entry — because a re-captured frame is no longer stale.
+        Updating the hash to make this pass puts the frame back in quarantine
+        it no longer belongs in.
+        """
+        for frame, path in self.frames:
+            expected = STALE_CHROME.get(frame)
+            if expected is None:
+                continue
+            with self.subTest(frame=frame):
+                actual = hashlib.sha256(path.read_bytes()).hexdigest()
+                self.assertEqual(
+                    actual, expected,
+                    f"{frame} changed while quarantined. If you re-captured "
+                    f"it, delete its STALE_CHROME entry — do not update the "
+                    f"digest.")
+
     def test_the_quarantine_names_only_real_frames(self):
         """A typo, or a frame someone deleted, would park a name in
         STALE_CHROME forever and quietly shrink what the guard covers."""
         known = {frame for frame, _ in self.frames}
-        self.assertEqual(sorted(STALE_CHROME - known), [])
+        self.assertEqual(sorted(set(STALE_CHROME) - known), [])
         self.assertEqual(sorted(set(PINNED) - known), [])
+
+    def test_every_digest_is_a_digest(self):
+        """A truncated or placeholder value would make the freeze check pass
+        on nothing while looking like it was doing its job."""
+        for frame, digest in sorted(STALE_CHROME.items()):
+            with self.subTest(frame=frame):
+                self.assertRegex(digest, r"\A[0-9a-f]{64}\Z")
+        self.assertEqual(len(set(STALE_CHROME.values())), len(STALE_CHROME),
+                         "two quarantined frames share a digest")
 
     def test_pinned_and_quarantined_do_not_overlap(self):
         """A frame cannot be both reproduced exactly and drawing obsolete
         chrome; if it ever is, one of the two lists is lying."""
-        self.assertEqual(sorted(set(PINNED) & STALE_CHROME), [])
+        self.assertEqual(sorted(set(PINNED) & set(STALE_CHROME)), [])
 
 
 if __name__ == "__main__":

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -459,16 +459,37 @@ class DocsFrameDriftTests(unittest.TestCase):
         `.PNG` in capitals is the cheap case and the one that makes this more
         than theory: it is a different string to a glob and the same file to
         every browser.
+
+        And the name is checked separately from the CONTENT, because they are
+        two different claims and the first version only made one. Lossless
+        TIFF data saved under a .png name decodes to identical pixels, size,
+        opacity and frame count — every comparison in this file passes — while
+        a browser shows a broken image. Reading the suffix was reading the
+        label on the tin.
         """
         wrong = []
         for name, path in docs_images():
             if name in NOT_FRAMES:
                 continue
             if path.suffix != ".png":
-                wrong.append(f"{name} is {path.suffix or 'extensionless'}")
+                wrong.append(f"{name} is named {path.suffix or 'nothing'}")
+                continue
+            # And the NAME is not the format. TIFF data under a .png name
+            # decodes to identical pixels, dimensions, opacity and frame
+            # count, so every comparison in this file passes while a browser
+            # renders nothing. Checking the suffix was checking the label on
+            # the tin.
+            try:
+                with Image.open(path) as im:
+                    fmt = im.format
+            except Exception as exc:                     # noqa: BLE001
+                wrong.append(f"{name} will not open as an image: {exc}")
+                continue
+            if fmt != "PNG":
+                wrong.append(f"{name} is named .png but contains {fmt}")
         self.assertEqual(wrong, [], "\n".join(
-            ["panel captures must be lowercase-.png. If this is not a "
-             "capture, name it in NOT_FRAMES with the reason:"]
+            ["panel captures must be real, lowercase-.png PNGs. If this is "
+             "not a capture, name it in NOT_FRAMES with the reason:"]
             + wrong))
 
     def test_every_image_is_a_frame_or_a_named_exception(self):

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -184,6 +184,37 @@ class DocsFrameDriftTests(unittest.TestCase):
     def tearDownClass(cls):
         cls.temp.cleanup()
 
+    def test_no_frame_smuggles_transparency(self):
+        """Both comparisons below call convert("RGB"), which silently DROPS an
+        alpha channel. Codex caught the consequence: an RGBA frame whose
+        hidden RGB still matched would pass as identical to the opaque
+        simulator BMP while the README rendered it differently — the exact
+        check advertised as exact, looking through the thing that changed.
+
+        The sound rule is not to work around the conversion but to reject its
+        precondition failing. These are captures of an AMOLED panel; the glass
+        has no transparency, the simulator writes opaque BMPs, and a frame
+        carrying alpha did not come from where it claims to. Asserting that
+        first makes convert("RGB") provably lossless for everything after it.
+
+        Checked as fully-opaque rather than as mode == "RGB": LA, PA and a
+        palette image with a `transparency` key all carry alpha too, and mode
+        alone would wave those past.
+        """
+        for frame, path in self.frames:
+            with self.subTest(frame=frame):
+                with Image.open(path) as im:
+                    has_alpha = ("A" in im.getbands()
+                                 or "transparency" in im.info)
+                    if not has_alpha:
+                        continue
+                    low, _ = im.convert("RGBA").getchannel("A").getextrema()
+                    self.assertEqual(
+                        low, 255,
+                        f"{frame} has transparent pixels. A panel capture is "
+                        f"opaque; alpha here would be dropped unnoticed by "
+                        f"the comparisons below.")
+
     def test_the_capture_sets_actually_ran(self):
         """Both QA modes writing nothing would make every other test in this
         file pass vacuously — an empty allowed-set rejects nothing only if

--- a/test/test_docs_frame_drift.py
+++ b/test/test_docs_frame_drift.py
@@ -7,47 +7,65 @@ and the drift is the invisible kind: the picture stays plausible, so nobody
 re-reads it, and a reader ends up trusting a screenshot of a build that no
 longer exists.
 
-WHAT ACTUALLY HAPPENED, since a guard written from a hypothesis is worth
-little. The global Wi-Fi indicator (platform/torget_ui.c, `wifi_status_*`)
-was redrawn: a thick bright-white fan became a thin muted-grey one, drawn
-from a different asset at a different offset. Fifteen of the twenty-three
-checked-in simulator frames still show the old glyph — including the three
-Wi-Fi onboarding images that test_wifi_setup_wiring.py already pins by size
-and by their presence in the README. Pinning a picture's dimensions does not
-pin its content, and the redraw walked straight through that gap.
+WHAT ACTUALLY HAPPENED. The global Wi-Fi indicator was redrawn in d5be82d
+(2026-08-22), which deleted the Font Awesome glyph font
+platform/fonts/torget_wifi_22.c and replaced it with the generated
+platform/wifi_status_assets.c: a thick bright-white fan became a thin
+muted-grey one at a different offset. The two Wi-Fi onboarding frames date
+from 1b6ba3a, the day before, so they were stale within twenty-four hours of
+being committed. test/test_wifi_setup_wiring.py "pinned" them the whole time
+— it asserts they exist, are PNG, are 480x480 and are linked from the README,
+and all four stayed true. A picture's dimensions are not its content.
 
-TWO CHECKS, because one is exact and the other is possible.
+THE RESULT IS BLUNT: of twenty-nine checked-in frames, this guard can verify
+FOUR. That is not the guard being weak; it is the guard refusing to call
+unverified frames verified, which is what the first three versions of this
+file did in three different ways.
 
-PINNED — a frame the current simulator reproduces byte for byte is compared
-byte for byte. That is the whole guard for those, and it is total: any
-future change to the page shell, the fonts, the palette or the layout breaks
-it. Only five frames qualify today.
+PINNED — byte for byte, and that is total. Four frames are reproduced exactly
+by a capture --vibepulse-static-qa still produces, so any change to the page
+shell, fonts, palette or layout breaks them. The mapping was found by
+comparing every frame against every capture, not guessed from filenames.
 
-CHROME — the other eighteen were captured from ad-hoc simulator states (a
-different fixture, a different tile, a different signal strength) that no
-pinned capture set reproduces, so there is no image to compare them against.
-What CAN be compared is the one rectangle whose content is decided by the
-firmware alone and not by the fixture: the Wi-Fi indicator's own 20x18 box.
-Across the 153 captures the QA sets produce, that rectangle takes exactly
-six renderings; a checked-in frame showing something else is showing a panel
-this build cannot draw.
+UNVERIFIED — everything else. Those frames came from ad-hoc simulator states
+that no pinned capture set reproduces, so there is no image to compare them
+with. Each is quarantined by name AND by a digest of its file. Most are
+positively stale: their Wi-Fi indicator is the pre-redraw glyph. The rest
+cannot be judged either way, and are quarantined for that reason rather than
+waved through — see the next paragraph, which is the whole reason this file
+was rewritten.
+
+WHY A BLANK RECTANGLE PROVES NOTHING. The check compares the indicator's own
+20x18 box at (426, 28) — the position wifi_status_create() gives it in
+platform/torget_ui.c — against the renderings the simulator produces. An
+earlier version accepted ANY rendering the QA sets emitted, including a
+blank box, and Codex caught what that let through: docs/img/launcher.png has
+an all-black box and sailed past, even though every launcher capture draws
+the indicator. Blankness is ambiguous by construction — a full-screen
+takeover hides the header, and so does a frame captured before the indicator
+existed — so it can never be evidence for an unpinned frame.
+
+Worse, and found while checking that: --vibepulse-pulse-qa and
+--vibepulse-completion-qa never call torget_wifi_status_set_mode(NORMAL), so
+the indicator stays HIDDEN for every capture they write. The SAME tag proves
+it — torget-vibepulse-claude-done-static.bmp has 56 indicator pixels under
+--vibepulse-static-qa and 0 under --vibepulse-completion-qa. Same surface,
+same firmware; the difference is the harness. Feeding those modes into the
+allowed set imported blanks that the panel never draws, which is how a
+frame's pin could rest on an artifact. This file now reads ONE mode, the one
+that exercises the page shell.
 
 THE QUARANTINE, AND WHAT IT ACTUALLY GUARANTEES. STALE_CHROME maps each
-frame that fails CHROME today to a digest of its file, and the test asserts
-both that the failures are exactly those frames and that each is still the
-file that was reviewed. A NEW stale frame fails, and re-capturing an old one
-fails until its entry is struck off.
-
-The first version of this list held filenames only, and the honest reading —
-Codex's, on the PR — is that it did not enforce the rule it advertised: add
-the new frame's name and everything passes again. Nothing in a repository
-can stop someone editing a constant, and claiming otherwise is the mistake
-AGENTS.md records about a merge block that was never there. What the digest
-changes is the price: quarantining a new frame now costs a filename AND a
-64-character hash of that exact file, which a reviewer sees. And it freezes
-what is already here — a quarantined frame cannot quietly become different
-stale art, and re-capturing one has exactly one correct resolution, which is
-to delete its entry rather than update its hash.
+unverified frame to a digest of its file, and the test asserts both that the
+unverified set is exactly those frames and that each is still the file that
+was reviewed. Its first version held filenames only, and Codex was right
+that this enforced nothing it advertised: add the new frame's name and
+everything passes. Nothing in a repository can stop someone editing a
+constant, and claiming otherwise is the mistake AGENTS.md records about a
+merge block that was never there. What the digest changes is the price —
+a filename AND a 64-character hash a reviewer sees — and it freezes what is
+already here: re-capturing a quarantined frame fails, with one correct
+answer, delete the entry rather than update the hash.
 
 Deliberately NOT covered: docs/img/mockups/, which are concept art from
 tools/mockups/gen_concept_mockups.py and never claimed to be captures, and
@@ -68,15 +86,15 @@ from PIL import Image, ImageChops
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# The QA modes that between them produce every capture a docs frame is
-# compared against. --vibepulse-pulse-qa is here for one frame only
-# (vibepulse-needs-you.png is its t0 bright tick), which is exactly why it
-# has to be named: without it that frame silently drops to "unpinned".
-QA_MODES = ("--vibepulse-static-qa", "--vibepulse-pulse-qa")
+# ONE mode, deliberately. --vibepulse-static-qa is the only QA flow that runs
+# capture_global_wifi_matrix() and therefore the only one whose captures show
+# the page shell the panel actually draws. See the docstring: the others
+# leave the indicator HIDDEN and their blanks are harness artifacts.
+QA_MODE = "--vibepulse-static-qa"
 
 # platform/torget_ui.c: wifi_status_create() places the group at (426, 28)
-# and sizes it 20x18. The rectangle holds the glyph and nothing else — all
-# 114 ordinary app captures render it identically — so a mismatch is the
+# and sizes it 20x18. The rectangle holds the glyph and nothing else — the
+# ordinary app captures render it identically — so a mismatch is the
 # indicator, not the page behind it.
 WIFI_BOX = (426, 28, 426 + 20, 28 + 18)
 
@@ -84,31 +102,23 @@ WIFI_BOX = (426, 28, 426 + 20, 28 + 18)
 PINNED = {
     "vibepulse-settings-menu.png": "torget-settings-menu.bmp",
     "vibepulse-settings-about.png": "torget-settings-about-found.bmp",
-    "vibepulse-settings-no-address.png": "torget-settings-menu-no-address.bmp",
+    "vibepulse-settings-no-address.png": "torget-settings-menu-address-lost.bmp",
     "vibepulse-wifi-setup.png": "torget-wifi-setup-open.bmp",
-    "vibepulse-needs-you.png": "torget-vibepulse-pulse-t0-bright.bmp",
 }
 
-# Frames still showing the pre-redraw Wi-Fi indicator, each frozen at the
-# exact bytes that were reviewed.
+# Frames whose chrome this guard cannot confirm is current, each frozen at
+# the exact bytes that were reviewed. Two populations, deliberately in one
+# list because the remedy is identical — re-capture from a named state:
 #
-# A NAME ALONE WOULD NOT BE A RATCHET. This started as a set of filenames,
-# and Codex was right to call that out: a contributor who adds a new stale
-# frame could add its name here and every test would pass again, so the
-# "may shrink, never grow" rule was a comment, not a check — the same shape
-# of mistake AGENTS.md records about promising a merge block that did not
-# exist. Nothing in a repository can stop someone editing a constant. What a
-# digest buys is that quarantining a NEW frame now costs a filename *and* a
-# 64-character hash of that specific file, which is a visible, deliberate
-# act in a diff rather than a one-word addition to a list.
+#   * positively stale: the box holds the pre-redraw glyph.
+#   * unjudgeable: the box is blank, which proves nothing on an unpinned
+#     frame (a takeover hides the header, and so does a capture predating
+#     the indicator). These are the eight Codex's review surfaced.
 #
-# It also freezes what is quarantined. A frame here cannot be swapped for
-# different stale art, and re-capturing one breaks its digest — which is the
-# intended exit: the fix is to delete the entry, not to update the hash.
-#
-# Re-capturing is a documentation change with a visible result — a different
-# fixture tells a different story on the glass — so which capture replaces
-# which is the maintainer's call, not this test's.
+# Strike a name off when its frame is re-captured; never add one to turn a
+# red run green. Re-capturing is a documentation change with a visible
+# result — a different fixture tells a different story on the glass — so
+# which capture replaces which is the maintainer's call, not this test's.
 STALE_CHROME = {
     "github/sim-cached.png":
         "371cfc2168bf7d6f85a3e8a83ac6848cdb12ce1a79a2b19a2d634087696ad7dc",
@@ -116,14 +126,30 @@ STALE_CHROME = {
         "19a106e5ff938dbbe1314ef7e93208f1d12c384b78cd441dc7c05d38d202f351",
     "github/sim-missing.png":
         "709d96c2c720510ceced9bca4dd41d615c21bfbd26e217605dbe6db934ada342",
+    "github/sim-star-popup.png":
+        "9683ea79d93d13dfba0ae0efa8505db7b7d5fa2320f5d8af71df5ae07e30676a",
+    "launcher.png":
+        "a8aad4b591a1152a8d9b0aa48628a11b95b1b5cc497f2385d7c7730392b60166",
+    "needs-you/vibepulse-needs-you-approval.png":
+        "704164c54756b6712cb9086016487eaba40a65e7b5c60504ef3157168991c921",
+    "needs-you/vibepulse-needs-you-attract.png":
+        "046155bfb4115f101a356cdd5ea2fcf3ec758d62c084f615af9641299fefc576",
     "needs-you/vibepulse-needs-you-none.png":
         "ba8b6cae7e893909b5fefb38029133a314ad9e5c68534a96957de5992fd1805a",
+    "needs-you/vibepulse-needs-you-payoff.png":
+        "02e2c8c430367db23e3ef167f9a9f8ee9b7409bca42ff50037f8ec4050950531",
+    "needs-you/vibepulse-needs-you-private.png":
+        "e5a5c439bf8c6db505003ddfbddbd510df89a1129f53c9d2d810146f4ead0fea",
+    "needs-you/vibepulse-needs-you-question.png":
+        "101ac6d584f551e764c8556be3364e5757842abb0db722bd77fecef3db212dc4",
     "vibepulse-agent-working.png":
         "3f2adbdf5020050c307120ce26d4af0a94af06defcc630fe91b57efeae6841b4",
     "vibepulse-burn-rate.png":
         "ced77198dbb1086e5fb68d04a85b980c08e7e71a9ad2f97ead524ccf70dfc0b3",
     "vibepulse-claude-week.png":
         "f5e0f17b4d437b864c79e0674e17f35860699c9e7ff8465e28328873ddd4bc65",
+    "vibepulse-codex-needs-you.png":
+        "21ea74df103b943e2efc0443e8558bc4bd5751edafb84f4f49e124b28bc090b9",
     "vibepulse-codex-week.png":
         "91be52589635e467cad6dbc62266676e958c94e81d891dedb99ba9ff946080c4",
     "vibepulse-max-tracker-claude.png":
@@ -134,6 +160,8 @@ STALE_CHROME = {
         "7f661a322aca5cea0f2645feffed6deba6a326936af9072ff2c97196105f78c0",
     "vibepulse-needs-you-codex-question.png":
         "4fd9fd20759c51bf29a8e6fb336033f43db27cd6b1ca0532df712c41f96e2406",
+    "vibepulse-needs-you.png":
+        "10a1fd51f5b56538a4f8c9557ee0fc9e3c81fad4b1418a2370651bdc8081292e",
     "vibepulse-no-data.png":
         "a70d4683b44819d3c3a40f34a74ef2ec69b125b668c254a2e469fc7794e241fb",
     "vibepulse-value-ahead.png":
@@ -144,12 +172,21 @@ STALE_CHROME = {
         "fd1fff6f8e42157a2143cd3c3fb66ae4ed125ffc72426e0d21f01dfc365ea66b",
 }
 
+# PNG chunks that change what a browser paints without changing a single
+# sample value, so a comparison of sample values alone looks straight
+# through them. Codex's second finding: an EXIF orientation or a colour
+# profile arriving on a pinned frame would leave this test green while the
+# README rendered the picture differently.
+DISPLAY_METADATA = ("icc_profile", "exif", "gamma", "srgb", "chromaticity")
+
 
 def docs_frames():
     """Every checked-in 480x480 simulator capture, by path under docs/img.
 
     Discovered rather than listed: a frame added to the README tomorrow must
-    face this guard without anyone remembering to enrol it.
+    face this guard without anyone remembering to enrol it. That is how
+    needs-you/vibepulse-needs-you-none.png joined the quarantine after being
+    missed by hand.
     """
     img = ROOT / "docs/img"
     for path in sorted(img.rglob("*.png")):
@@ -162,6 +199,16 @@ def docs_frames():
         yield rel.as_posix(), path
 
 
+def indicator(image):
+    return image.convert("RGB").crop(WIFI_BOX).tobytes()
+
+
+def is_blank(box):
+    """The indicator box with nothing drawn in it."""
+    return all(box[i] + box[i + 1] + box[i + 2] <= 75
+               for i in range(0, len(box), 3))
+
+
 class DocsFrameDriftTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -171,12 +218,11 @@ class DocsFrameDriftTests(unittest.TestCase):
                      ["cmake", "--build", "sim/build"]):
             subprocess.run(argv, cwd=ROOT, check=True, text=True,
                            capture_output=True)
-        for mode in QA_MODES:
-            subprocess.run(
-                [str(ROOT / "sim/build/torget-sim"), mode],
-                cwd=ROOT,
-                env={**os.environ, "TORGET_CAPTURE_DIR": str(cls.capture_dir)},
-                check=True, text=True, capture_output=True)
+        subprocess.run(
+            [str(ROOT / "sim/build/torget-sim"), QA_MODE],
+            cwd=ROOT,
+            env={**os.environ, "TORGET_CAPTURE_DIR": str(cls.capture_dir)},
+            check=True, text=True, capture_output=True)
         cls.captures = sorted(cls.capture_dir.glob("*.bmp"))
         cls.frames = list(docs_frames())
 
@@ -184,29 +230,48 @@ class DocsFrameDriftTests(unittest.TestCase):
     def tearDownClass(cls):
         cls.temp.cleanup()
 
-    def test_no_frame_smuggles_transparency(self):
-        """Both comparisons below call convert("RGB"), which silently DROPS an
-        alpha channel. Codex caught the consequence: an RGBA frame whose
-        hidden RGB still matched would pass as identical to the opaque
-        simulator BMP while the README rendered it differently — the exact
-        check advertised as exact, looking through the thing that changed.
+    def test_the_capture_set_actually_ran(self):
+        """The QA mode writing nothing would make every other test in this
+        file pass vacuously — an empty allowed-set rejects nothing unless
+        something notices, so notice here."""
+        self.assertGreater(len(self.captures), 100,
+                           "the QA mode produced almost no captures")
+        self.assertTrue(self.frames, "found no 480x480 frames under docs/img")
 
-        The sound rule is not to work around the conversion but to reject its
-        precondition failing. These are captures of an AMOLED panel; the glass
-        has no transparency, the simulator writes opaque BMPs, and a frame
-        carrying alpha did not come from where it claims to. Asserting that
-        first makes convert("RGB") provably lossless for everything after it.
+    def test_the_capture_set_really_exercises_the_indicator(self):
+        """The assumption the whole CHROME check rests on, asserted rather
+        than trusted. If someone changes QA_MODE to a flow that leaves the
+        indicator HIDDEN, every capture goes blank, the allowed set empties,
+        and the check would start rejecting correct frames — or, in the
+        version this replaced, accepting anything blank."""
+        drawn = [p for p in self.captures
+                 if not is_blank(indicator(Image.open(p)))]
+        self.assertGreater(
+            len(drawn), 50,
+            f"{QA_MODE} left the Wi-Fi indicator hidden in almost every "
+            f"capture; its blanks are a harness artifact, not the panel.")
+
+    def test_no_frame_smuggles_transparency(self):
+        """Both comparisons call convert("RGB"), which silently DROPS an
+        alpha channel: an RGBA frame whose hidden RGB still matched would
+        pass as identical to the opaque simulator BMP while the README
+        rendered it differently.
+
+        The sound move is to reject the precondition rather than work around
+        the conversion. These are captures of an AMOLED panel; the glass has
+        no transparency and the simulator writes opaque BMPs, so a frame
+        carrying alpha did not come from where it claims to. Asserting it
+        first makes convert("RGB") provably lossless everywhere after.
 
         Checked as fully-opaque rather than as mode == "RGB": LA, PA and a
-        palette image with a `transparency` key all carry alpha too, and mode
-        alone would wave those past.
+        palette image with a `transparency` key all carry alpha while
+        passing a mode test, and the palette case hides best — its mode is
+        "P" and "A" is not among its bands.
         """
         for frame, path in self.frames:
             with self.subTest(frame=frame):
                 with Image.open(path) as im:
-                    has_alpha = ("A" in im.getbands()
-                                 or "transparency" in im.info)
-                    if not has_alpha:
+                    if not ("A" in im.getbands() or "transparency" in im.info):
                         continue
                     low, _ = im.convert("RGBA").getchannel("A").getextrema()
                     self.assertEqual(
@@ -215,21 +280,30 @@ class DocsFrameDriftTests(unittest.TestCase):
                         f"opaque; alpha here would be dropped unnoticed by "
                         f"the comparisons below.")
 
-    def test_the_capture_sets_actually_ran(self):
-        """Both QA modes writing nothing would make every other test in this
-        file pass vacuously — an empty allowed-set rejects nothing only if
-        the tests below are written to notice, so notice here instead."""
-        self.assertGreater(len(self.captures), 100,
-                           "the QA modes produced almost no captures")
-        self.assertTrue(self.frames, "found no 480x480 frames under docs/img")
+    def test_pinned_frames_carry_no_display_affecting_metadata(self):
+        """Scoped to PINNED because that is where the word "exact" is used.
+        An ICC profile or an EXIF orientation changes what a browser paints
+        without touching one sample value, so the comparison below would stay
+        green while the README showed something else. All four are bare PNGs
+        today; this keeps them that way rather than trusting they stay."""
+        for frame in sorted(PINNED):
+            with self.subTest(frame=frame):
+                with Image.open(ROOT / "docs/img" / frame) as im:
+                    present = sorted(k for k in DISPLAY_METADATA
+                                     if k in im.info)
+                self.assertEqual(
+                    present, [],
+                    f"{frame} gained {present}, which changes how a browser "
+                    f"renders it while leaving its pixels equal. Re-save it "
+                    f"without the profile, or stop calling the check exact.")
 
     def test_pinned_frames_are_byte_identical_to_their_capture(self):
         names = {path.name for path in self.captures}
         for frame, capture in sorted(PINNED.items()):
             with self.subTest(frame=frame):
                 self.assertIn(capture, names,
-                              f"{frame} is pinned to a capture the QA modes "
-                              f"no longer produce: {capture}")
+                              f"{frame} is pinned to a capture {QA_MODE} no "
+                              f"longer produces: {capture}")
                 with Image.open(ROOT / "docs/img" / frame) as a, \
                         Image.open(self.capture_dir / capture) as b:
                     diff = ImageChops.difference(a.convert("RGB"),
@@ -240,49 +314,54 @@ class DocsFrameDriftTests(unittest.TestCase):
                         f"changed and the documentation did not: re-capture "
                         f"the frame in the same commit as the change.")
 
-    def test_every_frame_shows_a_wifi_indicator_this_build_can_draw(self):
+    def test_every_unpinned_frame_shows_an_indicator_this_build_draws(self):
+        """A blank box is never evidence here. See the docstring: it means
+        either a takeover hiding the header or a capture that predates the
+        indicator, and nothing distinguishes them from outside."""
         allowed = set()
         for path in self.captures:
             with Image.open(path) as im:
-                allowed.add(im.convert("RGB").crop(WIFI_BOX).tobytes())
-        self.assertTrue(allowed)
+                box = indicator(im)
+            if not is_blank(box):
+                allowed.add(box)
+        self.assertTrue(allowed, "no capture drew the indicator at all")
 
-        stale = set()
+        unverified = set()
         for frame, path in self.frames:
+            if frame in PINNED:
+                continue
             with Image.open(path) as im:
-                if im.convert("RGB").crop(WIFI_BOX).tobytes() not in allowed:
-                    stale.add(frame)
+                if indicator(im) not in allowed:
+                    unverified.add(frame)
 
-        new = sorted(stale - set(STALE_CHROME))
-        fixed = sorted(set(STALE_CHROME) - stale)
-        self.assertEqual(stale, set(STALE_CHROME), "\n".join(
+        new = sorted(unverified - set(STALE_CHROME))
+        fixed = sorted(set(STALE_CHROME) - unverified)
+        self.assertEqual(unverified, set(STALE_CHROME), "\n".join(
             [""]
-            + [f"  NEW stale frame: {n} — it shows a Wi-Fi indicator this "
-               f"build does not draw. Re-capture it." for n in new]
-            + [f"  no longer stale: {f} — remove it from STALE_CHROME."
+            + [f"  NEW unverified frame: {n} — its Wi-Fi indicator is not "
+               f"one this build draws (or is blank, which proves nothing). "
+               f"Re-capture it from a named simulator state." for n in new]
+            + [f"  now verifiable: {f} — remove it from STALE_CHROME."
                for f in fixed]))
 
     def test_each_quarantined_frame_is_frozen_at_the_reviewed_bytes(self):
         """The half that makes the quarantine cost something.
 
-        Without it, STALE_CHROME is a list of filenames and adding one entry
-        is enough to wave a brand-new stale frame past every check — the rule
-        would live in a comment instead of in the run. With it, quarantining
-        a frame costs its digest too, and a quarantined frame is pinned as
-        hard as a PINNED one: it cannot be swapped for different stale art,
-        and re-capturing it fails here. That failure has ONE correct answer —
-        delete the entry — because a re-captured frame is no longer stale.
-        Updating the hash to make this pass puts the frame back in quarantine
-        it no longer belongs in.
+        Without it STALE_CHROME is a list of filenames, and adding one entry
+        waves a brand-new unverified frame past every check — the rule would
+        live in a comment instead of in the run. With it, quarantining costs
+        a digest too, and a quarantined frame is pinned as hard as a PINNED
+        one. Re-capturing one fails here, and that failure has ONE correct
+        answer: delete the entry. Updating the hash puts the frame back into
+        a quarantine it has just left.
         """
         for frame, path in self.frames:
             expected = STALE_CHROME.get(frame)
             if expected is None:
                 continue
             with self.subTest(frame=frame):
-                actual = hashlib.sha256(path.read_bytes()).hexdigest()
                 self.assertEqual(
-                    actual, expected,
+                    hashlib.sha256(path.read_bytes()).hexdigest(), expected,
                     f"{frame} changed while quarantined. If you re-captured "
                     f"it, delete its STALE_CHROME entry — do not update the "
                     f"digest.")
@@ -304,9 +383,18 @@ class DocsFrameDriftTests(unittest.TestCase):
                          "two quarantined frames share a digest")
 
     def test_pinned_and_quarantined_do_not_overlap(self):
-        """A frame cannot be both reproduced exactly and drawing obsolete
-        chrome; if it ever is, one of the two lists is lying."""
+        """A frame cannot be both reproduced exactly and unverifiable; if it
+        ever is, one of the two lists is lying."""
         self.assertEqual(sorted(set(PINNED) & set(STALE_CHROME)), [])
+
+    def test_every_frame_is_accounted_for(self):
+        """No third category. A frame that is neither pinned nor quarantined
+        would be one this file silently ignores, which is how the blank-box
+        hole stayed open."""
+        unaccounted = sorted(frame for frame, _ in self.frames
+                             if frame not in PINNED
+                             and frame not in STALE_CHROME)
+        self.assertEqual(unaccounted, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

The 480×480 simulator captures under `docs/img/` — the ones README,
`docs/wifi.md` and the release bodies show — are now checked against what
this build actually renders.

**They had drifted, and the answer is blunt: of twenty-nine frames this
guard can verify four.** The global Wi-Fi indicator was redrawn in `d5be82d`
(2026-08-22), which deleted the Font Awesome glyph font
`platform/fonts/torget_wifi_22.c` and replaced it with the generated
`platform/wifi_status_assets.c` — a thick bright-white fan became a thin
muted-grey one at a different offset. Most frames still show the old glyph.
Anyone reading the README today is looking at a screen this firmware cannot
produce.

Nothing here re-captures them. That is deliberate — see below.

## Root cause / rationale

Three of the stale frames are the Wi-Fi onboarding images that
`test/test_wifi_setup_wiring.py` already pins. It asserts they exist, are
PNG, are 480×480 and are linked from the README. All four assertions stayed
true while the picture inside changed completely. **A picture's dimensions
are not its content**, and no test looked at a pixel. Those frames come from
`1b6ba3a`, dated 2026-08-21 — they were stale within a day of being
committed.

**PINNED — byte for byte.** Four frames are reproduced exactly by a capture
`--vibepulse-static-qa` still produces, so any change to the page shell,
fonts, palette or layout breaks them. The mapping was found by comparing
every frame against every capture, not guessed from filenames.

**UNVERIFIED — everything else**, quarantined by name *and* by a digest of
the file. Most are positively stale. The rest cannot be judged either way
and are quarantined for that reason rather than waved through.

**Why a blank rectangle proves nothing.** The check compares the indicator's
own 20×18 box at (426, 28) against what the simulator draws. An earlier
version accepted any rendering the QA sets emitted, blank included, and
`docs/img/launcher.png` sailed through with an all-black box while every
launcher capture draws the glyph — it was stale *and* passing, along with
seven more. Blankness is ambiguous by construction: a takeover hides the
header, and so does a capture predating the indicator.

**And one QA mode never draws it at all.** `--vibepulse-pulse-qa` and
`--vibepulse-completion-qa` never call
`torget_wifi_status_set_mode(NORMAL)`. The same tag proves it —
`torget-vibepulse-claude-done-static.bmp` has 56 indicator pixels under
static QA and 0 under completion QA. Same surface, same firmware, different
harness. Feeding those in imported blanks the panel never draws, and one pin
rested on that artifact. The file now reads one mode and asserts that it
exercises the shell.

**What the quarantine actually guarantees.** Its first version held
filenames only, which enforced nothing it advertised — add the new frame's
name and everything passes. Nothing in a repository can stop someone editing
a constant. What the digest changes is the price: a filename *and* a
64-character hash a reviewer sees. It also freezes what is quarantined —
re-capturing one fails, with one correct answer, delete the entry rather
than update the hash. **The residual is measured, not assumed: a name plus
the correct hash still passes.**

**Why re-capturing is not in this PR.** A different fixture tells a
different story on the glass — `vibepulse-agent-working.png` differs from
today's nearest capture only in its header (`NOW · OPUS 4.1 · ULTRA` versus
`2 AGENTS ACTIVE`), the divider, and the pager dots; the body is identical.
Which capture replaces which is a documentation decision about what each
image is meant to show, not a test fix, and it is yours to make.

Frames are **discovered** by walking `docs/img`, not listed — that is how
`needs-you/vibepulse-needs-you-none.png` joined the quarantine after being
missed by hand. Concept art under `docs/img/mockups/` and the photograph of
the physical panel are excluded by name, with reasons.

## Verification

- [x] Relevant focused tests pass — `test/test_docs_frame_drift.py`, 15
      tests, green.
- [x] **Mutation-checked, nineteen times**, including all eight review
      findings reproduced before fixing: a single pixel changed in a pinned
      frame; the old glyph pasted into a clean one; a name struck from the
      quarantine; a phantom name added; both QA modes producing nothing;
      a new stale frame waved through by filename alone, and the residual of
      that bypass confirmed to pass rather than assumed; a re-captured
      quarantined frame; a truncated digest; an RGBA frame with matching
      hidden RGB; a palette frame with a `transparency` key; `QA_MODE`
      pointed at a flow that leaves the indicator hidden; a 400×400
      screenshot; a `NOT_FRAMES` entry naming nothing; an ICC profile on a
      pinned frame; a two-frame APNG whose first frame is byte-identical to
      the capture; an uppercase `.PNG`; a JPEG; a 300×300 WebP; and TIFF data
      under a `.png` name. Each behaved as intended, each restored.
- [x] `./test/run.sh` passes except `test_interaction_relay_vectors.py`,
      which needs ESP-IDF's bundled Mbed TLS and fails identically on a clean
      checkout in this container — not a regression. Skipping only that line,
      the rest runs to the end with the exit code checked directly: 0, with
      the new file running inside it. Re-run after merging `origin/main` and
      after every review round.
- [x] No secret, credential, raw session content, production payload, or
      `torget.bin` is included. The test reads checked-in PNGs and simulator
      BMPs written to a temporary directory.
- [x] Documentation and changelog match the behavior — `CHANGELOG.md` and a
      `docs/lessons.md` entry, both stating how many frames remain unverified
      rather than implying the drift is fixed, and both corrected after the
      first review round so they no longer promise a ratchet the run does not
      enforce.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a
      real-host or physical-panel pass.
- [x] No Windows-specific path is touched.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed. Nothing in `main/`, `components/`
      or `platform/` is touched; no firmware source, no rendering, no assets.
      The exact 480×480 rasters this PR is *about* are the ones already in
      `docs/img/`, unchanged by it.
- [x] No physical flash was requested, performed, or authorized.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback
      were not treated as approval.

## Not tested / remaining risk

- **The check watches one rectangle, not the whole frame.** It catches drift
  in the shared page shell's indicator, which is what actually happened. It
  does **not** catch a stale *body* — a chart, a font or a layout that
  changed while the indicator stayed put. Only the four pinned frames are
  protected against that, and the only way to extend that protection is to
  re-capture the rest from named simulator states.
- **The quarantine's residual.** A filename plus the file's correct digest
  still gets a new unverified frame in. Deriving the grandfathered set from
  git history would close it, but `actions/checkout@v4` in `ci.yml` sets no
  `fetch-depth`, so CI runs on a shallow clone where `git log -- <path>`
  cannot answer, and widening the checkout to satisfy one test is not a trade
  I would make unasked.
- **Twenty-five frames are still unverified.** This PR makes them visible and
  stops the problem growing; it does not fix it.
- **On format hardening.** Alpha, colour profiles, animation and format-vs-name
  are all now checked, each after a demonstrated case. The family is
  open-ended and I have stopped adding to it speculatively; a further
  concrete case is worth a commit, a hypothetical one a line in the
  docstring.

Every one of the eight findings on this PR was about what the guard **reads
in** — which captures it trusts, which files it looks at, which extensions
it globs, whether a name stands for a format — and none about the comparison
itself. That is written into the file's docstring, because it is the part
worth remembering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE