### PR TITLE
fix(ota): the runbooks told you the wrong gesture, one of them at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+### Fixed
+
+- **The OTA runbook told you the wrong gesture, on the terminal, while you
+  stood at the panel.** `tools/ota-flash.sh` said "håll KEY3 ~3 s tills
+  UPDATES ON-ringen syns" — in its header *and* in the line it prints while
+  waiting for the window. The hold has opened SETTINGS since #72; UPDATE in
+  the menu is what opens the window. Someone following it would have held
+  the button and waited for a ring that never came. `tools/wifi-here.sh`
+  had the same error about the setup window. Both corrected, and
+  `test/test_ota_gesture_docs.py` — which exists precisely to catch this
+  class and did not — now reads the two runbooks and understands Swedish
+  verb-first phrasing ("Håll KEY3"), which is why it had called two wrong
+  files clean.
+
 ### Added
 
 - **`doctor` and Codex startup health now name a saved Codex mode that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   waiting for the window. The hold has opened SETTINGS since #72; UPDATE in
   the menu is what opens the window. Someone following it would have held
   the button and waited for a ring that never came. `tools/wifi-here.sh`
-  had the same error about the setup window. Both corrected, and
-  `test/test_ota_gesture_docs.py` — which exists precisely to catch this
-  class and did not — now reads the two runbooks and understands Swedish
-  verb-first phrasing ("Håll KEY3"), which is why it had called two wrong
-  files clean.
+  had the same error twice — in its header and in the retry advice it
+  prints when the Mac cannot reach the panel's access point, which is
+  exactly when the operator is stuck and reading carefully. All corrected,
+  and `test/test_ota_gesture_docs.py` — which exists to catch this class and
+  did not — now reads the two runbooks, understands Swedish verb-first
+  phrasing ("Håll KEY3"), normalises whitespace so a line break inside a
+  sentence no longer hides it, joins what a shell script actually prints
+  across several `echo` lines, and guards the Wi-Fi setup window as well as
+  the update window.
 
 ### Added
 

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -146,8 +146,30 @@ INSIDE = re.compile(
 # scripts under tools/ already address the operator with it, so a runbook
 # gaining one is a matter of time. Its format specifiers survive as literal
 # "%s" in the extracted text, which none of these patterns care about.
-ECHOED = re.compile(
-    r"""(?:echo|printf)\s+(?:-[neE]+\s+)*["']([^"']*)["']""")
+EMITTER = re.compile(r"""^\s*(?:echo|printf)\b""")
+QUOTED = re.compile(r"""["']([^"']*)["']""")
+
+
+def emitted(line):
+    """Everything an emitting line puts on the terminal, in order.
+
+    Matching the COMMAND and then taking every quoted run, rather than
+    writing one regex for the whole invocation, is the third attempt and the
+    only one that has held. The first knew `echo` and `echo -e`, so
+    `echo -n "... håll "` yielded nothing. The second added the flags but
+    still took only the FIRST quoted string, which is right for echo and
+    wrong for printf: `printf '%s%s\n' "... håll " "KEY3 ~3 s."` puts the
+    stale sentence on screen out of its ARGUMENTS, and the guard read the
+    format and called the file clean.
+
+    Both misses had the same cause — a pattern that had to anticipate every
+    shape of the invocation. This does not: the command name says the line
+    speaks, and the quotes say what it says. A format specifier survives as
+    a literal "%s" between the pieces, which none of the rules care about.
+    """
+    if not EMITTER.match(line):
+        return []
+    return QUOTED.findall(line)
 
 
 def passages(text):
@@ -192,7 +214,7 @@ def passages(text):
             yield " ".join(block.split())
     run = []
     for line in text.splitlines():
-        parts = ECHOED.findall(line)
+        parts = emitted(line)
         if parts:
             run.extend(parts)
             continue
@@ -317,6 +339,17 @@ class OtaGestureDocsTest(unittest.TestCase):
             'status() {\n'
             "  printf 'Underhållsfönstret öppnas med ett håll '\n"
             '  echo "KEY3 ~3 s."\n'
+            '}',
+            # One line, one command: the sentence lives in printf's ARGUMENTS
+            # and only "%s%s" is in the format. Reading the format alone —
+            # which a previous version did — sees nothing at all here.
+            'status() {\n'
+            "  printf '%s%s\\n' \"Underhållsfönstret öppnas med ett håll \" "
+            '"KEY3 ~3 s."\n'
+            '}',
+            # Several arguments to one echo are one line on the terminal too.
+            'status() {\n'
+            '  echo "Underhållsfönstret öppnas med ett håll " "KEY3 ~3 s."\n'
             '}',
         )
         for text in built:

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -19,20 +19,26 @@ shipped at the time, and docs/superpowers/plans/, which are implementation
 plans for work already done. Rewriting either to match today's behaviour
 would be falsifying the record, which is the opposite of the point.
 
