### PR TITLE
fix(net): stop logging the relay's secret URL on every failed fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **The panel printed the relay's secret URL every time a cloud fetch
+  failed.** All three failure paths in `components/torget_net/torget_http.c`
+  logged the address they had just failed on. When the fetch had failed over
+  to the numbers relay that address was the cloud mailbox URL, and its path
+  `/u/<secret>` *is* the access control — anyone handed a serial capture or a
+  pasted observability log after a relay outage could read the panel's
+  figures and overwrite them. `docs/relay.md` has said "Never print the
+  secret URL in logs or a shared transcript" since the relay shipped; the
+  code had simply never been revisited after a credential-bearing address
+  started flowing through the same helper. Failure lines now name a redacted
+  target — `<scheme>://<host> via LAN` or `… via relä` — which still
+  separates a wrong hostname from a wrong port from a dead relay, and drops
+  the path, query, fragment and any userinfo. The redaction is unconditional
+  rather than relay-only, so a fourth failure path inherits it instead of
+  having to remember it, and it lives in one pure helper
+  (`net_log_target.c`) that `test/test_net_log_target.c` host-tests directly.
+  `test/test_relay_boundary.py` now parses every `ESP_LOG*` call in the fetch
+  client and fails if one names a raw address.
+
 - **The OTA runbook told you the wrong gesture, on the terminal, while you
   stood at the panel.** `tools/ota-flash.sh` said "håll KEY3 ~3 s tills
   UPDATES ON-ringen syns" — in its header *and* in the line it prints while

--- a/components/torget_net/CMakeLists.txt
+++ b/components/torget_net/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Glance-mönstrets HTTP-klient: en begränsad GET, hela kroppen eller
 # ingenting — nu med reläet som reservväg när LAN:et inte går att nå.
 # net_source_policy är den rena kärnan och värdtestas i test/run.sh.
+# net_log_target håller reläets hemliga sökväg ur loggarna och värdtestas
+# på samma sätt.
 idf_component_register(
-  SRCS "torget_http.c" "net_source_policy.c" "service_discovery.c"
-       "service_discovery_policy.c"
+  SRCS "torget_http.c" "net_log_target.c" "net_source_policy.c"
+       "service_discovery.c" "service_discovery_policy.c"
   INCLUDE_DIRS "."
   PRIV_REQUIRES torget_app esp_http_client esp-tls esp_timer freertos mdns nvs_flash)

--- a/components/torget_net/net_log_target.c
+++ b/components/torget_net/net_log_target.c
@@ -1,0 +1,55 @@
+#include "net_log_target.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* Plats som vägordet måste få behålla när värden är lång: " via relä" är
+ * nio byte i UTF-8, och vilken väg som provades är själva poängen med
+ * raden — den får aldrig kapas bort till förmån för fler tecken av ett
+ * värdnamn. */
+#define TG_NET_LOG_ROUTE_RESERVE 12
+
+/*
+ * Ursprunget: schemat och värden, och inget av det som kan bära en
+ * hemlighet. Sökväg, fråga och fragment kapas alltid, och användarinfon
+ * före '@' hoppas över — den är också en referens, inte en adress.
+ */
+static bool origin_of(const char *url, char *out, size_t cap) {
+  if (url == NULL || out == NULL || cap == 0) return false;
+
+  const char *mark = strstr(url, "://");
+  if (mark == NULL || mark == url) return false;
+  const size_t scheme_len = (size_t)(mark - url) + 3;
+
+  const char *authority = url + scheme_len;
+  const size_t authority_len = strcspn(authority, "/?#");
+
+  size_t host_start = 0;
+  for (size_t i = 0; i < authority_len; i++) {
+    if (authority[i] == '@') host_start = i + 1;
+  }
+  const char *host = authority + host_start;
+  size_t host_len = authority_len - host_start;
+  if (host_len == 0) return false;
+  if (scheme_len + 1 >= cap) return false;
+
+  memcpy(out, url, scheme_len);
+  const size_t room = cap - scheme_len - 1;
+  if (host_len > room) host_len = room;
+  memcpy(out + scheme_len, host, host_len);
+  out[scheme_len + host_len] = '\0';
+  return true;
+}
+
+void tg_net_log_target(char *out, size_t cap, const char *url, bool relay) {
+  if (out == NULL || cap == 0) return;
+
+  const char *route = relay ? "relä" : "LAN";
+  char origin[TG_NET_LOG_TARGET_CAP - TG_NET_LOG_ROUTE_RESERVE];
+
+  if (!origin_of(url, origin, sizeof origin)) {
+    snprintf(out, cap, "okänd adress via %s", route);
+    return;
+  }
+  snprintf(out, cap, "%s via %s", origin, route);
+}

