### PR TITLE
docs: run sheet for the September flash session on the Mac

### DIFF
--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -90,9 +90,23 @@ In a second terminal (sourced the same way):
 
 ```sh
 ls -d build*/                 # only build/ should be here; remove any leftover build-stage/ first
+idf.py fullclean              # drop the CMake cache: a stale TORGET_WITH_BUDDY=ON would otherwise survive
 idf.py build
 tools/ota-flash.sh "$(cat .ota-device)" build   # the build dir is pinned on purpose
 ```
+
+**Say what went into the image.** This checkout's `git status` and the
+uploader's CI gate only vouch for *this* repo. `CMakeLists.txt` also
+pulls in `~/Solelkollen/components` whenever it exists, and Buddy if
+`TORGET_WITH_BUDDY=ON` is cached. Neither is covered by either gate, and
+Buddy carries a DMA configuration that has frozen the glass before. So,
+from a fresh configure: read the build's own status lines — `Solelkollen
+saknas` / `~/Buddy saknas` mean not included; otherwise record each
+companion's `git describe --tags --always --dirty` from its own checkout
+in the review, refuse a `-dirty` companion the same way the uploader
+refuses a dirty platform, and compare against
+`spec/hardware-sources.yaml`. Buddy stays **OFF** unless the user asks
+for it in this session.
 
 The build directory is passed explicitly because the script otherwise
 takes the newest `build*/torget.bin` by mtime, and it makes that choice

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -103,7 +103,7 @@ send the instant 4.1 opens a window, and 4.2 would never happen:
 | 4.1 | Hold KEY3 a full 3 s → SETTINGS → tap **UPDATE** | the window opens, ten-minute countdown, `KEY3 CLOSES` |
 | 4.2 | Short-tap | it closes early, with no upload |
 | 4.3 | Reopen the same way, then hold 3 s inside the already-open window | it switches to WIFI SETUP (the hold–hold shortcut); short-tap to close |
-| 4.4 | Only if there is a second build to install: start `tools/ota-flash.sh`, then hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass |
+| 4.4 | Only if a real second build exists — a *pushed* commit with green CI, since the uploader's CI gate refuses anything else: start `tools/ota-flash.sh`, then hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass. Otherwise record 4.4 as not exercised |
 
 That is all of §4. A short KEY3 press ends the re-armed chain whenever
 you are done.
@@ -157,10 +157,17 @@ network-off part is done once, not twice.
    ```
 
    The tokenserver advertises the newest `torget.bin` by mtime within
-   30 s; the panel sees a distance one higher and shows UPDATE READY.
-   Run 3.4–3.6 against it. This staged image is also a real second build
-   for 4.4 if you want that path exercised. **Before you leave:** confirm with
-   `git log -1` that the empty stage commit is still HEAD, drop it with
+   30 s; the panel sees a distance one higher and shows UPDATE READY
+   (3.4). **Do 3.6 before 3.5**: hold 3 s *while the notice is showing*
+   and confirm nothing happens, *then* tap LATER. LATER starts a one-hour
+   snooze, so the other order leaves 3.6 waiting an hour.
+
+   **This staged image is announcement-only.** The uploader's CI gate
+   refuses a commit without a green run on GitHub, and this one is local
+   and unpushed; do not push it, and do not set `TG_OTA_ALLOW_NO_CI` to
+   get past the gate — that is the user's call, not the sheet's. So 4.4
+   is not exercised by it. **Before you leave:** confirm with `git log -1`
+   that the empty stage commit is still HEAD, drop it with
    `git reset --hard HEAD~1`, and delete `build-stage/`, or the panel
    nags about a phantom version every hour from then on.
 4. **§4 update path** — covered by §1 of this sheet: 4.5 right after the

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -219,8 +219,10 @@ network-off part is done once, not twice.
   the first line, the way the 2026-08-30 one does. Name every step that
   was *not* run.
 - Failures → `docs/observability-backlog.md`; root causes →
-  `docs/lessons.md`. Note how long a hold actually lasted for 1.2, 2.7
-  and 3.3.
+  `docs/lessons.md`. For the three timing steps, record what was actually
+  timed: how long the press lasted in 1.2, how long the wait was before
+  the setup window opened by itself in 2.7, and how soon after the
+  takeover the short tap came in 3.3.
 - README's SETTINGS section still says no panel has been flashed with the
   menu. Once §3 passes, that sentence changes; do it in the same commit
   as the inventory update.

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -55,16 +55,29 @@ panel has never seen:
    `ls /dev/cu.usbmodem*` must list a port. If it never appears, §2
    cannot be done this session; the three lines are logged once at boot
    and nowhere else. Say so in the review rather than skipping §2 quietly.
