### PR TITLE
test(snapshot): cover tools/snapshot.sh, on macOS as well as Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,14 @@ jobs:
       # (SC1071, shellcheck kan inte läsa den alls), och `CDPATH= cd` i
       # install-local-skills.sh och preview-ui.sh ger SC1007 fast idiomet är
       # rätt. Att städa det är sitt eget ärende.
+      #
+      # --severity=warning, inte standardnivån. Info-nivån skiljer sig mellan
+      # shellcheck-versioner: runnerns version ger SC2015 på
+      # `[ -n "$r" ] && [ -d "$r" ] || continue` medan 0.11.0 tiger, och just
+      # där är varningen fel — att `continue` körs när A är sant men B falskt
+      # ÄR meningen. En grind som blir röd av att runnerimagen bytt version
+      # säger inget om koden. Fel och varningar (parsefel, SC1007, SC1071)
+      # fångas fortfarande.
       - name: Shellcheck the backup tool
         if: runner.os == 'Linux'
         run: |
@@ -189,7 +197,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends shellcheck
           fi
-          shellcheck tools/snapshot.sh
+          shellcheck --severity=warning tools/snapshot.sh
 
   firmware:
     name: ESP32-S3 firmware build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,47 @@ jobs:
             -CodexPlanCostUsd "20"
           .\test\windows-task-runner.ps1
 