--- a/components/torget_net/net_log_target.h
+++ b/components/torget_net/net_log_target.h
@@ -1,0 +1,33 @@
+#ifndef TORGET_NET_LOG_TARGET_H
+#define TORGET_NET_LOG_TARGET_H
+
+/*
+ * Loggsäker beskrivning av en hämtnings mål. Ren stränglogik utan ESP-IDF
+ * — värdtestad i test/run.sh (test_net_log_target.c).
+ *
+ * Varför den finns: reläets adress ÄR åtkomstnyckeln. Sökvägen
+ * `/u/<hemlighet>` är hela autentiseringen (docs/relay.md), så den som får
+ * en seriedump eller en klistrad observabilitetslogg kan både läsa
+ * panelens siffror och skriva över dem. En felad hämtning loggade förr
+ * hela adressen, och en logg delas långt mer vårdslöst än en hemlighet.
+ *
+ * Regeln: loggen får se schema + värd och vilken väg som provades, aldrig
+ * sökvägen. Redigeringen är ovillkorlig — den frågar inte om just den här
+ * adressen råkar vara hemlig — så en ny anropsplats ärver skyddet i
+ * stället för att behöva komma ihåg det.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Rymmer schema + värd + vägordet. Ett längre värdnamn kapas; en kapad
+ * värd är fortfarande bara en värd. */
+#define TG_NET_LOG_TARGET_CAP 96
+
+/* Skriver "<schema>://<värd> via LAN" eller "<schema>://<värd> via relä"
+ * till out, och NUL-terminerar alltid när cap > 0. En adress utan schema
+ * eller värd blir "okänd adress via <väg>": hellre intetsägande än
+ * läckande. */
+void tg_net_log_target(char *out, size_t cap, const char *url, bool relay);
+
+#endif

--- a/components/torget_net/torget_http.c
+++ b/components/torget_net/torget_http.c
@@ -12,6 +12,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 
+#include "net_log_target.h"
 #include "net_source_policy.h"
 #include "service_discovery.h"
 #include "vibepulse_recovery.h"
@@ -108,16 +109,32 @@ static bool http_get_timeout(const char *url, char *buf, size_t cap,
   esp_err_t err = esp_http_client_perform(client);
   int status = esp_http_client_get_status_code(client);
 
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "hämtning misslyckades: %s (%s)", esp_err_to_name(err), url);
-  } else if (status != 200) {
-    ESP_LOGW(TAG, "oväntad statuskod %d (%s)", status, url);
-  } else if (body.overflow) {
-    ESP_LOGW(TAG, "kroppen större än %u byte, avvisad (%s)", (unsigned)cap, url);
-  } else {
+  if (err == ESP_OK && status == 200 && !body.overflow) {
     buf[body.len] = '\0';
     if (len_out) *len_out = body.len;
     ok = true;
+  } else {
+    /* Adressen får ALDRIG loggas rå. Reläets sökväg, `/u/<hemlighet>`, är
+     * hela åtkomstkontrollen (docs/relay.md), och det som hamnar här läses
+     * ur en seriedump eller klistras in i en felsökningstråd. Schema, värd
+     * och vilken väg som provades räcker för att skilja fel hamn från fel
+     * värd från ett dött relä.
+     *
+     * `cloud` är vägordet: den är sann exakt när hämtningen gick till
+     * reläet (TG_NET_SOURCE_RELAY), och redigeringen är ändå ovillkorlig —
+     * en felställd flagga får kosta fel vägord, aldrig en läckt sökväg. */
+    char target[TG_NET_LOG_TARGET_CAP];
+    tg_net_log_target(target, sizeof target, url, cloud);
+
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "hämtning misslyckades: %s (%s)", esp_err_to_name(err),
+               target);
+    } else if (status != 200) {
+      ESP_LOGW(TAG, "oväntad statuskod %d (%s)", status, target);
+    } else {
+      ESP_LOGW(TAG, "kroppen större än %u byte, avvisad (%s)", (unsigned)cap,
+               target);
+    }
   }
 
 done:

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,40 @@ point at the backlog item.
 
 ---
 