-5. Open the serial monitor before flashing so the boot log is captured:
+5. **Find the panel's port, then open the monitor.** Source ESP-IDF in
+   every terminal you use, the monitor one included — `idf.py` does not
+   exist in a fresh shell:
 
    ```sh
-   idf.py -p $(ls /dev/cu.usbmodem* | head -1) monitor
+   . ~/esp/esp-idf/export.sh        # their install path may differ
+   ls /dev/cu.usbmodem*             # note the list
+   ```
+
+   Now unplug the panel's data cable, list again, plug it back, list a
+   third time: the entry that vanishes and returns is the panel. Use that
+   exact path, not the first match — a Mac with another serial device
+   would otherwise monitor the wrong thing and lose the once-only lines:
+
+   ```sh
+   idf.py -p /dev/cu.usbmodemXXXX monitor
    ```
 
 ## 1. Build and deliver (flash authorization required)
 
+In a second terminal (sourced the same way):
+
 ```sh
-. ~/esp/esp-idf/export.sh
 idf.py build
 tools/ota-flash.sh            # waits; prints the newest build*/torget.bin it will send
 ```
@@ -131,6 +144,25 @@ network-off part is done once, not twice.
    redraw) and 3.5 (LATER must not bring the menu back). **Do not have
    `tools/ota-flash.sh` running here**; a leftover copy uploads the moment
    a window opens.
+
+   **3.4 needs a strictly newer version than the one now running**, and
+   after §1 the newest `build*/torget.bin` on the Mac *is* the running
+   one, so nothing would announce. The firmware orders versions by the
+   commit distance in `git describe`, so stage one more commit and build
+   it into its own directory:
+
+   ```sh
+   git commit --allow-empty -m "stage: one commit ahead for manual-test 3.4"
+   idf.py -B build-stage build      # clean tree, so not -dirty
+   ```
+
+   The tokenserver advertises the newest `torget.bin` by mtime within
+   30 s; the panel sees a distance one higher and shows UPDATE READY.
+   Run 3.4–3.6 against it. This staged image is also a real second build
+   for 4.4 if you want that path exercised. **Before you leave:** confirm with
+   `git log -1` that the empty stage commit is still HEAD, drop it with
+   `git reset --hard HEAD~1`, and delete `build-stage/`, or the panel
+   nags about a phantom version every hour from then on.
 4. **§4 update path** — covered by §1 of this sheet: 4.5 right after the
    first delivery, then 4.1–4.3 on the new image with nothing armed, and
    4.4 only if a second build goes on. Nothing left here.

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -14,7 +14,7 @@ panel has never seen:
 
 | Change | Where it landed | What only the glass can prove |
 |---|---|---|
-| SETTINGS menu on a 3 s KEY3 hold (UPDATE / WIFI / ABOUT) | #72, #73 | timing, z-order against NO NETWORK, the takeover hand-off |
+| SETTINGS menu on a 3 s KEY3 hold (UPDATE / WIFI / ABOUT) | #72, #73 | timing, z-order against NO NETWORK, the takeover hand-off. The flashed image predates the menu: its hold opens the update window directly, which is how the first delivery in §1 goes |
 | Overlay cost lines at boot (`overlaykostnad …`) | #77 | the actual `settings` internal-RAM figure — the FEATURES row waits on it |
 | Setup QR no longer outlives its window | #76 | no leftover QR over `NO NETWORK` |
 | KEY3 arbitration moved to pure platform code | #73 | no behaviour change — a regression here would be a bug |