-NOT GUARDED, AND MEASURED RATHER THAN ASSUMED: the same mistake about the
-WI-FI SETUP window. tools/wifi-here.sh said the panel raises its access point
-"direkt om du håller KEY3 ~3 s" — the hold opens SETTINGS, where WIFI opens
-it. That text is corrected in this commit, but this guard did NOT catch it
-and cannot: WINDOW deliberately excludes the setup window so the two windows
-keep separate vocabularies, so the passage matched HOLD and nothing else.
+THE SAME MISTAKE ABOUT THE WI-FI SETUP WINDOW is now guarded too, and the
+story of why is the useful part. tools/wifi-here.sh said the panel raises its
+access point "direkt om du håller KEY3 ~3 s", and its retry advice said a
+hold opens a new one. Both are wrong the same way — the hold opens SETTINGS,
+where WIFI opens the window.
 
-Extending WINDOW to cover it was tried and rejected on evidence. A rule
-pairing a hold with setup-window words flags three passages that are
-CORRECT: wifi.md's hold-hold shortcut, ota.md's greyed-out-UPDATE
-explanation, and agent-setup.md's "(or a 3 s KEY3 hold -> WIFI)" table row.
-Same verdict as the takeover rule below, for the same reason. The runbook is
-still in LIVE_DOCS — it would catch an OTA-window claim appearing there — but
-its setup-window sentence is guarded by a reader, not by this file.
+I first judged this class unguardable and wrote that down: a rule pairing a
+hold with setup-window words appeared to flag three CORRECT passages. That
+measurement was wrong, and wrong for a reason worth keeping. Two of the
+three were artifacts of matching raw text — patterns here use literal
+spaces, and wifi.md's exempt sentence has a line break inside it, so INSIDE
+could not fire. The third was self-exemption: a step pattern accepting the
+bare word WIFI matches the window's own name, "WIFI SETUP".
+
+With passages whitespace-normalised (see below) and the step required to
+name SETTINGS or to *pick* WIFI rather than merely mention it, the rule
+flags zero correct passages in every live doc and catches both real misses.
+So the class needed a better rule, not a reader. The lesson is that "I tried
+it and it produced false positives" is only as good as the harness that
+produced them.
 
 Also deliberately NOT guarded, after trying: the neighbouring failure where
 a doc offers the hold *while the UPDATE READY takeover is up*, which the