+## 2026-09-06 · The panel logged the credential it was told never to print
+
+**What happened:** all three failure paths in `torget_http.c` logged the
+address they had just failed on — `hämtning misslyckades: … (%s)`,
+`oväntad statuskod %d (%s)`, `kroppen större än … (%s)`. When the fetch had
+failed over to the numbers relay, that address was the cloud mailbox URL,
+whose path `/u/<secret>` *is* the access control: it reads the panel's
+figures and overwrites them. `docs/relay.md` has said "Never print the
+secret URL in logs or a shared transcript" since the relay shipped, so the
+code contradicted a written safety rule — and a relay outage is exactly the
+moment someone attaches a monitor and pastes the output into a thread.
+**Root cause:** the logs predate the relay. They were written when every
+address was a LAN address and a URL was just a URL; the relay added a
+credential-bearing address to the same helper and nobody revisited what the
+old lines print. Found by a Codex review on the #87 cleanup PR, on a file
+that PR did not touch.
+**The rule now:** a log may see scheme + host and which route was tried;
+the path never. The redaction is **unconditional** — it does not ask
+whether this particular address is the secret one — and it lives in the one
+helper every failure path already goes through, so a fourth path inherits
+it instead of having to remember it. The general shape: when a value
+becomes a credential, the code that *prints* it is as much a caller as the
+code that sends it.
+**Guards:** `components/torget_net/net_log_target.c` is pure string logic,
+host-tested by `test/test_net_log_target.c` (secret never survives, route
+survives truncation, short buffers neither overflow nor leak).
+`test/test_relay_boundary.py` parses every `ESP_LOG*` call in
+`torget_http.c` and fails if one names a raw address — it catches all three
+original lines. **Watch for:** ESP-IDF's own `HTTP_CLIENT` tag prints the
+full request line at `ESP_LOGD`. The inherited default log level compiles
+that out today; raising it reopens the leak (OBS-35, paired with OBS-28).
+
+---
+
 ## 2026-09-05 · Pinning a screenshot's size did not pin its content
 
 **What happened:** the global Wi-Fi indicator was redrawn in `d5be82d`

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -479,6 +479,8 @@ of the full host-gate era; worth a signature here before it becomes a
 retry of) the unread body on early 4xx, and reproduce under load on a
 Windows box before trusting either — a wire test asserting a security
 boundary must not be loosened blindly.
+
+### OBS-28 · Pin logging config on purpose
 `firmware · S · open`
 `sdkconfig.defaults` deliberately pins flash, PSRAM, LVGL, and mbedTLS
 with reasoned comments — but nothing about logging: default level,
@@ -490,3 +492,20 @@ valve currently fails silently.
 **Fix:** pin `CONFIG_LOG_DEFAULT_LEVEL`, console, panic + TWDT choices
 (with the same style of comment the file already uses), enable
 `LV_USE_LOG` routed to `ESP_LOG`.
+
+### OBS-35 · A raised log level puts the relay secret back on the wire
+`firmware · S · open`
+The panel's own fetch logs are redacted: `torget_http.c` hands every
+failure line through `tg_net_log_target()`, which keeps scheme, host and
+route and drops the path — the relay's `/u/<secret>` is its whole access
+control (`docs/relay.md`). ESP-IDF's `HTTP_CLIENT` tag is not redacted:
+`esp_http_client.c` logs the full request line at `ESP_LOGD`
+("Write header[%d]: %s") and the `Location` header on a redirect, both of
+which contain the secret. Today that is inert — the inherited default log
+level compiles `ESP_LOGD` out — so this is a *latent* leak that OBS-28's
+"pin logging on purpose" would decide either way.
+**Fix:** when OBS-28 pins `CONFIG_LOG_DEFAULT_LEVEL`, pin
+`CONFIG_LOG_MAXIMUM_LEVEL` with it, and if a debug level is ever wanted
+on a relay-enabled build, clamp the `HTTP_CLIENT` tag
+(`esp_log_level_set("HTTP_CLIENT", ESP_LOG_INFO)`) rather than trusting
+the operator to remember.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,7 +45,7 @@ Eleven tags:
 |-----|-------|-------------|
 | `torget` | `main/main.c` | boot, WiFi candidate hunt, SNTP, heap, brightness, MADCTL |
 | `rotation` | `main/rotation.c` | IMU reads, display rotation |