@@ -45,9 +45,17 @@ panel has never seen:
 
    Then `python3 tools/vibepulse_setup.py doctor` — it now names a saved
    Codex mode that would silently hide permission cards (#82).
-4. Panel on **its own USB power supply**, not the Mac's port. The Mac port
-   cannot run the AMOLED and it looks exactly like a bad cable.
-5. Open a serial monitor before flashing so the boot log is captured:
+4. **Power and serial at the same time.** The panel must run from its
+   own power supply (a Mac port cannot run the AMOLED; it looks exactly
+   like a bad cable) *and* the Mac must still see `/dev/cu.usbmodem*` to
+   capture the boot log. That takes a powered USB hub or a PSU/data-split
+   cable, not a plain wall charger. `docs/lessons.md` (2026-08-13) records
+   serial-monitoring a *running* board as unverified, so this is the
+   first thing to confirm: with the panel booted on that arrangement,
+   `ls /dev/cu.usbmodem*` must list a port. If it never appears, §2
+   cannot be done this session; the three lines are logged once at boot
+   and nowhere else. Say so in the review rather than skipping §2 quietly.
+5. Open the serial monitor before flashing so the boot log is captured:
 
    ```sh
    idf.py -p $(ls /dev/cu.usbmodem* | head -1) monitor
@@ -61,12 +69,31 @@ idf.py build
 tools/ota-flash.sh            # waits; prints the newest build*/torget.bin it will send
 ```
 
-Then, **at the panel**: hold KEY3 a full 3 s → SETTINGS → tap **UPDATE**.
-The uploader only starts when the window is open; the hold alone reaches
-the menu, nothing more. Expect RECEIVING → VERIFYING → RESTARTING, then
-the boot-health gate. After the reboot the window re-arms once, so a
-second build in the same sitting needs no new hold. A short KEY3 press
-ends the chain when you are done.
+**The first delivery lands on the old image, and the old image has no
+SETTINGS menu.** On `v1.0.0-25-g054db68` the 3 s KEY3 hold opens the
+update window directly; the menu, and UPDATE inside it, arrive with this
+build. So for this one upload: hold KEY3 a full 3 s, the UPDATES ON ring
+appears, and the uploader (already polling) sends. Expect RECEIVING →
+VERIFYING → RESTARTING, then the boot-health gate. The script exits after
+the one upload.
+
+After the reboot the window re-arms itself once (manual-test **4.5**).
+Nothing is armed on the Mac now, so nothing uploads. Short-tap KEY3 to
+close it.
+
+Now the new image is up and the rest of `docs/manual-test-key3.md` §4
+runs with **nothing polling on the Mac** — the uploader would otherwise
+send the instant 4.1 opens a window, and 4.2 would never happen:
+
+| # | At the panel | Expect |
+|---|---|---|
+| 4.1 | Hold KEY3 a full 3 s → SETTINGS → tap **UPDATE** | the window opens, ten-minute countdown, `KEY3 CLOSES` |
+| 4.2 | Short-tap | it closes early, with no upload |
+| 4.3 | Reopen the same way, then hold 3 s inside the already-open window | it switches to WIFI SETUP (the hold–hold shortcut); short-tap to close |
+| 4.4 | Only if there is a second build to install: start `tools/ota-flash.sh`, then hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass |
+
+That is all of §4. A short KEY3 press ends the re-armed chain whenever
+you are done.
 
 If the panel shows **UPDATE READY** the moment it boots, the booted image
 is older than what the tokenserver advertises — compare the banner with
@@ -104,9 +131,9 @@ network-off part is done once, not twice.
    redraw) and 3.5 (LATER must not bring the menu back). **Do not have
    `tools/ota-flash.sh` running here**; a leftover copy uploads the moment
    a window opens.
-4. **§4 update path** — already exercised by §1 of this sheet; only 4.3
-   (hold–hold shortcut inside an open window) and 4.5 (re-arm once) still
-   need a look.
+4. **§4 update path** — covered by §1 of this sheet: 4.5 right after the
+   first delivery, then 4.1–4.3 on the new image with nothing armed, and
+   4.4 only if a second build goes on. Nothing left here.
 5. **Codex smoke test** — `docs/agent-setup.md`, "Post-flash physical Codex
    smoke test": one `mcp__vibepulse__ask` with header `Test`, question
    `Ser du APPROVE?`, `Ja` recommended. Pass only on a real APPROVE tap

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -109,8 +109,9 @@ first is the normal one:
 - **UPDATE READY is showing.** Tap its **UPDATE** pill. A KEY3 hold does
   nothing while the takeover owns the glass — deliberately — so holding
   here leaves the uploader waiting forever.