@@ -105,6 +111,17 @@ WINDOW = re.compile(
 # a first version of this guard that accepted it.
 STEP = re.compile(r"SETTINGS")
 
+# ---- the Wi-Fi setup window, which has its own vocabulary and its own step.
+SETUP_WINDOW = re.compile(
+    r"(setup[- ]?f[öo]nstret|setup window|accesspunkt|VibePulse-setup"
+    r"|WIFI SETUP|WiFi SETUP)", re.I)
+
+# Must name the MENU, or picking WIFI *from* it. The bare word WIFI cannot be
+# the step: "WIFI SETUP" contains it, so a passage naming only the window
+# would exempt itself — which is exactly what a first attempt did.
+SETUP_STEP = re.compile(
+    r"SETTINGS|(v[äa]lj|pick|choose|→|->)\s+\*{0,2}WIFI", re.I)
+
 # The one legitimate way a hold and the update window belong in the same
 # breath without the menu: the hold–hold shortcut, which happens INSIDE an
 # already-open window and switches to Wi-Fi setup. That passage is true and
@@ -116,18 +133,40 @@ INSIDE = re.compile(
     r"|while the OTA window is (already )?open)", re.I)
 
 
+ECHOED = re.compile(r"""echo\s+(?:-e\s+)?["']([^"']*)["']""")
+
+
 def passages(text):
     """Blank-line paragraphs, plus each table row on its own.
 
     Tables carry one instruction per row, so a row must stand up alone —
     the 403 troubleshooting entry was exactly such a row.
+
+    WHITESPACE IS NORMALISED, and that is not cosmetic. Every pattern here
+    is written with literal spaces, and prose wraps: wifi.md's hold-hold
+    passage says "while the update window is open" with a line break inside
+    it, so INSIDE — the exemption meant precisely for that sentence — did not
+    fire, and the passage was one line-wrap away from being reported as a
+    violation. A guard that depends on where an author pressed Enter is a
+    guard that reports noise.
+
+    A SHELL SCRIPT ALSO GETS WHAT THE OPERATOR ACTUALLY READS. A message
+    split across two echo statements is one sentence on the terminal and two
+    unrelated fragments on disk: wifi-here.sh's retry advice ended "— håll"
+    on one line and began "KEY3 ~3 s" on the next, with `" >&2\n  echo "` in
+    between, so no pattern could bridge it. Codex found that line by reading
+    it; this yields the joined text so the guard can too.
     """
     for block in text.split("\n\n"):
         rows = [ln for ln in block.splitlines() if ln.lstrip().startswith("|")]
         if rows:
-            yield from rows
+            for row in rows:
+                yield " ".join(row.split())
         else:
-            yield block
+            yield " ".join(block.split())
+    spoken = ECHOED.findall(text)
+    if spoken:
+        yield " ".join(" ".join(spoken).split())
 
 
 class OtaGestureDocsTest(unittest.TestCase):
@@ -146,6 +185,58 @@ class OtaGestureDocsTest(unittest.TestCase):
         self.assertEqual(offenders, [], "\n".join(
             ["a KEY3 hold opens SETTINGS; name the UPDATE step too:"]
             + offenders))
+
+    def test_no_live_doc_sends_a_hold_straight_to_the_setup_window(self):
+        """The Wi-Fi half of the same class. wifi-here.sh got it wrong twice
+        — in its header and, worse, in the retry advice it prints when the
+        Mac fails to reach the panel's AP, which is exactly when the operator
+        is stuck and reading carefully."""
+        offenders = []
+        for name in LIVE_DOCS:
+            path = ROOT / name
+            if not path.exists():
+                continue
+            for passage in passages(path.read_text(encoding="utf-8")):
+                if HOLD.search(passage) and SETUP_WINDOW.search(passage) \
+                        and not SETUP_STEP.search(passage) \
+                        and not INSIDE.search(passage):
+                    offenders.append(f"{name}: {passage[:160]}")
+        self.assertEqual(offenders, [], "\n".join(
+            ["a KEY3 hold opens SETTINGS; name the WIFI step too:"]
+            + offenders))
+
+    def test_the_setup_rule_catches_its_real_misses_and_spares_the_rest(self):
+        """Both halves measured, because a rule is only as trustworthy as the
+        evidence that it neither under- nor over-reaches."""
+        misses = (
+            "#   1. Panelen reser sin egen accesspunkt (VibePulse-setup). "
+            "Den gör det\n#      själv efter 90 s utan nät, eller direkt om "
+            "du håller KEY3 ~3 s.",
+            '  echo "Står WIFI SETUP på glaset? Fönstret är öppet i tio '
+            'minuter — håll" >&2\n  echo "KEY3 ~3 s för att öppna ett '
+            'nytt." >&2',
+        )
+        correct = (
+            "#      själv efter 90 s utan nät, eller om du håller KEY3 ~3 s "
+            "och väljer\n#      WIFI i SETTINGS — hållet öppnar menyn, inte "
+            "fönstret.",
+            "**Hold again to switch windows.** A second full 3 s hold while "
+            "the update\nwindow is open closes it and opens WIFI SETUP "
+            "instead.",
+        )
+
+        def flagged(text):
+            return [p for p in passages(text)
+                    if HOLD.search(p) and SETUP_WINDOW.search(p)
+                    and not SETUP_STEP.search(p) and not INSIDE.search(p)]
+
+        for text in misses:
+            with self.subTest(miss=text[:60]):
+                self.assertTrue(flagged(text), "setup rule missed a real one")
+        for text in correct:
+            with self.subTest(ok=text[:60]):
+                self.assertEqual(flagged(text), [],
+                                 "setup rule rejects correct wording")
 
     def test_the_guard_would_have_caught_the_real_misses(self):
         """A guard that passes everything proves nothing, so run it against

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -133,7 +133,21 @@ INSIDE = re.compile(
     r"|while the OTA window is (already )?open)", re.I)
 
 
-ECHOED = re.compile(r"""echo\s+(?:-e\s+)?["']([^"']*)["']""")
+# What a shell script actually puts on the operator's terminal.
+#
+# The flags matter and are not cosmetic. A first version accepted only -e, so
+# `echo -n "... håll "` followed by `echo "KEY3 ~3 s."` — one continuous
+# sentence to the reader, and precisely how you would build one — matched
+# nothing on the first line. That did not merely lose half the message: a
+# line yielding no parts ENDS the adjacent-run grouping, so the guard scanned
+# the tail alone and saw nothing wrong with it.
+#
+# printf is here for the same reason rather than a hypothetical one: other
+# scripts under tools/ already address the operator with it, so a runbook
+# gaining one is a matter of time. Its format specifiers survive as literal
+# "%s" in the extracted text, which none of these patterns care about.
+ECHOED = re.compile(
+    r"""(?:echo|printf)\s+(?:-[neE]+\s+)*["']([^"']*)["']""")
 
 
 def passages(text):
@@ -288,6 +302,32 @@ class OtaGestureDocsTest(unittest.TestCase):
             [p for p in passages(script)
              if HOLD.search(p) and WINDOW.search(p)
              and not STEP.search(p) and not INSIDE.search(p)], [])
+
+    def test_a_message_built_with_echo_n_or_printf_is_still_read(self):
+        """Both are ways to emit one sentence from two commands, and both
+        were invisible: a line the pattern cannot read yields no parts, which
+        ends the adjacent run, so the guard scanned the tail on its own and
+        found nothing wrong with it. Missing a flag did not weaken the
+        reading — it silenced it."""
+        built = (
+            'status() {\n'
+            '  echo -n "Underhållsfönstret öppnas med ett håll "\n'
+            '  echo "KEY3 ~3 s."\n'
+            '}',
+            'status() {\n'
+            "  printf 'Underhållsfönstret öppnas med ett håll '\n"
+            '  echo "KEY3 ~3 s."\n'
+            '}',
+        )
+        for text in built:
+            with self.subTest(form=text.split("\n")[1].strip()[:20]):
+                flagged = [p for p in passages(text)
+                           if HOLD.search(p) and WINDOW.search(p)
+                           and not STEP.search(p) and not INSIDE.search(p)]
+                self.assertTrue(
+                    flagged,
+                    "a message split across two emitting commands was not "
+                    "reassembled, so the guard never saw the sentence")
 
     def test_the_guard_would_have_caught_the_real_misses(self):
         """A guard that passes everything proves nothing, so run it against

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -19,6 +19,21 @@ shipped at the time, and docs/superpowers/plans/, which are implementation
 plans for work already done. Rewriting either to match today's behaviour
 would be falsifying the record, which is the opposite of the point.
 
+NOT GUARDED, AND MEASURED RATHER THAN ASSUMED: the same mistake about the
+WI-FI SETUP window. tools/wifi-here.sh said the panel raises its access point
+"direkt om du håller KEY3 ~3 s" — the hold opens SETTINGS, where WIFI opens
+it. That text is corrected in this commit, but this guard did NOT catch it
+and cannot: WINDOW deliberately excludes the setup window so the two windows
+keep separate vocabularies, so the passage matched HOLD and nothing else.
+
+Extending WINDOW to cover it was tried and rejected on evidence. A rule
+pairing a hold with setup-window words flags three passages that are
+CORRECT: wifi.md's hold-hold shortcut, ota.md's greyed-out-UPDATE
+explanation, and agent-setup.md's "(or a 3 s KEY3 hold -> WIFI)" table row.
+Same verdict as the takeover rule below, for the same reason. The runbook is
+still in LIVE_DOCS — it would catch an OTA-window claim appearing there — but
+its setup-window sentence is guarded by a reader, not by this file.
+
 Also deliberately NOT guarded, after trying: the neighbouring failure where
 a doc offers the hold *while the UPDATE READY takeover is up*, which the
 firmware ignores. The ota.md diagram shipped that way ("tap UPDATE pill, or
@@ -46,14 +61,31 @@ LIVE_DOCS = (
     "docs/ota.md",
     "docs/wifi.md",
     "docs/agent-setup.md",
+    # The two operator runbooks. Adding them is the whole reason this file
+    # changed: both still described the old gesture, and ota-flash.sh printed
+    # it at RUNTIME — "håll KEY3 ~3 s..." on the terminal at the exact moment
+    # someone is standing at the panel waiting for a ring that will not come.
+    # A guard scoped to .md files was never going to see it. A doc is
+    # whatever a person follows, not whatever has a Markdown extension.
+    #
+    # ota-flash.sh is genuinely covered: reverting its header fails this file.
+    # wifi-here.sh is here for the OTA-window class only — its own error was
+    # about the SETUP window, which WINDOW does not match. See the docstring.
+    "tools/ota-flash.sh",
+    "tools/wifi-here.sh",
 )
 
 # A hold is not always spelled with KEY3 next to it. The README passage
 # that shipped wrong said "hold twice: the first 3-second hold opens the
 # update window" and never named the button in that sentence at all — the
 # first version of this guard required the adjacency and sailed past it.
+# Swedish puts the verb first — "Håll KEY3", "om du håller KEY3" — and the
+# noun form "KEY3-håll" was the only Swedish shape the first version knew.
+# Both missed passages were verb-first, so the guard read two files that were
+# wrong and called them clean.
 HOLD = re.compile(
     r"(hold\w*\s+(the\s+)?KEY3|KEY3[- ]h[åo]ll|KEY3\s+hold"
+    r"|h[åa]ll\w*\s+(ned\s+)?(på\s+)?KEY3"
     r"|\d+[\s-](?:second|s)\s+h[åo]?ll?d?|full hold|hold twice"
     r"|hold[–-]hold)", re.I)
 
@@ -127,6 +159,11 @@ class OtaGestureDocsTest(unittest.TestCase):
             "On a panel that already *has* a network, hold twice: the first "
             "3-second hold opens the update window, a second full hold "
             "switches it to WIFI SETUP.",
+            # Swedish, verb-first, from tools/ota-flash.sh — the header line
+            # and the runtime echo. Both sailed past the first HOLD pattern.
+            "#   3. Håll KEY3 ~3 s tills UPDATES ON-ringen syns — "
+            "uppladdningen går av sig själv.",
+            'echo "väntar på underhållsfönstret på $HOST — håll KEY3 ~3 s..."',
         )
         for text in real_misses:
             with self.subTest(text=text[:60]):
@@ -144,6 +181,14 @@ class OtaGestureDocsTest(unittest.TestCase):
             "| Upload gets 403 | Window not open | Hold KEY3, then pick "
             "UPDATE in SETTINGS — the hold alone only opens the menu; the "
             "glass must show the ring/UPDATES ON |",
+            # The corrected Swedish, so the widened pattern is checked for
+            # over-reach too: it must accept these, not merely reject the old.
+            "#   3. Håll KEY3 ~3 s och välj UPDATE i SETTINGS — hållet "
+            "öppnar MENYN, inte fönstret. När UPDATES ON-ringen syns går "
+            "uppladdningen av sig själv.",
+            "#      själv efter 90 s utan nät, eller om du håller KEY3 ~3 s "
+            "och väljer WIFI i SETTINGS — hållet öppnar menyn, inte "
+            "fönstret.",
         )
         for text in corrected:
             with self.subTest(text=text[:60]):

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -156,6 +156,18 @@ def passages(text):
     on one line and began "KEY3 ~3 s" on the next, with `" >&2\n  echo "` in
     between, so no pattern could bridge it. Codex found that line by reading
     it; this yields the joined text so the guard can too.