-| `torget-http` | `components/torget_net/torget_http.c` | every GET: error name, status, cap, URL; `LAN svarade inte, provar reläet` when a fetch fails over to the relay |
+| `torget-http` | `components/torget_net/torget_http.c` | every failed GET: error name, status, cap, and a **redacted target** — `<scheme>://<host> via LAN` or `… via relä`, never the path; `LAN svarade inte, provar reläet` when a fetch fails over to the relay |
 | `tokens` | `components/app_tokens/net.c` | /api/tokens + /api/max-tracker polls |
 | `agent-net` | `components/app_tokens/agent_net.c` | /api/agent-status poll (1 Hz, log rate-limited to 30 s) |
 | `github-net` | `components/app_tokens/github_net.c` | the optional /api/github poll |
@@ -75,6 +75,11 @@ lines every 30 s and a `heap:` line every 10 s.
   coredump partition and no reboot counter (OBS-02, OBS-03).
 - The log level and console routing are inherited IDF defaults, not
   pinned in `sdkconfig.defaults` like everything else is (OBS-28).
+- Fetch failures name a *redacted* target (scheme, host, and whether LAN
+  or the relay was tried) because the relay URL's path is a credential.
+  ESP-IDF's own `HTTP_CLIENT` tag would print the whole request line at
+  `DEBUG`, but `ESP_LOGD` is compiled out at the inherited default level;
+  raising it reopens that (OBS-35).
 - Serial-monitoring a *running* board is physically unverified: the panel
   draw can bounce the board off a computer USB port
   (`docs/superpowers/reviews/2026-08-13-max-tracker-physical-static.md`).
@@ -274,7 +279,8 @@ Verbatim strings worth grepping for, and what they mean:
 |-----------|--------|------------------|
 | `WiFi tappat ("…", orsak 201)` | fw `torget` | network invisible: wrong SSID or 5 GHz-only. 15/204 = bad password. |
 | `ingen tid från SNTP ännu` | fw `torget` | clock unset — but fetches proceed anyway and TLS fails as generic transport errors (OBS-15). Treat later cert/transport noise as *this*. |
-| `hämtning misslyckades: ESP_ERR_… (http://…)` | fw `torget-http` | transport failure, with URL. Wrong hostname shows up here. |
+| `hämtning misslyckades: ESP_ERR_… (http://<värd>:8737 via LAN)` | fw `torget-http` | transport failure. The target is scheme + host + route only: the relay's path is `/u/<secret>` and *is* its access key, so no fetch log may carry a path (`docs/relay.md`). Wrong hostname and wrong port still show up here; *which* endpoint failed comes from the `tokens`/`github-net` line beside it. `okänd adress via …` means the address had no scheme or host at all. |
+| `oväntad statuskod 404 (https://<värd> via relä)` | fw `torget-http` | the target answered but not with 200. `via relä` says the cloud mailbox answered, `via LAN` the local tokenserver — the two are otherwise indistinguishable now that the path is gone. |
 | `kroppen större än … byte, avvisad` | fw `torget-http` | payload over cap — server-side schema growth. See lessons: the 1058-byte incident. |
 | `hämtningen avvisad, värden står kvar` | fw `tokens` | fetch rejected. If no `torget-http` line explains it, the parser rejected the schema — suspect server/firmware version skew (OBS-22). |
 | `agentstatus avvisad: transportfel ESP_FAIL` | fw `agent-net` | always literally `ESP_FAIL` — the real cause is discarded before logging (OBS-12). Only says "agent feed unhappy". |

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -67,6 +67,17 @@ end-to-end encrypted features described in
 [docs/interaction-relay.md](interaction-relay.md). Enabling this numbers relay
 never enables either encrypted activity feature.
 