-- **It has not appeared yet.** Hold KEY3 a full 3 s; on this old image
-  the hold opens the update window directly and the ring appears.
+- **It has not appeared yet.** Hold KEY3 a full 3 s. There is no
+  SETTINGS on this old image for the hold to reach, so it opens the
+  update window directly and the ring appears.
 
 Either way the uploader (already polling) sends. Expect RECEIVING →
 VERIFYING → RESTARTING, then the boot-health gate. The script exits after

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -168,8 +168,10 @@ network-off part is done once, not twice.
    get past the gate — that is the user's call, not the sheet's. So 4.4
    is not exercised by it. **Before you leave:** confirm with `git log -1`
    that the empty stage commit is still HEAD, drop it with
-   `git reset --hard HEAD~1`, and delete `build-stage/`, or the panel
-   nags about a phantom version every hour from then on.
+   `git reset --soft HEAD~1` — *soft*, so the review notes and inventory
+   edits from §4 that may already be in the working tree survive — and
+   delete `build-stage/` separately, or the panel nags about a phantom
+   version every hour from then on.
 4. **§4 update path** — covered by §1 of this sheet: 4.5 right after the
    first delivery, then 4.1–4.3 on the new image with nothing armed, and
    4.4 only if a second build goes on. Nothing left here.

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -44,7 +44,17 @@ panel has never seen:
    ```
 
    Then `python3 tools/vibepulse_setup.py doctor` — it now names a saved
-   Codex mode that would silently hide permission cards (#82).
+   Codex mode that would silently hide permission cards (#82) — **and**
+   `python3 tools/tokenserver/smoke.py`, which compares the live service's
+   `rev` and `srcFingerprint` against *this* checkout. That second check
+   is not optional: `kickstart` restarts whatever checkout the plist
+   already points at, and a service running from an older worktree
+   (`docs/lessons.md`, 2026-08-13 and its 2026-08-28 recurrence) would
+   read `build*/torget.bin` from *that* tree, so the staged build in §3
+   would never be advertised and 3.4 could not fire. If smoke reports a
+   rev or fingerprint mismatch, re-point the service with
+   `tools/vibepulse_macos_service.py` (`bootout` + `bootstrap`, not
+   `kickstart`) before going on.
 4. **Power and serial at the same time.** The panel must run from its
    own power supply (a Mac port cannot run the AMOLED; it looks exactly
    like a bad cable) *and* the Mac must still see `/dev/cu.usbmodem*` to

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -53,8 +53,9 @@ panel has never seen:
    read `build*/torget.bin` from *that* tree, so the staged build in §3
    would never be advertised and 3.4 could not fire. If smoke reports a
    rev or fingerprint mismatch, re-point the service with
-   `tools/vibepulse_macos_service.py` (`bootout` + `bootstrap`, not
-   `kickstart`) before going on.
+   `python3 tools/vibepulse_macos_service.py install` from this checkout
+   (it does a real `bootout` + `bootstrap`; `kickstart` cannot move it),
+   then run smoke again before going on.
 4. **Power and serial at the same time.** The panel must run from its
    own power supply (a Mac port cannot run the AMOLED; it looks exactly
    like a bad cable) *and* the Mac must still see `/dev/cu.usbmodem*` to

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -1,0 +1,131 @@
+# Flash session 2026-09: bring the panel up to main
+
+A run sheet for the *local* Claude Code session on the Mac that has the
+panel on USB and `.ota-device` in the repo root. A cloud session cannot
+reach the panel, the serial port or the tokenserver; it can only prepare
+this list. Nothing here authorizes a flash by itself — the user says
+"flash" in the local session, and that session does it.
+
+## Why this session exists
+
+`spec/device-units.yaml` says `torget-home-01` runs `v1.0.0-25-g054db68`
+(flashed 2026-08-30). `main` is roughly 40 commits past that. What the
+panel has never seen:
+
+| Change | Where it landed | What only the glass can prove |
+|---|---|---|
+| SETTINGS menu on a 3 s KEY3 hold (UPDATE / WIFI / ABOUT) | #72, #73 | timing, z-order against NO NETWORK, the takeover hand-off |
+| Overlay cost lines at boot (`overlaykostnad …`) | #77 | the actual `settings` internal-RAM figure — the FEATURES row waits on it |
+| Setup QR no longer outlives its window | #76 | no leftover QR over `NO NETWORK` |
+| KEY3 arbitration moved to pure platform code | #73 | no behaviour change — a regression here would be a bug |
+| `claudeSourcePresent`, Codex-only host start, body drain | #69–#71 | host side; flashed panels tolerate them by design |
+
+## 0. Preflight (before any build)
+
+1. **Both docs PRs are merged**: #83 (README frame-drift guard) and #84
+   (OTA runbooks say the right gesture). Neither touches firmware, but #84
+   fixes the line `tools/ota-flash.sh` prints while you stand at the panel.
+2. On the Mac, in the repo that `.ota-device` lives in:
+
+   ```sh
+   git checkout main && git pull origin main
+   git describe --tags --always --dirty      # must NOT end in -dirty
+   git status --short                        # empty
+   ```
+
+   Write the version down. It is compared against `otaAvailableVersion`
+   and the booted banner later. The sender refuses `-dirty` on purpose;
+   never set `TG_OTA_ALLOW_DIRTY` without the user saying so.
+3. Tokenserver: if anything under `tools/tokenserver/` changed since it
+   was last restarted (it has — #69, #70, #71, #82), restart it:
+
+   ```sh
+   launchctl kickstart -k gui/$(id -u)/se.torget.tokenserver
+   ```
+
+   Then `python3 tools/vibepulse_setup.py doctor` — it now names a saved
+   Codex mode that would silently hide permission cards (#82).
+4. Panel on **its own USB power supply**, not the Mac's port. The Mac port
+   cannot run the AMOLED and it looks exactly like a bad cable.
+5. Open a serial monitor before flashing so the boot log is captured:
+
+   ```sh
+   idf.py -p $(ls /dev/cu.usbmodem* | head -1) monitor
+   ```
+
+## 1. Build and deliver (flash authorization required)
+
+```sh
+. ~/esp/esp-idf/export.sh
+idf.py build
+tools/ota-flash.sh            # waits; prints the newest build*/torget.bin it will send
+```
+
+Then, **at the panel**: hold KEY3 a full 3 s → SETTINGS → tap **UPDATE**.
+The uploader only starts when the window is open; the hold alone reaches
+the menu, nothing more. Expect RECEIVING → VERIFYING → RESTARTING, then
+the boot-health gate. After the reboot the window re-arms once, so a
+second build in the same sitting needs no new hold. A short KEY3 press
+ends the chain when you are done.
+
+If the panel shows **UPDATE READY** the moment it boots, the booted image
+is older than what the tokenserver advertises — compare the banner with
+the version from §0 before doing anything else.
+
+USB (`idf.py -p <port> flash`, BOOT held + RESET) stays the rescue path
+if the image does not boot. It needs its own go-ahead.
+
+## 2. Read the boot log (2 min, do it first)
+
+Three lines appear once, early:
+
+```
+overlaykostnad wifi-setup: LVGL-pool +N B (pool U/T använt), internt ±N B (kvar F)
+overlaykostnad settings:   ...
+overlaykostnad ota:        ...
+```
+
+Copy all three into the review. The `settings` internal figure is the
+budget the AMOLED rule asks for: `+0 B` retires the internal-RAM worry
+with evidence; anything else is the number FEATURES has to fit under.
+Also note the first `heap:` line (internal free, largest DMA block).
+
+## 3. The panel checks, in order
+
+Run `docs/manual-test-key3.md` as written. The order below is only so the
+network-off part is done once, not twice.
+
+1. **§1 gesture** (2 min) — 1.2 is the one to be careful with: a ~2 s
+   press must panic and open *nothing*.
+2. **§2 without a network** (5 min, AP off) — 2.4 (ABOUT shows a dash, not
+   `0.0.0.0`) and 2.8 (no leftover QR over NO NETWORK) are the two least
+   proven.
+3. **§3 menu vs takeover** (5 min) — 3.1 (menu stays above the NO NETWORK
+   redraw) and 3.5 (LATER must not bring the menu back). **Do not have
+   `tools/ota-flash.sh` running here**; a leftover copy uploads the moment
+   a window opens.
+4. **§4 update path** — already exercised by §1 of this sheet; only 4.3
+   (hold–hold shortcut inside an open window) and 4.5 (re-arm once) still
+   need a look.
+5. **Codex smoke test** — `docs/agent-setup.md`, "Post-flash physical Codex
+   smoke test": one `mcp__vibepulse__ask` with header `Test`, question
+   `Ser du APPROVE?`, `Ja` recommended. Pass only on a real APPROVE tap
+   returning `answered`, `option_index: 0`. LEAVE IT, timeout or the
+   computer fallback is not a pass.
+6. **§5 soak** (30+ min) — `heap:` every 10 s, DMA largest block steady;
+   open and close SETTINGS a dozen times and confirm the pool figure does
+   **not** climb per open.
+
+## 4. Close out (same session, before the shelf gets it back)
+
+- `spec/device-units.yaml`: set `installed_firmware` to the booted
+  `git describe` and `last_physical_verification` to today.
+- Write the review under `docs/superpowers/reviews/` with the outcome in
+  the first line, the way the 2026-08-30 one does. Name every step that
+  was *not* run.
+- Failures → `docs/observability-backlog.md`; root causes →
+  `docs/lessons.md`. Note how long a hold actually lasted for 1.2, 2.7
+  and 3.3.
+- README's SETTINGS section still says no panel has been flashed with the
+  menu. Once §3 passes, that sentence changes; do it in the same commit
+  as the inventory update.

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -78,9 +78,15 @@ panel has never seen:
 In a second terminal (sourced the same way):
 
 ```sh