+
+    ADJACENT echoes only, and that word is load-bearing. A first version
+    joined every echo in the file into one synthetic passage, which Codex
+    caught as a hole I had just dug: ota-flash.sh's corrected text mentions
+    SETTINGS, so ANY other echo in that file — a different branch, a
+    mutually exclusive path, text no operator ever sees in the same
+    breath — would inherit that word and be excused by it. Reproduced before
+    fixing: a stale two-line message injected into ota-flash.sh was NOT
+    flagged, while the same message in a file without a SETTINGS echo was.
+    A guard that grows a blind spot as the file it watches gets more correct
+    is worse than one that never looked. Consecutive echo lines are one
+    emitted message; a blank line, a command, or a closing brace ends it.
     """
     for block in text.split("\n\n"):
         rows = [ln for ln in block.splitlines() if ln.lstrip().startswith("|")]
@@ -164,9 +176,17 @@ def passages(text):
                 yield " ".join(row.split())
         else:
             yield " ".join(block.split())
-    spoken = ECHOED.findall(text)
-    if spoken:
-        yield " ".join(" ".join(spoken).split())
+    run = []
+    for line in text.splitlines():
+        parts = ECHOED.findall(line)
+        if parts:
+            run.extend(parts)
+            continue
+        if run:
+            yield " ".join(" ".join(run).split())
+            run = []
+    if run:
+        yield " ".join(" ".join(run).split())
 
 
 class OtaGestureDocsTest(unittest.TestCase):
@@ -237,6 +257,37 @@ class OtaGestureDocsTest(unittest.TestCase):
             with self.subTest(ok=text[:60]):
                 self.assertEqual(flagged(text), [],
                                  "setup rule rejects correct wording")
+
+    def test_one_correct_echo_cannot_excuse_a_stale_one_elsewhere(self):
+        """The hole a first version of the echo-joining dug.
+
+        Joining every echo in a file into one passage means the file's own
+        corrected text — ota-flash.sh now names SETTINGS — is inherited by
+        every other echo in it, including ones in a different branch that no
+        operator sees in the same breath. The guard would then get blinder
+        the more of the file was fixed, which is the worst possible
+        direction. Consecutive lines are one message; anything else is not.
+        """
+        script = (ROOT / "tools/ota-flash.sh").read_text(encoding="utf-8")
+        planted = script + (
+            '\nretry() {\n'
+            '  echo "kom inte in. Underhållsfönstret stängdes — håll" >&2\n'
+            '  echo "KEY3 ~3 s för att öppna ett nytt." >&2\n'
+            '}\n')
+        flagged = [p for p in passages(planted)
+                   if HOLD.search(p) and WINDOW.search(p)
+                   and not STEP.search(p) and not INSIDE.search(p)]
+        self.assertTrue(
+            flagged,
+            "a stale message in another branch was excused by the SETTINGS "
+            "in this script's own corrected text")
+
+        # And the script as it stands must stay clean, so the grouping is not
+        # merely strict enough to flag everything.
+        self.assertEqual(
+            [p for p in passages(script)
+             if HOLD.search(p) and WINDOW.search(p)
+             and not STEP.search(p) and not INSIDE.search(p)], [])
 
     def test_the_guard_would_have_caught_the_real_misses(self):
         """A guard that passes everything proves nothing, so run it against

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -172,6 +172,35 @@ def emitted(line):
     return QUOTED.findall(line)
 
 