+Because the URL *is* the credential, the panel treats it as one. A failed
+fetch used to log the whole address, so a serial capture or a pasted
+observability transcript handed over both read and write access to the
+figures. `torget_http.c` now sends every failure line through
+`tg_net_log_target()` (`components/torget_net/net_log_target.c`), which keeps
+what diagnoses — scheme, host, and whether LAN or the relay was tried — and
+drops the path, the query, the fragment and any userinfo. The redaction is
+unconditional rather than relay-only, so a future call site inherits it
+instead of having to remember it; `test/test_net_log_target.c` and the log
+guard in `test/test_relay_boundary.py` hold both halves of that.
+
 ## Multiple publishers
 
 Every quota pool carries its own observation timestamp

--- a/test/run.sh
+++ b/test/run.sh
@@ -264,6 +264,14 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
   -o /tmp/torget-service-discovery-policy-test
 /tmp/torget-service-discovery-policy-test
 
+# Reläets adress ÄR nyckeln. Redigeringen som håller den ur loggarna är ren
+# stränglogik och testas som sådan — inte bara som ett anrop i torget_http.c.
+cc -std=c11 -Wall -Wextra -Werror -O1 \
+  ../components/torget_net/net_log_target.c \
+  test_net_log_target.c \
+  -o /tmp/torget-net-log-target-test
+/tmp/torget-net-log-target-test
+
 cc -std=c11 -Wall -Wextra -Werror -O1 \
   ../components/torget_wifi/wifi_slots.c \
   test_wifi_slots.c \