+ls -d build*/                 # only build/ should be here; remove any leftover build-stage/ first
 idf.py build
-tools/ota-flash.sh            # waits; prints the newest build*/torget.bin it will send
+tools/ota-flash.sh "$(cat .ota-device)" build   # the build dir is pinned on purpose
 ```
+
+The build directory is passed explicitly because the script otherwise
+takes the newest `build*/torget.bin` by mtime, and it makes that choice
+only after the window opens — too late for you to see it. A stale
+`build-stage/` from an earlier session would win and be sent.
 
 **The first delivery lands on the old image, and the old image has no
 SETTINGS menu.** On `v1.0.0-25-g054db68` the 3 s KEY3 hold opens the
@@ -103,7 +109,7 @@ send the instant 4.1 opens a window, and 4.2 would never happen:
 | 4.1 | Hold KEY3 a full 3 s → SETTINGS → tap **UPDATE** | the window opens, ten-minute countdown, `KEY3 CLOSES` |
 | 4.2 | Short-tap | it closes early, with no upload |
 | 4.3 | Reopen the same way, then hold 3 s inside the already-open window | it switches to WIFI SETUP (the hold–hold shortcut); short-tap to close |
-| 4.4 | Only if a real second build exists — a *pushed* commit with green CI, since the uploader's CI gate refuses anything else: start `tools/ota-flash.sh`, then hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass. Otherwise record 4.4 as not exercised |
+| 4.4 | Only if a real second build exists — a *pushed* commit with green CI, since the uploader's CI gate refuses anything else: start `tools/ota-flash.sh "$(cat .ota-device)" <that build dir>`, then hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass. Otherwise record 4.4 as not exercised |
 
 That is all of §4. A short KEY3 press ends the re-armed chain whenever
 you are done.

--- a/docs/flash-session-2026-09.md
+++ b/docs/flash-session-2026-09.md
@@ -99,10 +99,20 @@ only after the window opens — too late for you to see it. A stale
 `build-stage/` from an earlier session would win and be sent.
 
 **The first delivery lands on the old image, and the old image has no
-SETTINGS menu.** On `v1.0.0-25-g054db68` the 3 s KEY3 hold opens the
-update window directly; the menu, and UPDATE inside it, arrive with this
-build. So for this one upload: hold KEY3 a full 3 s, the UPDATES ON ring
-appears, and the uploader (already polling) sends. Expect RECEIVING →
+SETTINGS menu.** On `v1.0.0-25-g054db68` the menu does not exist yet; it
+arrives with this build. What that image *does* have is the UPDATE READY
+takeover, and the tokenserver advertises the new `build/torget.bin`
+within about 30 s of `idf.py build` — so by the time you reach the panel
+the takeover has most likely already taken the glass. Two cases, and the
+first is the normal one:
+
+- **UPDATE READY is showing.** Tap its **UPDATE** pill. A KEY3 hold does
+  nothing while the takeover owns the glass — deliberately — so holding
+  here leaves the uploader waiting forever.
+- **It has not appeared yet.** Hold KEY3 a full 3 s; on this old image
+  the hold opens the update window directly and the ring appears.
+
+Either way the uploader (already polling) sends. Expect RECEIVING →
 VERIFYING → RESTARTING, then the boot-health gate. The script exits after
 the one upload.
 
@@ -119,7 +129,7 @@ send the instant 4.1 opens a window, and 4.2 would never happen:
 | 4.1 | Hold KEY3 a full 3 s → SETTINGS → tap **UPDATE** | the window opens, ten-minute countdown, `KEY3 CLOSES` |
 | 4.2 | Short-tap | it closes early, with no upload |
 | 4.3 | Reopen the same way, then hold 3 s inside the already-open window | it switches to WIFI SETUP (the hold–hold shortcut); short-tap to close |
-| 4.4 | Only if a real second build exists — a *pushed* commit with green CI, since the uploader's CI gate refuses anything else: start `tools/ota-flash.sh "$(cat .ota-device)" <that build dir>`, then hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass. Otherwise record 4.4 as not exercised |
+| 4.4 | Only if a real second build exists — a *pushed* commit with green CI, since the uploader's CI gate refuses anything else. The panel will already be showing UPDATE READY for it: tap **LATER** first, because the point of 4.4 is the menu's route and the hold is ignored under the takeover. Then start `tools/ota-flash.sh "$(cat .ota-device)" <that build dir>`, hold 3 s → SETTINGS → tap **UPDATE** | the upload runs through the menu's row, the first time that path is used on the glass. Otherwise record 4.4 as not exercised |
 
 That is all of §4. A short KEY3 press ends the re-armed chain whenever
 you are done.

--- a/test/test_ota_gesture_docs.py
+++ b/test/test_ota_gesture_docs.py
@@ -46,6 +46,7 @@ LIVE_DOCS = (
     "docs/ota.md",
     "docs/wifi.md",
     "docs/agent-setup.md",
+    "docs/flash-session-2026-09.md",
 )
 
 # A hold is not always spelled with KEY3 next to it. The README passage


### PR DESCRIPTION
## Outcome

A single run sheet, `docs/flash-session-2026-09.md`, for the local Mac session that brings the panel from `v1.0.0-25-g054db68` (flashed 2026-08-30, per `spec/device-units.yaml`) up to current `main` (`v1.0.0-66-g900c4d1`). It gathers what is otherwise spread over four documents: preflight (clean `main`, tokenserver restart, dedicated power, monitor open before the flash), OTA delivery through **SETTINGS → UPDATE**, the three `overlaykostnad` boot lines to write down, the order to run `docs/manual-test-key3.md` in with the least-proven steps named, the post-flash Codex smoke test, the soak, and the close-out (device inventory, review, the README sentence that still says no panel has SETTINGS).

It authorizes nothing. The flash order is given in the local session, as `CLAUDE.md` requires.

The sheet is also added to `LIVE_DOCS` in `test/test_ota_gesture_docs.py`, as that file's own comment asks of any new runbook, and it passes the guard, including the setup-window check #84 added.

## Root cause / rationale

`main` is some forty commits past the flashed image and the SETTINGS menu has never been on the glass. The existing manual is deliberately scoped to the KEY3 flow alone; the preflight, the boot-log capture and the close-out live elsewhere, and a cloud session cannot reach the panel to do any of it. A cloud session *can* write the list the local one follows.

## Verification

- [x] Relevant focused tests pass — `test/test_ota_gesture_docs.py`, 7 tests, green with the new doc in `LIVE_DOCS`.
- [x] `./test/run.sh` passes, or the exact omission and reason are stated: in this container it stops at `test_interaction_relay_vectors.py` (needs ESP-IDF's bundled Mbed TLS, the same omission #83 and #84 recorded) and, with that line skipped, at `test_vibepulse_visual_landmarks.py` (the simulator's `cmake -G Ninja` configure fails, no toolchain here). Everything before those two runs green. Neither touches this change; CI runs both.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] Documentation and changelog match the behavior — no changelog entry: a run sheet for one session is not a user-facing change.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass.
- [x] No Windows-specific path is touched.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed. Documentation and one test-list entry only.
- [x] No physical flash was requested, performed, or authorized. The sheet says so in its first paragraph.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval.

## Not tested / remaining risk

- The sheet has not yet been followed at the panel. That is what the session it describes will do; step numbers were checked against the current `docs/manual-test-key3.md` by hand.
- The merge with `main` resolved a one-line conflict in `LIVE_DOCS` by keeping both #84's two scripts and this doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BDZhEymP8PfmsRB6DoR5C

---
_Generated by [Claude Code](https://claude.ai/code/session_014BDZhEymP8PfmsRB6DoR5C)_