+  snapshot-tool:
+    # tools/snapshot.sh är backupen AGENTS.md kräver före varje
+    # historikomskrivning, och den körs på maintainerns Mac. Tre av de fem
+    # defekter granskningen hittade i filen — awk med NUL som RS, `head -c -1`
+    # och `mktemp` utan mall — är OSYNLIGA på Linux: GNU:s verktyg gör precis
+    # vad skriptet ber om. Matrisen är därför inte lyx. Ubuntu ensamt fångar
+    # ingen av dem, och testets statiska vakter är en andra linje, inte en
+    # ersättning för att faktiskt köra filen mot BSD-verktygen.
+    #
+    # Eget jobb i stället för en gren i tokenserverjobbet: det kör också
+    # windows-latest, där ett bash-verktyg inte hör hemma, och installerar
+    # beroenden det här testet inte har — det klarar sig på stdlib och git.
+    name: Snapshot tool (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify the backup tool against synthetic repositories
+        shell: bash
+        run: python test/test_snapshot_tool.py
+      # Ett KOMPLEMENT, inte en ersättning: shellcheck flaggar varken
+      # RS="\0" eller en mktemp utan mall. Bara snapshot.sh, för hela
+      # tools/*.sh är rött idag av skäl som inte hör hit — flasha.sh är zsh
+      # (SC1071, shellcheck kan inte läsa den alls), och `CDPATH= cd` i
+      # install-local-skills.sh och preview-ui.sh ger SC1007 fast idiomet är
+      # rätt. Att städa det är sitt eget ärende.
+      - name: Shellcheck the backup tool
+        if: runner.os == 'Linux'
+        run: |
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends shellcheck
+          fi
+          shellcheck tools/snapshot.sh
+
   firmware:
     name: ESP32-S3 firmware build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,35 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- **`tools/snapshot.sh` has host tests, on macOS as well as Linux.** The
+  backup `AGENTS.md` makes mandatory before any history rewrite had no
+  coverage at all: no entry in `test/run.sh`, no test file, no shellcheck.
+  Three consecutive review rounds each found a real defect in that one file,
+  and every one was found by a reviewer building a repository shape by hand.
+  `test/test_snapshot_tool.py` now runs the tool against ten synthetic
+  repositories and asserts both the exit code and the published artifacts: an
+  ordinary repository publishes a `.bundle` plus its `.refs` sidecar at mode
+  0600 and clones back; a bare repository and a repository whose bundle
+  advertises no HEAD both exit 0; a shallow clone is refused with
+  `--unshallow` named; a destination inside a checkout is refused directly,
+  via `..`, via a linked worktree, and via a worktree whose path contains a
+  newline; a `prunable` registration neither refuses nor crashes; a run from a
+  linked worktree lands beside the **main** checkout; and a byte flipped in
+  the pack is caught — by the tool's own fetch into a temp bare repository,
+  because `git bundle verify` reads the header only and calls a corrupted
+  pack "okay".
+
+  The portability half is not decoration. Three of the five defects — `awk`
+  with NUL as `RS`, `head -c -1`, `mktemp` without a template — are invisible
+  on Linux, where GNU's tools do exactly what the script asks; they only bite
+  on the maintainer's own machine. A new `Snapshot tool` CI job therefore runs
+  the same file on `ubuntu-latest` **and** `macos-latest`, and the test carries
+  static guards for that class so a reintroduced GNU-ism goes red on ubuntu
+  the minute it is written. `shellcheck tools/snapshot.sh` runs alongside as a
+  complement, not a substitute: it flags neither `RS="\0"` nor a missing
+  `mktemp` template. Each of the five defects was reverted one at a time and
+  the test watched go red before this landed.
+
 - **The screenshots in `docs/img/` are checked against the simulator.**
   `test/test_docs_frame_drift.py` compares every checked-in 480 × 480 frame
   with what this build actually renders, and the answer is blunt: of

--- a/test/run.sh
+++ b/test/run.sh
@@ -315,6 +315,12 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_ota_partition.py
 "$PYTHON_BIN" test_ota_reopen_wiring.py
 "$PYTHON_BIN" test_ota_sender_gates.py
+# Backupen AGENTS.md kräver före varje historikomskrivning. Testet bygger
+# syntetiska repon med git och kör verktyget mot dem på riktigt. Halva
+# svaret ligger dock i CI: tre av de fem defekter granskningen hittade i
+# snapshot.sh är osynliga på Linux, så jobbet "Snapshot tool" kör samma
+# fil även på macOS.
+"$PYTHON_BIN" test_snapshot_tool.py
 "$PYTHON_BIN" test_ota_gesture_docs.py
 "$PYTHON_BIN" test_wifi_setup_wiring.py
 "$PYTHON_BIN" test_settings_design.py

--- a/test/test_snapshot_tool.py
+++ b/test/test_snapshot_tool.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+r"""Regressionsvakt för tools/snapshot.sh — backupen AGENTS.md kräver före
+varje historikomskrivning.
+
+Verktyget hade noll testtäckning fram till den här filen. Tre
+granskningsrundor på PR #87 hittade var sin äkta defekt i det, och varje
+defekt hittades av en människa som byggde upp en repoform för hand:
+
+  1. `awk 'BEGIN{RS="\0"}'` läser NUL-poster i mawk och gawk men inte i BSD
+     awk (macOS /usr/bin/awk — maintainerns egen maskin), där "\0" blir tom
+     sträng och tom RS betyder styckeläge. Vakten "ligger målet inuti en
+     utcheckning?" hade då läst fel poster, tyst.
+  2. `head -c -1` är en GNU-utvidgning; BSD head vägrar ett negativt antal.
+  3. `mktemp` utan mall är en GNU-bekvämlighet; BSD mktemp kräver en — och
+     det träffade filens FÖRSTA rad.
+  4. Verifieringsfetchen blandade wildcard-refspecar med den EXAKTA
+     `+HEAD:refs/p-head/HEAD`. Mot en bundle från ett repo utan giltig HEAD
+     avbryts fetchen med "couldn't find remote ref HEAD" — verktyget dömde ut
+     ett helt paket som trasigt och raderade backupen. Fel åt fel håll.
+  5. I ett bart repo dör `git status` med 128, statusen gick genom `pipefail`
+     in i `n=$(...)`, och `set -e` avslutade skriptet EFTER "verifierad" men
+     FÖRE återställningsraderna: exit 128 på en backup som låg färdig och
+     korrekt på disk.
+
+Testet har därför två halvor, och båda behövs:
+
+  * BETEENDET körs mot riktiga syntetiska repon och gäller på varje
+    plattform. Det täcker 4 och 5 var som helst.
+  * PORTABILITETEN kontrolleras statiskt, för 1–3 är OSYNLIGA på Linux:
+    mawk klarar RS="\0" alldeles utmärkt, och GNU head och mktemp gör precis
+    som skriptet ber om. CI:s macOS-jobb kör hela den här filen och är det
+    riktiga beviset; de statiska vakterna gör att en återinförd GNU-ism blir
+    röd redan på ubuntu, samma minut den skrivs. shellcheck flaggar ingen av
+    dem — varken RS="\0" eller en mktemp utan mall är ett skalfel.
+"""
+
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "snapshot.sh"
+
+# Hermetisk git: maintainerns globala config kan ha hooks, templates, signering
+# eller ett annat init.defaultBranch, och inget av det får avgöra en dom här.
+BASE_ENV = {
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "Snapshot Test",
+    "GIT_AUTHOR_EMAIL": "snapshot@test.invalid",
+    "GIT_COMMITTER_NAME": "Snapshot Test",
+    "GIT_COMMITTER_EMAIL": "snapshot@test.invalid",
+    "GIT_TERMINAL_PROMPT": "0",
+}
+
+
+# --------------------------------------------------------------------------
+# Hjälpare
+# --------------------------------------------------------------------------
+
+def git(*args, cwd=None, check=True):
+    """Kör riktiga git för att bygga en fixtur. Aldrig via skriptet."""
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=None if cwd is None else str(cwd),
+        env={**os.environ, **BASE_ENV},
+        capture_output=True,
+    )
+    if check and proc.returncode != 0:
+        raise AssertionError(
+            "fixturen gick inte att bygga: git {}\n{}".format(
+                " ".join(args), proc.stderr.decode("utf-8", "replace")))
+    return proc.stdout.decode("utf-8", "replace")
+
+
+def snapshot(cwd, dest=None, path_prefix=None):
+    """Kör tools/snapshot.sh som en människa gör det: via shebangen.
+
+    Utdata avkodas explicit som UTF-8 i stället för med `text=True`. Skriptets
+    meddelanden är svenska, och under LC_ALL=C hade Pythons locale-beroende
+    avkodning kvävts på första Ä:et i "VÄGRAR" — ett testhaveri som inte hade
+    haft ett dugg med snapshot.sh att göra.
+    """
+    env = {**os.environ, **BASE_ENV}
+    env.pop("TG_SNAPSHOT_DIR", None)
+    if dest is not None:
+        env["TG_SNAPSHOT_DIR"] = str(dest)
+    if path_prefix is not None:
+        env["PATH"] = "{}{}{}".format(path_prefix, os.pathsep, env["PATH"])
+    proc = subprocess.run(
+        [str(SCRIPT)], cwd=str(cwd), env=env, capture_output=True)
+    proc.out = proc.stdout.decode("utf-8", "replace")
+    proc.err = proc.stderr.decode("utf-8", "replace")
+    return proc
+
+
+def detail(label, proc):
+    return "{}\n  exit={}\n  stdout:\n{}\n  stderr:\n{}".format(
+        label, proc.returncode,
+        "\n".join("    " + ln for ln in proc.out.splitlines()) or "    (tomt)",
+        "\n".join("    " + ln for ln in proc.err.splitlines()) or "    (tomt)")
+
+
+def bundles(directory):
+    directory = Path(directory)
+    if not directory.is_dir():
+        return []
+    return sorted(directory.glob("*.bundle"))
+
+
+def make_repo(path, payload=1):
+    """Ett litet repo med riktigt innehåll, så bundlen får ett riktigt pack."""
+    path.mkdir(parents=True, exist_ok=True)
+    git("init", "-q", "-b", "main", ".", cwd=path)
+    for index in range(payload):
+        # Inkompressibelt innehåll: ett pack som DEFLATE kan krympa till
+        # nästan ingenting ger byte-vändningstestet för lite att träffa.
+        (path / "fil{}.txt".format(index)).write_bytes(os.urandom(512))
+    git("add", "-A", cwd=path)
+    git("commit", "-q", "-m", "innehall", cwd=path)
+    return path
+
+
+# --------------------------------------------------------------------------
+# Halva 1: portabilitet (statisk — defekt 1–3 syns inte på Linux)
+# --------------------------------------------------------------------------
+
+def code_of(script_text):
+    r"""Bara kodraderna.
+
+    Prosan i snapshot.sh är lång och nämner varje fallgrop vid sitt riktiga
+    namn — `RS="\0"` och `mktemp` står ordagrant i kommentarerna. En grep över
+    hela filen hade träffat förklaringen i stället för koden.
+    """
+    return "\n".join(
+        line for line in script_text.splitlines()
+        if not line.lstrip().startswith("#"))
+
+
+# Stavningar som bara finns i GNU:s coreutils. Var och en är tyst på
+# ubuntu-runnern och dödar filen på maintainerns Mac — alltså exakt den
+# klass som ingen körning på Linux kan upptäcka. Listan är avsedd att växa.
+GNU_ONLY = (
+    (r"""RS\s*=\s*["']?\\+(?:0|x0*0)\b""",
+     'awk med NUL som RS: mawk och gawk klarar det, men BSD awk läser "\\0" '
+     "som tom sträng, och tom RS betyder styckeläge (defekt 1)"),
+    (r"\bhead\b[^|;&\n]*-c\s+-\d",
+     "head -c -N är en GNU-utvidgning; BSD head vägrar ett negativt antal "
+     "(defekt 2)"),
+    (r"\bsed\b[^|;&\n]*\s-i(?=\s|$)",
+     "sed -i utan suffixargument: BSD sed läser nästa ord som suffix"),
+    (r"\breadlink\b[^|;&\n]*\s-f(?=\s|$)",
+     "readlink -f saknas i äldre BSD; skriptet använder `cd && pwd -P`"),
+    (r"\bgrep\b[^|;&\n]*\s-P(?=\s|$)",
+     "grep -P finns inte i BSD grep"),
+    (r"\bstat\b[^|;&\n]*\s-c(?=\s|$)",
+     "stat -c är GNU; BSD stat stavar det -f"),
+    (r"\bdate\b[^|;&\n]*\s-d(?=\s|$)",
+     "date -d är GNU; BSD date stavar det -v/-j"),
+)
+
+
+def scenario_portabilitet(_work):
+    assert SCRIPT.is_file(), "tools/snapshot.sh saknas"
+    assert os.access(SCRIPT, os.X_OK), (
+        "tools/snapshot.sh måste vara körbar — AGENTS.md säger åt en människa "
+        "att köra den, inte att lista ut vilket skal den vill ha")
+
+    text = SCRIPT.read_text(encoding="utf-8")
+    code = code_of(text)
+
+    for pattern, why in GNU_ONLY:
+        found = re.search(pattern, code)
+        assert not found, (
+            "tools/snapshot.sh: {!r} är inte portabel — {}".format(
+                found.group(0), why))
+
+    # Varje mktemp måste ha en egen mall. GNU gör mallen valfri, BSD kräver
+    # den, och en mktemp utan mall dör på den FÖRSTA raden som körs — på just
+    # den maskin där AGENTS.md gör filen obligatorisk före en omskrivning.
+    calls = re.findall(r"\bmktemp\b[^|;&\n)]*", code)
+    assert calls, "ingen mktemp kvar i snapshot.sh — vakten mäter inget"
+    for call in calls:
+        assert "XXXXXX" in call, (
+            "tools/snapshot.sh: `{}` saknar mall — BSD mktemp kräver en "
+            "(defekt 3)".format(call.strip()))
+
+    # Och den NUL-terminerade worktree-listan ska tolkas i skalet. `-z` är det
+    # som gör listan entydig när en sökväg innehåller en radbrytning;
+    # `read -r -d ""` är primitiven som läser den utan externt verktyg.
+    assert "git worktree list --porcelain -z" in code, (
+        "worktree-listan måste läsas NUL-terminerad (-z) — en radorienterad "
+        "läsning delar en sökväg med radbrytning mitt itu (defekt 1)")
+    assert 'read -r -d ""' in code, (
+        "NUL-posterna ska tolkas i skalet med `read -r -d \"\"`, inte av ett "
+        "externt verktyg vars NUL-stöd skiljer sig mellan plattformar")
+
+    print("OK: snapshot.sh är fri från GNU-bara stavningar; "
+          "varje mktemp har mall och worktree-listan läses NUL-terminerad")
+
+
+# --------------------------------------------------------------------------
+# Halva 2: beteende mot riktiga syntetiska repon
+# --------------------------------------------------------------------------
+
+def scenario_vanligt_repo(work):
+    repo = make_repo(work / "repo")
+    dest = work / "backups"
+    proc = snapshot(repo, dest)
+
+    assert proc.returncode == 0, detail("vanligt repo ska lyckas", proc)
+    assert "verifierad" in proc.out, detail("saknar verifieringsraden", proc)
+
+    published = bundles(dest)
+    assert len(published) == 1, detail(
+        "exakt en bundle ska publiceras, hittade {}".format(published), proc)
+    bundle = published[0]
+
+    sidecar = bundle.with_suffix(".refs")
+    assert sidecar.is_file(), detail(".refs-sidan saknas bredvid bundlen", proc)
+    assert sidecar.read_text(encoding="utf-8").strip(), detail(
+        ".refs är tom — innehållsförteckningen ska lista bundlens heads", proc)
+
+    mode = stat.S_IMODE(bundle.stat().st_mode)
+    assert mode == 0o600, detail(
+        "bundlen är HELA repot i en fil och ska vara 0600, inte {:04o} — "
+        "backupen får inte bli spridningsvägen".format(mode), proc)
+    assert stat.S_IMODE(sidecar.stat().st_mode) & 0o077 == 0, detail(
+        ".refs röjer varje grennamn och ska inte vara läsbar för andra", proc)
+
+    assert not list(dest.glob(".incomplete-*")), detail(
+        "en halvskriven .incomplete-fil lämnades kvar", proc)
+
+    # Artefakten ska duga till det den finns för: att återställa repot.
+    restored = work / "restored"
+    git("clone", "-q", str(bundle), str(restored))
+    assert (restored / "fil0.txt").is_file(), (
+        "den publicerade bundlen gick inte att klona tillbaka")
+
+    print("OK: vanligt repo — bundle + .refs publicerade, läge 0600, "
+          "och bundlen går att klona tillbaka")
+
+
+def scenario_bart_repo(work):
+    """Defekt 5: `git status` dör med 128 i ett bart repo."""
+    source = make_repo(work / "kalla")
+    bare = work / "bart.git"
+    git("clone", "-q", "--bare", str(source), str(bare))
+    assert git("rev-parse", "--is-bare-repository", cwd=bare).strip() == "true"
+
+    dest = work / "bart-backups"
+    proc = snapshot(bare, dest)
+
+    assert proc.returncode == 0, detail(
+        "ett bart repo har inget arbetsträd att varna om och ska ge exit 0 "
+        "(defekt 5: status 128 gick genom pipefail och dödade skriptet)", proc)
+    assert len(bundles(dest)) == 1, detail("ingen bundle publicerades", proc)
+    # Det är inte nog att bundlen ligger där: skriptet dog EFTER "verifierad"
+    # men FÖRE återställningsraderna. Slutet av utskriften är domen.
+    assert "Återställ:" in proc.out, detail(
+        "skriptet nådde aldrig återställningsraderna — exakt defekt 5", proc)
+
+    print("OK: bart repo — exit 0 och återställningsraderna skrivs ut")
+
+
+def scenario_bundle_utan_head(work):
+    """Defekt 4: en exakt +HEAD-refspec mot en bundle som saknar HEAD."""
+    repo = make_repo(work / "utan-head")
+    sha = git("rev-parse", "HEAD", cwd=repo).strip()
+    git("tag", "v1", cwd=repo)
+    git("update-ref", "refs/remotes/origin/main", sha, cwd=repo)
+    git("update-ref", "-d", "refs/heads/main", cwd=repo)
+
+    dest = work / "utan-head-backups"
+    proc = snapshot(repo, dest)
+
+    assert proc.returncode == 0, detail(
+        "ett repo vars enda refs är remote-refs och taggar ger en bundle utan "
+        "HEAD; den är hel och ska verifieras som hel (defekt 4)", proc)
+    published = bundles(dest)
+    assert len(published) == 1, detail(
+        "bundlen dömdes ut som trasig och raderades", proc)
+
+    # Förutsättningen måste hålla, annars testar fallet ingenting: skulle en
+    # framtida git ändå annonsera HEAD är +HEAD-refspecen aldrig tom längre.
+    heads = published[0].with_suffix(".refs").read_text(encoding="utf-8")
+    advertised = [ln.split(" ", 1)[1] for ln in heads.splitlines() if " " in ln]
+    assert "HEAD" not in advertised, (
+        "fixturen skulle ge en bundle UTAN HEAD, men den annonserar: "
+        "{}".format(advertised))
+
+    print("OK: bundle utan HEAD — verifieras som hel i stället för att raderas")
+
+
+def scenario_shallow(work):
+    source = make_repo(work / "djup")
+    git("commit", "-q", "--allow-empty", "-m", "tva", cwd=source)
+    shallow = work / "avhuggen"
+    git("clone", "-q", "--depth", "1", source.as_uri(), str(shallow))
+    assert git(
+        "rev-parse", "--is-shallow-repository", cwd=shallow).strip() == "true", (
+        "fixturen blev inte shallow — fallet hade testat ingenting")
+
+    dest = work / "shallow-backups"
+    proc = snapshot(shallow, dest)
+
+    assert proc.returncode == 1, detail(
+        "en shallow klon ska vägras: bundlen hade sett komplett ut och "
+        "innehållit en femtedel av historiken", proc)
+    assert "VÄGRAR" in proc.err, detail("vägran ska sägas högt", proc)
+    assert "--unshallow" in proc.err, detail(
+        "vägran ska namnge vägen ut: git fetch --unshallow", proc)
+    assert not bundles(dest), detail("en shallow bundle publicerades ändå", proc)
+    assert not dest.exists(), detail(
+        "vägran skedde efter att målkatalogen skapats — kontrollen ska ske "
+        "innan något rörs på disk", proc)
+
+    print("OK: shallow klon — vägras med exit 1 och --unshallow i meddelandet")
+
+
+def scenario_mal_inuti_utcheckning(work):
+    repo = make_repo(work / "inuti-repo")
+    (work / "utanfor").mkdir()
+    linked = work / "inuti-wt"
+    git("worktree", "add", "-q", str(linked), "-b", "sidogren", cwd=repo)
+
+    cases = (
+        ("direkt i repot", repo / "backups"),
+        ("via ..", work / "utanfor" / ".." / "inuti-repo" / "snap"),
+        ("via en länkad worktree", linked / "snap"),
+    )
+    for label, dest in cases:
+        proc = snapshot(repo, dest)
+        assert proc.returncode == 1, detail(
+            "{}: en backup får aldrig bo inuti det den säkerhetskopierar "
+            "— en rm -rf av trädet tar då med sig räddningsfilen".format(
+                label), proc)
+        assert "VÄGRAR" in proc.err, detail(
+            "{}: vägran ska sägas högt, inte bli ett tyst exit 1".format(
+                label), proc)
+        assert "TG_SNAPSHOT_DIR" in proc.err, detail(
+            "{}: meddelandet ska namnge vägen ut".format(label), proc)
+        assert not list(work.rglob("*.bundle")), detail(
+            "{}: en bundle publicerades trots vägran".format(label), proc)
+
+    print("OK: mål inuti en utcheckning vägras — direkt, via .. och via en "
+          "länkad worktree")
+
+
+def scenario_worktree_med_radbrytning(work):
+    """Defekt 1: en radorienterad läsning ser bara sökvägens första rad."""
+    repo = make_repo(work / "nl-repo")
+    linked = work / "wt\nbryt"
+    git("worktree", "add", "-q", str(linked), "-b", "radbrytning", cwd=repo)
+    listing = git("worktree", "list", "--porcelain", cwd=repo)
+    assert "wt\nbryt" in listing, (
+        "fixturen fick ingen worktree med radbrytning i sökvägen")
+
+    proc = snapshot(repo, linked / "snap")
+
+    assert proc.returncode == 1, detail(
+        "målet ligger inuti worktreen `wt<radbrytning>bryt`. En radorienterad "
+        "parser ser bara `wt`, som inte är ett prefix till målet — vakten "
+        "släpper då igenom en backup rakt in i utcheckningen (defekt 1)", proc)
+    assert "VÄGRAR" in proc.err, detail("vägran ska sägas högt", proc)
+    assert not list(work.rglob("*.bundle")), detail(
+        "en bundle publicerades inuti worktreen", proc)
+
+    print("OK: worktree med radbrytning i sökvägen — målet inuti den vägras")
+
+
+def scenario_prunable_worktree(work):
+    repo = make_repo(work / "prune-repo")
+    gone = work / "borta-wt"
+    git("worktree", "add", "-q", str(gone), "-b", "borta", cwd=repo)
+    # Katalogen raderas och återskapas som en VANLIG katalog: den passerar
+    # `[ -d ]`, medan `git -C` där dör med "not a git repository".
+    shutil.rmtree(gone)
+    gone.mkdir()
+    listing = git("worktree", "list", "--porcelain", cwd=repo)
+    assert "prunable" in listing, (
+        "fixturen blev inte prunable — git ska rapportera det självt")
+
+    dest = work / "prune-backups"
+    proc = snapshot(repo, dest)
+
+    assert proc.returncode == 0, detail(
+        "en död worktree-registrering får varken vägra eller krascha", proc)
+    assert len(bundles(dest)) == 1, detail("ingen bundle publicerades", proc)
+    # Repot och dess levande utcheckning är rena, så en korrekt körning har
+    # ingenting att varna om. Dyker det upp en OBS-rad är det den döda
+    # registreringen som behandlats som en levande utcheckning — livlighet
+    # ska läsas ur gits egen `prunable`, inte gissas ur [ -d ].
+    assert "OBS:" not in proc.out, detail(
+        "en död worktree-registrering varnades om som vore den levande", proc)
+    assert str(gone) not in proc.out, detail(
+        "den prunable registreringen behandlades som en levande utcheckning",
+        proc)
+
+    print("OK: prunable worktree — varken vägran eller krasch, och den räknas "
+          "inte som en levande utcheckning")
+
+
+def scenario_default_fran_lankad_worktree(work):
+    repo = make_repo(work / "huvudrepo")
+    linked = work / "lankad"
+    git("worktree", "add", "-q", str(linked), "-b", "sido", cwd=repo)
+
+    proc = snapshot(linked, dest=None)
+
+    assert proc.returncode == 0, detail(
+        "körning från en länkad worktree ska lyckas", proc)
+    beside_main = work / "huvudrepo-backups"
+    beside_linked = work / "lankad-backups"
+    assert len(bundles(beside_main)) == 1, detail(
+        "defaultmålet ska ligga bredvid HUVUDutcheckningen ({})".format(
+            beside_main), proc)
+    assert not beside_linked.exists(), detail(
+        "backupen landade bredvid den länkade worktreen — den ligger under "
+        "repot, och en rm -rf av repot tar då med sig räddningsfilen", proc)
+
+    print("OK: körd från en länkad worktree — defaultmålet landar bredvid "
+          "huvudutcheckningen")
+
+
+def scenario_vand_bit(work):
+    """En bundle vars pack är korrupt får aldrig publiceras.
+
+    `git bundle verify` duger inte som verifiering: den läser huvudet och
+    säger "The bundle is okay" om ett paket vars pack är sönder, medan
+    `git clone` dör på "inflate returned -5". Verktyget fetchar därför in i
+    ett tomt bart repo, vilket tvingar git att packa upp och kontrollsumma
+    varje objekt. Testet mäter VERKTYGETS dom, inte `git bundle verify`:s.
+
+    Biten vänds med ett git-skal först i PATH som skriver sönder paketet i
+    samma ögonblick som `bundle create` lämnat det ifrån sig.
+    """
+    repo = make_repo(work / "korrupt", payload=6)
+    shim_dir = work / "skal"
+    shim_dir.mkdir()
+    marker = shim_dir / "vandes"
+
+    (shim_dir / "shim.py").write_text(
+        "import pathlib, subprocess, sys\n"
+        "args = sys.argv[1:]\n"
+        "rc = subprocess.run([{real!r}] + args).returncode\n"
+        "if rc == 0 and 'bundle' in args and 'create' in args:\n"
+        "    out = next((pathlib.Path(a) for a in args[args.index('create'):]\n"
+        "                if not a.startswith('-') and a != 'create'), None)\n"
+        "    if out is not None and out.is_file():\n"
+        "        data = bytearray(out.read_bytes())\n"
+        "        at = data.find(b'PACK') + 40\n"
+        "        if 40 <= at < len(data):\n"
+        "            data[at] ^= 0xFF\n"
+        "            out.write_bytes(bytes(data))\n"
+        "            pathlib.Path({marker!r}).write_text('1')\n"
+        "sys.exit(rc)\n".format(real=shutil.which("git"), marker=str(marker)),
+        encoding="utf-8")
+    shim = shim_dir / "git"
+    shim.write_text(
+        '#!/bin/sh\nexec {py} {script} "$@"\n'.format(
+            py=shlex.quote(sys.executable),
+            script=shlex.quote(str(shim_dir / "shim.py"))),
+        encoding="utf-8")
+    shim.chmod(0o755)
+
+    dest = work / "korrupt-backups"
+    proc = snapshot(repo, dest, path_prefix=str(shim_dir))
+
+    # Utan det här hade fallet kunnat bli grönt av att ingenting gick sönder.
+    assert marker.is_file(), detail(
+        "skalet vände aldrig någon bit — fallet testade ingenting", proc)
+
+    assert proc.returncode != 0, detail(
+        "ett korrupt pack ska aldrig kallas verifierat", proc)
+    assert "VERIFIERING MISSLYCKADES" in proc.err, detail(
+        "verifieringen ska säga ifrån med ord", proc)
+    assert not bundles(dest), detail(
+        "en korrupt bundle publicerades — falsk trygghet är precis vad "
+        "verktyget finns för att undvika", proc)
+    assert not list(dest.glob(".incomplete-*")), detail(
+        "den halvskrivna filen städades inte bort", proc)
+
+    print("OK: vänd bit i paketet — verifieringen fångar det och ingen bundle "
+          "publiceras")
+
+
+# --------------------------------------------------------------------------
+
+SCENARIOS = (
+    scenario_portabilitet,
+    scenario_vanligt_repo,
+    scenario_bart_repo,
+    scenario_bundle_utan_head,
+    scenario_shallow,
+    scenario_mal_inuti_utcheckning,
+    scenario_worktree_med_radbrytning,
+    scenario_prunable_worktree,
+    scenario_default_fran_lankad_worktree,
+    scenario_vand_bit,
+)
+
+
+def main():
+    if shutil.which("git") is None:
+        print("ERROR: test_snapshot_tool.py kräver git i PATH", file=sys.stderr)
+        return 1
+    with tempfile.TemporaryDirectory(
+            prefix="tg-snapshot-test-", ignore_cleanup_errors=True) as base:
+        # .resolve() är inte kosmetik. På macOS ligger TMPDIR under
+        # /var -> /private/var, och skriptet rapporterar `pwd -P`-sökvägar.
+        # En oupplöst sökväg på Python-sidan hade aldrig kunnat matcha dem,
+        # och en jämförelse som aldrig kan slå till är ett grönt test som
+        # inte mäter något.
+        root = Path(base).resolve()
+        for scenario in SCENARIOS:
+            work = root / scenario.__name__
+            work.mkdir()
+            scenario(work)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/snapshot.sh
+++ b/tools/snapshot.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# En fil som kan återställa hela repot. Kör den före allt som skriver om
+# historik — rebase, filter-repo, force-push — och löpande om du vill.
+#
+# TÄCKER: varje commit som nås från varje ref. Alla grenar, taggar, notes.
+# TÄCKER INTE: ocommittade ändringar, ospårade filer, och allt .gitignore
+# döljer. Det betyder att `secrets.h` (WiFi-uppgifter + device key) och
+# `.ota-device` INTE ligger här, med flit — en backup som sprider hemligheter
+# till en katalog du glömmer bort är en läcka, inte ett skydd. De två filerna
+# behöver sin egen plats; se docs/lessons.md.
+#
+# DEN RADERAR ALDRIG NÅGOT. Första versionen rensade gamla snapshots, med
+# motiveringen att en katalog som växer obegränsat slutar bli körd. Den
+# rensningen stod sedan för HÄLFTEN av alla buggar granskningen hittade i
+# filen — den tog andra repons bundles i en delad katalog, sedan repon som
+# råkade heta samma sak, sedan forkar som delar rotcommit. Varje lagning
+# öppnade nästa hål. En backup som växer kostar diskutrymme; en som raderar
+# fel fil kostar backupen. `rm` den du inte vill ha kvar, själv, när du ser
+# vad du gör.
+#
+# Bakgrunden till den första vakten: 2026-09-06 stoppades en historik-
+# omskrivning av att klonen var SHALLOW. `git rev-parse
+# --is-shallow-repository` svarar "true" när klonen är avhuggen, vilket läses
+# som ett ja om man skummar. En bundle tagen därifrån hade sett komplett ut
+# och innehållit en femtedel av historiken.
+set -euo pipefail
+
+# Allt den här filen skapar är privat för ägaren. En bundle är HELA repot i en
+# fil — varje gren, även opublicerade, och notes — och `git bundle create`
+# skriver 0644 under normal umask: mktemps 0600 överlever inte, för git
+# återskapar filen. På en delad maskin kunde vem som helst läsa hela
+# historiken ur räddningsfilen. Samma resonemang som gäller `secrets.h`:
+# säkerhetskopian får inte bli spridningsvägen.
+umask 077
+
+# Alla utcheckningar av repot, inte bara den vi råkar stå i. Kört från en
+# länkad worktree under `.worktrees/` — vilket `.gitignore` uttryckligen
+# förutser här — pekar `--show-toplevel` på den nästlade katalogen, och både
+# defaultmålet och "ligger den inuti repot"-vakten hade då bara jämfört mot
+# den. Backupen landade inuti huvudcheckouten, och en `rm -rf` av den tar med
+# sig räddningsfilen.
+# Bara LEVANDE utcheckningar. En registrering vars katalog raderats står kvar
+# som `prunable`, och att gissa liveness ur `[ -d ]` räcker inte: återskapas
+# sökvägen som en vanlig katalog passerar den testet, medan `git -C` där dör
+# med "not a git repository" — vilket avslutade skriptet med 128 efter att
+# bundlen publicerats men före återställningsraderna. Git rapporterar
+# `prunable` självt; det är den signalen som gäller, inte en gissning.
+# Listan läses NUL-terminerad (`-z`) och lagras i en fil, inte i en variabel:
+# en sökväg får innehålla radbrytningar, och då delar en radorienterad parser
+# posten mitt itu. Verifierat med en worktree på `/tmp/wt<radbrytning>break` —
+# den radorienterade varianten såg `/tmp/wt`, så ett mål inuti den riktiga
+# katalogen hade passerat vakten obemärkt. En shellvariabel kan inte bära NUL,
+# därför filen.
+#
+# Parsningen görs i skalet, inte i awk. `RS="\0"` fungerar i mawk och gawk men
+# inte i BSD awk — `/usr/bin/awk` på macOS, alltså maintainerns egen maskin —
+# där strängar är C-strängar: `"\0"` blir tom sträng, tom RS betyder styckeläge,
+# och vakten hade läst fel poster utan att säga ifrån. `read -r -d ""` är samma
+# primitiv som resten av filen redan använder, och behöver inget externt verktyg.
+# Av samma skäl har varje `mktemp` en egen mall: BSD mktemp kräver en, GNU:s
+# gör den valfri, och utan mall dör filen på rad ett på just den maskin där
+# AGENTS.md gör den obligatorisk före en historikomskrivning.
+part=""; probe=""
+roots_file="$(mktemp "${TMPDIR:-/tmp}/tg-snapshot-roots-XXXXXXXX")"
+trap 'rm -f "$part" "$roots_file"; rm -rf "$probe"' EXIT
+git worktree list --porcelain -z | {
+  cur=""; prunable=0
+  emit() { if [ -n "$cur" ] && [ "$prunable" = 0 ]; then printf '%s\0' "$cur"; fi; }
+  while IFS= read -r -d "" line; do
+    case "$line" in
+      "worktree "*) emit; cur="${line#worktree }"; prunable=0 ;;
+      prunable*)    prunable=1 ;;
+    esac
+  done
+  emit
+} > "$roots_file"
+# Första posten är huvudutcheckningen. Ett tomt resultat är inte tänkbart —
+# git listar alltid minst en — men ett tyst `exit 1` från ett misslyckat `read`
+# vore precis den ordlösa vägran som redan bitit en gång i den här filen.
+if ! IFS= read -r -d "" repo < "$roots_file"; then
+  echo "VÄGRAR: git worktree list gav ingen levande utcheckning att utgå från." >&2
+  exit 1
+fi
+repo="$(cd "$repo" && pwd -P)"
+dest="${TG_SNAPSHOT_DIR:-$(dirname "$repo")/$(basename "$repo")-backups}"
+
+if [ "$(git -C "$repo" rev-parse --is-shallow-repository)" = "true" ]; then
+  printf '%s\n' \
+    'VÄGRAR: klonen är shallow — en bundle härifrån vore en trunkerad historik' \
+    'som ser komplett ut. Kör först:' \
+    '  git fetch --unshallow' >&2
+  exit 1
+fi
+
+# En backup får aldrig bo inuti det den säkerhetskopierar. Jämförelsen sker på
+# den UPPLÖSTA sökvägen: `TG_SNAPSHOT_DIR=.snap` och sökvägar med `..` pekar in
+# i repot utan att se ut att göra det, och en textjämförelse släpper igenom dem
+# — då hamnar räddningsfilen i trädet den ska överleva.
+# Städningen vid vägran gäller BARA en katalog den här körningen själv skapade.
+# Filen lovar att aldrig radera något; ett `rmdir` som inte skiljer på egen och
+# befintlig katalog bryter det löftet för den som redan lagt upp målet och
+# råkat peka det fel — rättigheter och annan metadata är hens, inte vår.
+dest_was_created=0
+[ -d "$dest" ] || dest_was_created=1
+mkdir -p "$dest"
+dest="$(cd "$dest" && pwd -P)"
+# En FLAGGA, inte `exit` i loopen. Loopen läser numera från en fil i stället
+# för genom ett rör, alltså körs den i det här skalet — och då avslutade
+# `exit 1` hela skriptet direkt och hoppade över meddelandet som skulle
+# förklara varför. Vägran blev tyst: exit 1, tomt stderr. Fångat genom att
+# faktiskt köra fallet i stället för att läsa diffen.
+inside=0
+while IFS= read -r -d "" r; do
+  [ -n "$r" ] && [ -d "$r" ] || continue
+  rp="$(cd "$r" && pwd -P)"
+  case "$dest" in "$rp"|"$rp"/*) inside=1; break ;; esac
+done < "$roots_file"
+if [ "$inside" = 1 ]; then
+  if [ "$dest_was_created" = 1 ]; then rmdir "$dest" 2>/dev/null || true; fi
+  echo "VÄGRAR: $dest ligger inuti en utcheckning av repot. Sätt TG_SNAPSHOT_DIR utanför." >&2
+  exit 1
+fi
+
+# Namnet får inte kunna kollidera. En sekundstämpel räcker inte — två
+# körningar inom samma sekund får identisk sökväg och `git bundle create`
+# TRUNKERAR en befintlig fil i stället för att vägra. PID räckte inte heller:
+# den är unik bara inom en PID-rymd, så två containrar som delar katalog kan
+# få samma. mktemp skapar filen EXKLUSIVT och ger slumpen som suffix; ingen
+# `[ -e ]`-kontroll behövs, och den hade ändå varit racy.
+#
+# Skrivs till ett namn som INTE slutar på .bundle. En avbruten körning lämnar
+# då något ingen kan förväxla med en färdig backup.
+stamp="$(date +%Y%m%d-%H%M%S)"
+part="$(mktemp "$dest/.incomplete-$stamp-XXXXXXXX")"
+bundle="$dest/$(basename "$repo")-$stamp-${part##*-}.bundle"
+
+# `--quiet` FÖRE filnamnet. Efter det tolkas det som ett rev-list-argument —
+# git accepterar det tyst och skriver ändå förloppet till en terminal.
+git -C "$repo" bundle create --quiet "$part" --all
+
+# En overifierad backup är ingen backup — men `git bundle verify` räcker inte
+# som verifiering. Den läser huvudet och kontrollerar att förutsättningarna
+# finns; den rör inte paketets kontrollsummor. En bit vänd mitt i filen ger
+# fortfarande "The bundle is okay", medan `git clone` dör på
+# "inflate returned -5". Att kalla det verifierat vore precis den falska
+# trygghet den här filen finns för att undvika.
+#
+# Därför indexeras paketet på riktigt: en fetch in i ett tomt bart repo tvingar
+# git att packa upp och kontrollsummera varje objekt. Det kostar ~1,3 s på 13
+# MB, vilket är gratis jämfört med att upptäcka det efter en omskrivning.
+# Refspecarna har skilda mål så de aldrig kan peka på samma ref, och täcker
+# även en bundle vars enda head är pseudo-refen HEAD.
+#
+# `+HEAD:` läggs till bara om bundlen annonserar HEAD. En refspec med `*` är
+# tyst när inget matchar, men en EXAKT refspec är det inte: mot en bundle utan
+# HEAD — ett repo vars enda refs är remote-refs och taggar — avbryter fetchen
+# med "couldn't find remote ref HEAD", och skriptet hade då rapporterat ett
+# helt paket som trasigt och raderat backupen. Fel åt fel håll.
+probe="$(mktemp -d "${TMPDIR:-/tmp}/tg-snapshot-probe-XXXXXXXX")"
+git init -q --bare "$probe"
+heads="$(git bundle list-heads "$part")"
+specs=('+refs/*:refs/p/*' '+worktrees/*:refs/p-wt/*')
+if grep -qx '[0-9a-f]* HEAD' <<<"$heads"; then
+  specs+=('+HEAD:refs/p-head/HEAD')
+fi
+if ! git -C "$probe" fetch "$part" "${specs[@]}" >/dev/null 2>&1; then
+  echo "VERIFIERING MISSLYCKADES: paketet gick inte att packa upp." >&2
+  echo "  $bundle skrevs aldrig — ingen falsk trygghet." >&2
+  exit 1
+fi
+rm -rf "$probe"
+
+# `ln` publicerar atomiskt OCH vägrar om målet finns — `mv` skriver över, och
+# `mv -n` gör tyst ingenting och returnerar 0, vilket vore värst av allt här.
+#
+# Men hårdlänkar finns inte överallt. exFAT, FAT och SMB-monteringar saknar
+# dem — och det är just sådana volymer man hänger på för externa backuper. Ett
+# `ln` som alltid failar där hade fått skriptet att påstå att målet redan finns
+# och sedan låta trappen radera den färdigverifierade bundlen. Därför skiljs
+# de två orsakerna åt: finns målet är det en vägran, annars saknar filsystemet
+# hårdlänkar och `mv` är det bästa som går att få. Fönstret mellan kontroll och
+# flytt är litet och på en FAT-volym finns ingen atomisk primitiv att välja i
+# stället.
+if ln "$part" "$bundle" 2>/dev/null; then
+  rm -f "$part"
+elif [ -e "$bundle" ]; then
+  echo "VÄGRAR: $bundle finns redan — skriver inte över en befintlig backup." >&2
+  exit 1
+else
+  mv "$part" "$bundle"
+fi
+
+# Innehållsförteckningen bredvid, så man ser vad en bundle höll utan att packa
+# upp den. Den läses ur BUNDLEN, inte ur repot: `git show-ref` listar bara
+# vanliga refs, alltså varken `HEAD` från en detached checkout eller
+# `worktrees/<namn>/HEAD` från en länkad worktree — precis de heads vars
+# commits ingen gren når och som därför är hela poängen med att spara dem. Och
+# i ett repo utan vanliga refs returnerar show-ref 1, vilket under `set -e`
+# hade dödat skriptet tyst efter att bundlen redan flyttats på plats.
+git bundle list-heads "$bundle" > "${bundle%.bundle}.refs"
+
+refs=$(wc -l < "${bundle%.bundle}.refs" | tr -d ' ')
+commits=$(git -C "$repo" rev-list --all --count)
+size=$(du -h "$bundle" | cut -f1)
+printf 'Snapshot: %s\n  %s refs, %s commits, %s — verifierad\n' \
+  "$bundle" "$refs" "$commits" "$size"
+
+# Varningen gäller VARJE levande utcheckning, inte bara huvudworktreen. Sedan
+# `repo` blev huvudcheckouten hade en körning från en länkad worktree med
+# osparat arbete tigit still — den som stod där hade fått "verifierad" utan
+# ett ord om att just deras ändringar ligger utanför.
+while IFS= read -r -d "" r; do
+  [ -n "$r" ] && [ -d "$r" ] || continue
+  # Ett BART repo listas som worktree men har inget arbetsträd: `git status`
+  # dör där med 128, och `2>/dev/null` tystar bara meddelandet — statusen går
+  # vidare genom `pipefail` och dödade skriptet på tilldelningen nedan. Efter
+  # "verifierad", före återställningsraderna, med exit 128 på en backup som
+  # faktiskt låg färdig och verifierad på disk. Reproducerat med en bar klon.
+  # Ett bart repo har heller inget osparat att varna om.
+  if [ "$(git -C "$r" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+    continue
+  fi
+  # Och går status ändå inte att läsa: säg det. Att tyst rapportera noll
+  # ändringar vore en falsk friskförklaring av precis det slag den här filen
+  # finns för att undvika — men det får aldrig avsluta skriptet efter att
+  # bundlen redan ligger på plats.
+  if ! n=$(git -C "$r" status --porcelain 2>/dev/null | wc -l | tr -d ' '); then
+    printf '  OBS: kunde inte läsa git status i %s — kontrollera själv vad som ligger osparat där.\n' "$r"
+    continue
+  fi
+  # `if`, inte `[ ] && printf`: när sista utcheckningen är ren returnerar
+  # testet 1, hela pipelinen returnerar 1, och under `set -euo pipefail` dog
+  # skriptet där — efter att ha skrivit "verifierad" men före
+  # återställningsraderna. Det rena enkelworktree-fallet är normalfallet.
+  if [ "$n" -gt 0 ]; then
+    printf '  OBS: %s ocommittade ändringar i %s ligger UTANFÖR snapshoten.\n' "$n" "$r"
+  fi
+done < "$roots_file"
+
+# Sökvägen citeras: en katalog med mellanslag hade annars gjort raden obrukbar
+# i precis det läge man klistrar in den utan att tänka.
+q() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+# INGET fullständigt återställningsrecept skrivs ut här, och det är ett beslut
+# taget efter åtta granskningsrundor där nästan varje ny kant satt i just de
+# raderna: refspecar som tappade taggar och notes, ett grennamn som kunde
+# innehålla `$(...)`, en detached HEAD utan namn, en länkad worktree, och till
+# sist ett räddningsnamn som kolliderade med sig självt så fort man återställt
+# en gång. En återställning görs sällan, av en människa, en gång — den tål att
+# slås upp. Ett recept som är fel i det läget gör skada.
+#
+# Det som står kvar är sant utan förbehåll: filen, vad den innehåller, och det
+# enda kommandot som inte kan bli fel.
+printf '\nInnehåll:  git bundle list-heads %s\n' "$(q "$bundle")"
+printf '           (eller läs %s)\n' "$(basename "${bundle%.bundle}.refs")"
+printf 'Återställ: git clone %s <katalog>\n' "$(q "$bundle")"
+printf '           Klonen tar grenar och taggar. Innehåller listan ovan\n'
+printf '           HEAD eller worktrees/... är de commits ingen gren når;\n'
+printf '           hämta dem med en egen refspec, se docs/lessons.md.\n'


### PR DESCRIPTION
## Outcome

`tools/snapshot.sh` — the backup `AGENTS.md` makes mandatory before any history
rewrite — had **no test coverage at all**: no entry in `test/run.sh`, no
`test/test_*.py`, no shellcheck. Three consecutive review rounds on #87 each
found a real defect in that one file, and every one was found by a reviewer
constructing a repository shape by hand.

`test/test_snapshot_tool.py` now runs the tool against ten synthetic
repositories and asserts both the exit code and the published artifacts:

- ordinary repository → exit 0, publishes a `.bundle` plus its `.refs`
  sidecar, bundle mode 0600, and the bundle clones back
- bare repository → exit 0
- repository whose bundle advertises no HEAD → exit 0
- shallow clone → refused, exit 1, message names `--unshallow`
- `TG_SNAPSHOT_DIR` inside a checkout → refused, four ways: directly, via `..`,
  via a linked worktree, and via a worktree whose path contains a newline
- a `prunable` worktree registration → neither refuses nor crashes, and is not
  counted as a live checkout
- run from a linked worktree → the default destination lands beside the
  **main** checkout, not the linked one
- a byte flipped in the pack → the verification catches it and nothing is
  published

A new `Snapshot tool` CI job runs the same file on **ubuntu-latest and
macos-latest**, plus `shellcheck` on the tool.

## Root cause / rationale

The five defects split into two classes, and only one of them is visible here.

**Logic** (4 and 5) reproduces on any platform: the verification fetch mixed
wildcard refspecs with the exact `+HEAD:refs/p-head/HEAD`, so a bundle from a
repository with no valid HEAD aborted the fetch and the tool declared an intact
bundle corrupt and deleted it; and in a bare repository `git status` exits 128,
the status travelled through `pipefail` into `n=$(...)`, and `set -e` ended the
script after printing "verifierad" but before the restore guidance.

**Portability** (1, 2 and 3) is invisible on Linux entirely: `awk` with NUL as
`RS` works in mawk and gawk, GNU `head` accepts `-c -1`, and GNU `mktemp` makes
the template optional. All three only bite on the maintainer's own Mac — the
machine where `AGENTS.md` makes this file mandatory. Running on ubuntu alone
catches none of them, which is why the job is a matrix rather than a single
runner, and why the test also carries static guards for that class so a
reintroduced GNU-ism goes red on ubuntu the minute it is written.

`shellcheck` is a complement, not a substitute: it flags neither `RS="\0"` nor
a missing `mktemp` template.

Two deliberate scoping decisions, both because the alternative would have been
red for reasons unrelated to this change:

- **shellcheck covers `snapshot.sh`, not `tools/*.sh`.** `flasha.sh` is zsh, so
  SC1071 means shellcheck cannot read it at all, and `CDPATH= cd` in
  `install-local-skills.sh` and `preview-ui.sh` trips SC1007 although the idiom
  is correct — "fixing" those would make them worse. Widening the glob is its
  own errand.
- **`--severity=warning`, not the default.** The first CI run went red on two
  info-level SC2015 findings on `[ -n "$r" ] && [ -d "$r" ] || continue`. The
  note is that C may run when A is true, which is exactly the intent here, and
  it is version-dependent: the runner image's shellcheck emits it, 0.11.0 does
  not — so the gate's colour tracked the image rather than the file. Errors and
  warnings still fail the step; parse errors, SC1007 and SC1071 were each
  checked against `--severity=warning` and still fail.

A dedicated job rather than a branch in the existing macOS tokenserver job:
that one also runs windows-latest, where a bash tool does not belong, and
installs dependencies this test does not have — it needs only stdlib and git.

## Verification

- [x] Relevant focused tests pass.
- [x] `./test/run.sh` passes, or the exact omission and reason are stated.
      **It could not be run in the container this was written in** — no Pillow,
      PyYAML or SDL2, the same environment gap #87 hit. It was syntax-checked
      (`sh -n`) and the new test was run from `test/`'s own cwd. **CI's
      `Host gate (./test/run.sh)` job ran the real thing green on this branch**
      ([run 584](https://github.com/niclasvestlund-YT/vibepulse/actions/runs/34060259854)),
      along with all eight other jobs.
- [x] No secret, credential, raw session content, production payload, or
      `torget.bin` is included.
- [x] Documentation and changelog match the behavior. `CHANGELOG.md` gains an
      `Unreleased → Added` entry.

**Each of the five defects was reverted one at a time and the test watched go
red** — the whole reason this task existed is that reasoning about these cases
was not enough:

| reverted | caught by |
| --- | --- |
| `awk 'BEGIN{RS="\0"}'` | static portability guard |
| line-oriented worktree parse | static guard **and** the newline scenario — the backup landed *inside* `wt⏎bryt/snap/` |
| `head -c -1` | static portability guard |
| `mktemp` without a template | static portability guard |
| exact `+HEAD` refspec always | no-HEAD scenario — an intact bundle declared corrupt and deleted |
| bare-repository guard removed | bare scenario — exit 128 after "verifierad", before the restore lines |
| *(bonus)* prunable filter removed | prunable scenario |

The byte-flip case's premise was confirmed directly rather than assumed:
`git bundle verify` reports *"The bundle records a complete history"* and exits
0 on the corrupted bundle, while the tool's fetch into a temp bare repository
dies on `inflate returned -3`. The test therefore asserts the tool's verdict,
not `git bundle verify`'s. A `git` shim injects the corruption and writes a
marker file, so the case cannot pass vacuously if the shim ever stops firing.

### Platform claims

- [x] This does not change a platform support claim. The new job is CI
      automation only; no support matrix, installer or runtime path changed.
- [x] A green CI runner is described only as automated evidence, not as a
      real-host or physical-panel pass. The macOS job proves the tool runs
      under BSD `awk`, `head` and `mktemp` on a hosted runner — that is
      automated evidence about a shell script, not a claim about the
      maintainer's bench.
- [x] Windows-affecting changes follow `docs/windows-validation.md`. Nothing
      Windows-affecting: the tool is bash, and the job deliberately does not
      run there.
- [x] Linux is not called supported. The ubuntu runner is CI evidence for a
      host-side shell script, exactly as the existing host-gate job already is.

### Hardware / UI

- [x] No hardware or UI behavior changed. Firmware, `components/`, `platform/`
      and `sim/` are untouched; the diff is one test file, one line plus a
      comment in `test/run.sh`, one CI job, a changelog entry, and the vendored
      tool itself.
- [x] A physical flash was separately and explicitly authorized. No flash was
      performed or requested.
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were
      not treated as approval.

## Not tested / remaining risk

**Merging this lands `tools/snapshot.sh` on `main` ahead of #87, which is where
the file was actually authored.** #87 is still open and already conflicted
against main; the first commit here vendors the file byte-identical to that
PR's head (`7fd11ad`), with no edits and the same mode, purely so the test has
something to run against. After this merges, #87's own diff for that file
should collapse to nothing — but that is a conflict its author will need to
resolve, and the changelog and `docs/lessons.md` entries about the tool remain
#87's.

The static portability guards are a grep, not an interpreter. They catch the
three spellings that actually bit plus five adjacent GNU-only ones (`sed -i`,
`readlink -f`, `grep -P`, `stat -c`, `date -d`), and they will not catch a
sixth nobody has thought of. **The macOS job is the real net; the guards only
shorten the feedback loop.** If the macOS runner is ever dropped from the
matrix, that class goes unguarded again.

The test does not cover: the `ln`-vs-`mv` publish fallback on filesystems
without hard links (exFAT/FAT/SMB, which cannot be synthesised in CI), the
refusal-cleanup promise that only a directory this run created is ever
`rmdir`'d, or the uncommitted-changes warning. Those are untested, not
unimportant.

`bash` 3.2 was checked for statically (no `declare -A`, `mapfile`, `readarray`,
`${var^^}`, `;;&` or `&>>`) but the macOS runner may provide a newer bash than
`/bin/bash`, so an actual bash-3.2 execution is inferred rather than proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPeAdD9heGCNW7WoRN6xfz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPeAdD9heGCNW7WoRN6xfz)_