--- a/test/test_net_log_target.c
+++ b/test/test_net_log_target.c
@@ -1,0 +1,144 @@
+/*
+ * Reläets adress är åtkomstnyckeln, inte bara en adress: sökvägen
+ * `/u/<hemlighet>` räcker för att både läsa panelens siffror och skriva
+ * över dem (docs/relay.md). Den här sviten håller den ur loggarna, och
+ * håller kvar det som faktiskt felsöker: schema, värd och vilken väg som
+ * provades.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../components/torget_net/net_log_target.h"
+
+static int failures;
+
+static void check(const char *what, int condition) {
+  if (!condition) {
+    printf("FAIL %s\n", what);
+    failures++;
+  }
+}
+
+static void expect(const char *what, const char *url, bool relay,
+                   const char *want) {
+  char out[TG_NET_LOG_TARGET_CAP];
+  tg_net_log_target(out, sizeof out, url, relay);
+  if (strcmp(out, want) != 0) {
+    printf("FAIL %s\n  fick:  \"%s\"\n  ville: \"%s\"\n", what, out, want);
+    failures++;
+  }
+}
+
+/* Den riktiga formen: en Worker-värd och en hemlig brevlådesökväg, med
+ * endpointen påhängd av TK_*_RELAY_URL. */
+#define SECRET "s3kr3t-mailbox-2f9c41a8"
+#define RELAY_ORIGIN "https://vibepulse.example.workers.dev"
+#define RELAY_URL RELAY_ORIGIN "/u/" SECRET "/api/tokens"
+
+static void test_the_relay_secret_never_reaches_a_log(void) {
+  expect("the relay keeps its scheme and host, and loses its path",
+         RELAY_URL, true, RELAY_ORIGIN " via relä");
+
+  char out[TG_NET_LOG_TARGET_CAP];
+  tg_net_log_target(out, sizeof out, RELAY_URL, true);
+  check("no fragment of the secret survives", strstr(out, SECRET) == NULL);
+  check("not even the mailbox prefix survives", strstr(out, "/u/") == NULL);
+  check("and the endpoint path goes with it",
+        strstr(out, "/api/tokens") == NULL);
+}
+
+static void test_the_line_still_says_where_and_which_way(void) {
+  /* Fel hamn, fel värdnamn och ett dött relä ska gå att skilja åt utan
+   * sökvägen — det är hela poängen med att logga något alls. */
+  expect("the LAN host and port stay readable",
+         "http://192.168.1.7:8737/api/tokens", false,
+         "http://192.168.1.7:8737 via LAN");
+  expect("a wrong hostname still shows up",
+         "http://mac-mini.local:8737/api/max-tracker", false,
+         "http://mac-mini.local:8737 via LAN");
+  /* Samma adress, två vägar: bara vägordet skiljer raderna åt. */
+  expect("the same host is labelled by the route it was tried on",
+         RELAY_ORIGIN "/u/" SECRET "/api/github", false,
+         RELAY_ORIGIN " via LAN");
+}
+
+static void test_anything_credential_shaped_is_dropped(void) {
+  /* Användarinfo är en referens, inte en adress. */
+  expect("userinfo never survives",
+         "https://user:pw@relay.example.com/u/" SECRET, true,
+         "https://relay.example.com via relä");
+  expect("an @ inside the path cannot pull the path back in",
+         "https://relay.example.com/u/a@b/api/tokens", true,
+         "https://relay.example.com via relä");
+  expect("a query string is a path too",
+         "https://relay.example.com?token=" SECRET, true,
+         "https://relay.example.com via relä");
+  expect("and so is a fragment",
+         "https://relay.example.com#" SECRET, true,
+         "https://relay.example.com via relä");
+}
+
+static void test_a_malformed_address_says_nothing_rather_than_too_much(void) {
+  expect("a schemeless address is not guessed at",
+         "vibepulse.example.workers.dev/u/" SECRET, true,
+         "okänd adress via relä");
+  expect("an empty host is not a host",
+         "https:///u/" SECRET, true, "okänd adress via relä");
+  expect("a bare path is never mistaken for an origin",
+         "/u/" SECRET, true, "okänd adress via relä");
+  expect("nor is an empty string", "", false, "okänd adress via LAN");
+  expect("nor is a missing address", NULL, false, "okänd adress via LAN");
+}
+
+static void test_a_long_host_loses_the_host_not_the_route(void) {
+  char url[512];
+  char host[300];
+  memset(host, 'a', sizeof host - 1);
+  host[sizeof host - 1] = '\0';
+  snprintf(url, sizeof url, "https://%s/u/%s/api/tokens", host, SECRET);
+
+  char out[TG_NET_LOG_TARGET_CAP];
+  tg_net_log_target(out, sizeof out, url, true);
+  check("an oversized host stays inside the buffer",
+        strlen(out) < TG_NET_LOG_TARGET_CAP);
+  check("a truncated host still says which way was tried",
+        strstr(out, " via relä") != NULL);
+  check("and truncation never lets the path back in",
+        strstr(out, SECRET) == NULL && strstr(out, "/u/") == NULL);
+}
+
+static void test_a_short_buffer_neither_overflows_nor_leaks(void) {
+  /* Anropsplatsen äger bufferten; en framtida mindre buffert får kosta
+   * tecken, aldrig minne bredvid och aldrig hemligheten. */
+  for (size_t cap = 1; cap <= 24; cap++) {
+    char canary[64];
+    memset(canary, '#', sizeof canary);
+    tg_net_log_target(canary, cap, RELAY_URL, true);
+    check("the write stays inside the given cap",
+          canary[cap] == '#' && memchr(canary, '\0', cap) != NULL);
+    check("a short buffer never spills the secret",
+          strstr(canary, SECRET) == NULL);
+  }
+
+  /* cap 0 får inte skriva en enda byte. */
+  char none[4] = { '#', '#', '#', '#' };
+  tg_net_log_target(none, 0, RELAY_URL, true);
+  check("a zero cap writes nothing at all", none[0] == '#');
+}
+
+int main(void) {
+  test_the_relay_secret_never_reaches_a_log();
+  test_the_line_still_says_where_and_which_way();
+  test_anything_credential_shaped_is_dropped();
+  test_a_malformed_address_says_nothing_rather_than_too_much();
+  test_a_long_host_loses_the_host_not_the_route();
+  test_a_short_buffer_neither_overflows_nor_leaks();
+
+  if (failures) {
+    printf("%d test(er) föll\n", failures);
+    return 1;
+  }
+  printf("OK: reläets hemliga sökväg kan inte nå en logg\n");
+  return 0;
+}

--- a/test/test_relay_boundary.py
+++ b/test/test_relay_boundary.py
@@ -8,6 +8,7 @@ direct LAN client from accidentally becoming an activity transport.
 
 from pathlib import Path
 import plistlib