+def logical_lines(text):
+    """Physical lines joined across trailing backslashes.
+
+    A shell command wrapped over several lines is ONE command, and a long
+    message is exactly what gets wrapped:
+
+        printf '%s%s\n' \\
+          "Underhållsfönstret öppnas med ett håll " \\
+          "KEY3 ~3 s."
+
+    Scanning physical lines saw `printf` on the first and nothing but
+    orphaned quotes after it, so the arguments carrying the sentence were
+    never read. Joining first is what "read what the line emits" meant all
+    along; doing it per physical line was an implementation detail that
+    quietly became the rule.
+    """
+    joined, buf = [], ""
+    for line in text.splitlines():
+        stripped = line.rstrip()
+        if stripped.endswith("\\"):
+            buf += stripped[:-1] + " "
+            continue
+        joined.append(buf + line)
+        buf = ""
+    if buf:
+        joined.append(buf)
+    return joined
+
+
 def passages(text):
     """Blank-line paragraphs, plus each table row on its own.
 
@@ -213,7 +242,7 @@ def passages(text):
         else:
             yield " ".join(block.split())
     run = []
-    for line in text.splitlines():
+    for line in logical_lines(text):
         parts = emitted(line)
         if parts:
             run.extend(parts)
@@ -350,6 +379,14 @@ class OtaGestureDocsTest(unittest.TestCase):
             # Several arguments to one echo are one line on the terminal too.
             'status() {\n'
             '  echo "Underhållsfönstret öppnas med ett håll " "KEY3 ~3 s."\n'
+            '}',
+            # One command wrapped over three physical lines. A long message
+            # is precisely what gets wrapped, so this is the shape a real
+            # regression would take, not a contrived one.
+            'status() {\n'
+            "  printf '%s%s\\n' \\\n"
+            '    "Underhållsfönstret öppnas med ett håll " \\\n'
+            '    "KEY3 ~3 s."\n'
             '}',
         )
         for text in built:

--- a/tools/ota-flash.sh
+++ b/tools/ota-flash.sh
@@ -32,6 +32,8 @@ BUILD_ARG=${2:-}
 
 echo "väntar på underhållsfönstret på $HOST"
 echo "  håll KEY3 ~3 s och välj UPDATE i SETTINGS — hållet öppnar bara menyn"
+echo "  ligger UPDATE READY redan på glaset: tryck på dess UPDATE-pill."
+echo "  ett håll gör ingenting där, så vänta inte på menyn."
 while ! curl -s --max-time 2 "http://$HOST/api/ota/status" 2>/dev/null \
     | grep -q '"maintenance_open":true'; do
   sleep 1

--- a/tools/ota-flash.sh
+++ b/tools/ota-flash.sh
@@ -3,8 +3,11 @@
 #
 #   1. idf.py build                       (eller -B <byggkatalog>)
 #   2. tools/ota-flash.sh <enhetens-ip>   — skriptet väntar på fönstret
-#   3. Håll KEY3 ~3 s tills UPDATES ON-ringen syns — uppladdningen går av
-#      sig själv, enheten verifierar SHA-256, byter lucka och startar om.
+#   3. Håll KEY3 ~3 s och välj UPDATE i SETTINGS — hållet öppnar MENYN,
+#      inte fönstret. När UPDATES ON-ringen syns går uppladdningen av sig
+#      själv, enheten verifierar SHA-256, byter lucka och startar om.
+#      (Ligger UPDATE READY-övertagandet redan på glaset: svara med dess
+#      UPDATE-pill. Ett håll gör ingenting där.)
 #   4. Efter omstarten återöppnas fönstret själv (PENDING_VERIFY-boot):
 #      nästa bygge i samma arbetspass behöver inget nytt håll. Ett kort
 #      KEY3-tryck stänger när passet är klart.
@@ -27,7 +30,8 @@ TOKEN=$(sed -n 's/.*TG_OTA_TOKEN[^"]*"\([0-9a-f]\{64\}\)".*/\1/p' secrets.h | he
 [ -n "$TOKEN" ] || { echo "inget TG_OTA_TOKEN i secrets.h — uppladdning avstängd" >&2; exit 1; }
 BUILD_ARG=${2:-}
 
-echo "väntar på underhållsfönstret på $HOST — håll KEY3 ~3 s..."
+echo "väntar på underhållsfönstret på $HOST"
+echo "  håll KEY3 ~3 s och välj UPDATE i SETTINGS — hållet öppnar bara menyn"
 while ! curl -s --max-time 2 "http://$HOST/api/ota/status" 2>/dev/null \
     | grep -q '"maintenance_open":true'; do
   sleep 1

--- a/tools/wifi-here.sh
+++ b/tools/wifi-here.sh
@@ -70,8 +70,9 @@ fi
 echo "hoppar över till $AP_SSID (Macen är offline en stund)..."
 if ! networksetup -setairportnetwork "$IFACE" "$AP_SSID" "$AP_PASS" >/dev/null 2>&1; then
   echo "kom inte in på $AP_SSID." >&2
-  echo "Står WIFI SETUP på glaset? Fönstret är öppet i tio minuter — håll" >&2
-  echo "KEY3 ~3 s för att öppna ett nytt." >&2
+  echo "Står WIFI SETUP på glaset? Fönstret är öppet i tio minuter." >&2
+  echo "Behöver du ett nytt: håll KEY3 ~3 s och välj WIFI i SETTINGS —" >&2
+  echo "hållet öppnar menyn, inte fönstret." >&2
   exit 1
 fi
 

--- a/tools/wifi-here.sh
+++ b/tools/wifi-here.sh
@@ -4,7 +4,8 @@
 # att skriva av från glaset.
 #
 #   1. Panelen reser sin egen accesspunkt (VibePulse-setup). Den gör det
-#      själv efter 90 s utan nät, eller direkt om du håller KEY3 ~3 s.
+#      själv efter 90 s utan nät, eller om du håller KEY3 ~3 s och väljer
+#      WIFI i SETTINGS — hållet öppnar menyn, inte fönstret.
 #   2. tools/wifi-here.sh
 #
 # Skriptet läser Macens nuvarande SSID, hämtar lösenordet ur nyckelringen


### PR DESCRIPTION
## Outcome

`tools/ota-flash.sh` told you to hold KEY3 until the ring appears. It has not
worked that way since #72 — the hold opens **SETTINGS**, and **UPDATE**
inside the menu opens the window.

It said so in its header *and* in the line it prints at runtime:

```
echo "väntar på underhållsfönstret på $HOST — håll KEY3 ~3 s..."
```

That prints on the terminal at the exact moment someone is standing at the
panel, and it would have had them holding the button waiting for a ring that
never comes. `tools/wifi-here.sh` was wrong twice about the setup window —
in its header, and in the retry advice it prints when the Mac cannot reach
the panel's access point, which is exactly when the operator is stuck. And
the OTA prompt was still incomplete in one state: with **UPDATE READY**
already on the glass a hold does nothing at all, and only the takeover's
UPDATE pill works.

All four corrected.

**Found while preparing to run `docs/manual-test-key3.md`** — the script the
operator would have followed next.

## Root cause / rationale

`test/test_ota_gesture_docs.py` exists to catch exactly this class and did
not. Nine review rounds later, every fix has been in the same place: what
the guard **reads in**, never the rules it applies.

**It only read `.md` files.** A doc is whatever a person follows, not
whatever has a Markdown extension — and a shell runbook is followed more
literally than any prose here, one of them printing its line at the moment of
use. Both scripts are now scanned.

**It only knew English word order** plus the Swedish *noun* form
`KEY3-håll`. Swedish puts the verb first — *"Håll KEY3"* — so both offending
passages matched nothing and the guard called two wrong files clean.

**It matched raw text with literal spaces**, so prose that wraps mid-sentence
escaped it — including the exemption written for `wifi.md`'s hold–hold
passage, which is why I first measured that class as unguardable.

**It could not read a message split across commands.** `— håll` on one
`echo`, `KEY3 ~3 s` on the next, with `" >&2\n  echo "` between them. Then:
only `echo`/`echo -e`, missing `echo -n`; only printf's *format* and not its
arguments; and only physical lines, so a backslash-wrapped invocation lost
everything after the first. Each of those didn't merely weaken the reading —
a line yielding nothing also **ends** the message grouping, so the half
carrying the verb was dropped twice over.

**And joining every `echo` in a file was a hole I dug myself**: the file's
own corrected text names SETTINGS, so any other echo in it inherited that
word. That guard got *blinder the more of the file was fixed*. Adjacent lines
only, now.

**The setup-window class is guarded after all.** I wrote in this file that it
could not be — a rule pairing a hold with setup-window words appeared to flag
three correct passages. That measurement was wrong twice: two were line-wrap
artifacts, and the third was self-exemption, since a step pattern accepting
the bare word `WIFI` matches the window's own name `WIFI SETUP`. With
whitespace normalised and the step required to name SETTINGS or *pick* WIFI,
it flags zero correct passages and catches both real misses. **"I tried it
and got false positives" is only as good as the harness that produced them.**

## Verification

- [x] Relevant focused tests pass — `test/test_ota_gesture_docs.py`, 7 tests,
      green.
- [x] **Mutation-checked every round, in both directions.** Reverting each
      corrected passage fails; narrowing `HOLD`, `ECHOED`, the adjacent
      grouping, the whitespace normalisation and the logical-line joining
      each fail the case written for them. The whitespace mutation
      reproduces on demand the very false positive I had once taken as proof
      the setup rule was unworkable. And after every widening, all seven live
      docs are re-checked to report **zero** on both rules — reach bought
      without noise.
- [x] Both scripts pass `sh -n`.
- [x] `./test/run.sh` passes except `test_interaction_relay_vectors.py`,
      which needs ESP-IDF's bundled Mbed TLS and fails identically on a clean
      checkout in this container — not a regression. Skipping only that line,
      the rest runs to the end with the exit code checked directly: 0.
- [x] No secret, credential, raw session content, production payload, or
      `torget.bin` is included. `TG_OTA_TOKEN` handling is untouched.
- [x] Documentation and changelog match the behavior.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a
      real-host or physical-panel pass.
- [x] No Windows-specific path is touched.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed — comment and `echo` text only, plus
      a test. No firmware source, no consent logic, no upload path.
- [x] No physical flash was requested, performed, or authorized. The consent
      chain is unchanged: the window still opens **only** from the device.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback
      were not treated as approval.

## Not tested / remaining risk

- **No corrected line has been read off a real terminal mid-flash.** They are
  comment and `echo` text, verified by `sh -n` and by reading, not by
  watching someone follow them at the panel. The next real OTA session is
  what confirms the wording actually helps — and that session is the reason
  this PR exists.
- **The takeover completeness fix has no test.** This guard checks that a
  hold is not described as reaching the window without naming the step; it
  does not check that a prompt lists every route out of every state. The rule
  that would is recorded in the docstring as tried and rejected for flagging
  correct prose. That fix rests on review.
- **The parser reads `echo` and `printf`.** A message emitted some other way
  — `cat <<EOF`, a variable printed later — is not reassembled. No script
  here does that today, and I have stopped extending the parser for shapes
  with no instance in the repo; a demonstrable case is worth a commit.
- **The second commit on this branch fixes a false claim in the first.** I
  edited `wifi-here.sh`, then reverted it with `git checkout --` while
  mutation-testing, and pushed a commit whose message and CHANGELOG entry
  said it was corrected when it was not. Kept in history rather than
  force-pushed away, since rewriting it would leave the CHANGELOG sitting on
  a commit that still did not do what it said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33PGKYzaQMyagrqY5dkfE