+import re
 
 root = Path(__file__).resolve().parents[1]
 read = lambda p: (root / p).read_text(encoding="utf-8")
@@ -18,6 +19,9 @@ github = read("components/app_tokens/github_net.c")
 agent = read("components/app_tokens/agent_net.c")
 needs_you = read("components/app_tokens/needs_you_net.c")
 http = read("components/torget_net/torget_http.c")
+log_target = read("components/torget_net/net_log_target.c")
+relay_doc = read("docs/relay.md")
+run_sh = read("test/run.sh")
 example = read("secrets.h.example")
 readme = read("README.md")
 agent_setup = read("docs/agent-setup.md")
@@ -76,6 +80,45 @@ assert "if (!relay_url || !relay_url[0])" in http, (
 # Only the LAN attempt may fall onwards; a dead relay must not bounce back
 # or two dead addresses spin a fetch in circles.
 assert "tg_net_source_may_fall_back(source)" in http
+
+# --- The secret URL may never reach a log --------------------------------
+# The relay's path IS its access control: `/u/<secret>` reads the panel's
+# figures and overwrites them. A serial capture or a pasted observability
+# transcript is shared far more casually than the address itself, so the
+# fetch client must never hand a raw address to ESP_LOG. The redaction sits
+# in ONE helper, so a fourth failure path inherits it instead of having to
+# remember it.
+assert "Never print the secret URL in logs or a shared transcript." in \
+    " ".join(relay_doc.split()), (
+        "docs/relay.md must keep stating the rule this guard enforces"
+    )
+assert "tg_net_log_target(target, sizeof target, url, cloud)" in http, (
+    "every logged fetch target must go through the redaction helper"
+)
+address_names = (
+    r"\b(url|lan_url|relay_url|configured_url|discovered|alternate)\b"
+)
+for call in re.findall(r"ESP_LOG[A-Z]\((?:[^;]*?)\);", http, re.DOTALL):
+    assert not re.search(address_names, call), (
+        "a fetch log must name the redacted target, never a raw address:\n"
+        + call
+    )
+
+# The helper keeps only what diagnoses — scheme, host, and which way was
+# tried — and it does so unconditionally, without asking whether this
+# particular address happens to be the secret one.
+assert 'strcspn(authority, "/?#")' in log_target, (
+    "path, query and fragment must all be cut, not just the path"
+)
+assert "if (authority[i] == '@') host_start = i + 1;" in log_target, (
+    "userinfo is a credential too and must never be logged"
+)
+assert 'relay ? "relä" : "LAN"' in log_target, (
+    "a redacted line must still say which route was taken"
+)
+assert "test_net_log_target.c" in run_sh, (
+    "the redaction core is pure logic and must be host-tested in the gate"
+)
 
 # --- The opt-in stays opt-in -------------------------------------------
 assert "/* #define TK_VIBEPULSE_RELAY_URL" in example, (


### PR DESCRIPTION
## Outcome

A failed fetch no longer prints the numbers relay's secret URL. All three
failure paths in `components/torget_net/torget_http.c` logged the address they
had just failed on:

```
hämtning misslyckades: %s (%s)        <- esp_err_to_name(err), url
oväntad statuskod %d (%s)             <- status, url
kroppen större än %u byte, avvisad (%s)  <- cap, url
```

On the relay route that `url` is the cloud mailbox URL, and its path —
`/u/<secret>` — **is** the access control. Anyone handed a serial capture or a
pasted observability log after a relay outage could read the panel's figures
and overwrite them; the same secret authenticates GET and POST.

The lines now name a redacted target instead:

| before | after |
|---|---|
| `hämtning misslyckades: ESP_ERR_HTTP_CONNECT (https://host/u/<secret>/api/tokens)` | `hämtning misslyckades: ESP_ERR_HTTP_CONNECT (https://host via relä)` |
| `oväntad statuskod 404 (http://mac.local:8737/api/tokens)` | `oväntad statuskod 404 (http://mac.local:8737 via LAN)` |

Scheme, host and route still separate a wrong hostname from a wrong port from a
dead relay, which is what these lines are read for. Which endpoint failed still
comes from the `tokens`/`github-net` line beside it.

## Root cause / rationale

`docs/relay.md:171` has said *"Never print the secret URL in logs or a shared
transcript"* since the relay shipped, so this was code contradicting a written
safety rule, not a new policy decision.

The lines predate the relay. They were written when every address was a LAN
address and a URL was just a URL; the relay later routed a credential-bearing
address through the same helper and nobody revisited what the old lines print.
That is the general shape worth remembering: when a value becomes a credential,
the code that *prints* it is as much a caller as the code that sends it.

The redaction sits in **one** new pure helper, `tg_net_log_target()`
(`components/torget_net/net_log_target.c`), rather than at the three call
sites, and it is **unconditional** — it does not ask whether this particular
address happens to be the secret one. A fourth failure path inherits the
protection instead of having to remember it, and a mis-set route flag can cost
a wrong route word but never a leaked path. Path, query, fragment and userinfo
are all dropped; a truncated long host loses host characters, never the route
word; a malformed address logs `okänd adress` rather than a guess.

Before choosing where the redaction belongs I checked the rest of the tree: no
other firmware call site logs a URL (`service_discovery.c` logs none,
`interaction_relay_net.c` logs readiness only), and the host publisher already
logs the endpoint path alone, never the relay address. No test asserted the old
log strings.

Found by a Codex review on #87 and verified there, but left unfixed because the
file is outside that PR's diff:
https://github.com/niclasvestlund-YT/vibepulse/pull/87#discussion_r3944784427

## Verification

- [x] Relevant focused tests pass.
- [x] `./test/run.sh` passes, or the exact omission and reason are stated.
  Green end to end, including the Node lanes.
- [x] No secret, credential, raw session content, production payload, or
      `torget.bin` is included.
- [x] Documentation and changelog match the behavior.

New guards:

- `test/test_net_log_target.c` host-tests the redaction core directly — the
  secret never survives, the route word survives truncation, short buffers
  neither overflow nor leak. Wired into `test/run.sh` and clean under
  ASan/UBSan.
- `test/test_relay_boundary.py` now parses every `ESP_LOG*` call in
  `torget_http.c` and fails if one names a raw address. Run against the pre-fix
  file it catches all three lines.

**`idf.py build` could not be run in the sandbox this was written in:** the
environment's network policy denies `components.espressif.com`, so the 24
managed components (including the Waveshare BSP, which has no GitHub mirror)
cannot be fetched. Instead the changed component was cross-compiled for
esp32s3 against ESP-IDF v5.5.2 headers with the real xtensa toolchain — clean
under `-Wall -Wextra -Werror -Wformat=2` — and linked into an app. **CI's
firmware job is the real check on the full image.**

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence, not as a
      real-host or physical-panel pass.
- [x] Windows-affecting changes follow `docs/windows-validation.md` — n/a, no
      Windows-affecting change.
- [x] Linux is not called supported before issue #2 and every real-host/panel
      gate pass.

### Hardware / UI

- [x] No hardware or UI behavior changed — this only alters serial log text.
- [x] A physical flash was separately and explicitly authorized — **no flash
      was performed and none is requested by this PR.**
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were
      not treated as approval.

## Not tested / remaining risk

- **Not run on hardware.** The change is log-text only and cannot alter fetch
  behavior, but the new lines have not been read off a physical serial console.
- **The full firmware image was not built here** — see the note above. CI's
  ESP-IDF job covers it.
- **One residual leak path, recorded not fixed:** ESP-IDF's own `HTTP_CLIENT`
  tag prints the whole request line at `ESP_LOGD` ("Write header[%d]: %s") and
  the `Location` header on a redirect. Both contain the secret. This is inert
  today — `CONFIG_LOG_MAXIMUM_LEVEL=3` compiles `ESP_LOGD` out — so it is a
  *latent* leak that raising the log level would reopen. Filed as **OBS-35**,
  paired with OBS-28's "pin logging on purpose".
- **Operator-facing change:** these log lines are ones people grep for, so
  saved greps matching `hämtning misslyckades: … (http://…)` need updating.
  `docs/observability.md` carries the new signatures.
- While editing the backlog I also restored the `### OBS-28` heading, which
  `8f007bf` overwrote with OBS-31's and left that entry headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtG2Y3US8raxCiJDuKTBKo

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtG2Y3US8raxCiJDuKTBKo)_