### PR TITLE
fix(setup): a Claude-only install must not require a Codex CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,13 @@ jobs:
       - name: Run setup integration tests on Windows
         if: runner.os == 'Windows'
         shell: powershell
-        run: python test/test_vibepulse_codex_plugin.py
+        run: |
+          # PowerShell does not stop on a native command's non-zero exit, and
+          # the runner only checks the LAST exit code — so the first failure
+          # would be masked without this guard.
+          python test/test_vibepulse_codex_plugin.py
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python test/test_vibepulse_setup_claude_only.py
       - name: Validate the Windows Task Scheduler installer without installing
         if: runner.os == 'Windows'
         shell: powershell

--- a/test/run.sh
+++ b/test/run.sh
@@ -333,6 +333,7 @@ cc -std=c11 -Wall -Wextra -Werror -O1 \
 "$PYTHON_BIN" test_interaction_relay_build.py
 "$PYTHON_BIN" test_interaction_relay_net_source.py
 "$PYTHON_BIN" test_vibepulse_codex_plugin.py
+"$PYTHON_BIN" test_vibepulse_setup_claude_only.py
 
 cd ..
 "$PYTHON_BIN" -m unittest tools.agent_assets.test_build_agent_images -v

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -2187,16 +2187,30 @@ class SetupPlanTests(unittest.TestCase):
                 self.assertEqual((saved.claude_interactions,
                                   saved.codex_interactions), pair)
                 self.assertFalse(saved.interaction_detail)
-                self.assertEqual(len(runner.calls), 13)
-                self.assertEqual(
-                    [call[0] for call in runner.calls[5:10]],
-                    setup.plan_codex_install(
-                        ROOT, Path(sys.executable), Path("/codex")))
                 self.assertTrue(all(isinstance(call[0], list)
                                     and call[1].get("shell") is False
                                     for call in runner.calls))
-                self.assertIn("/hooks", out.getvalue())
                 self.assertIn("computer fallback", out.getvalue().lower())
+
+                # A choice that does not include Codex owns no Codex resources,
+                # so it mutates none and needs no Codex CLI (#65). Demanding one
+                # made the documented "claude" choice unreachable on a machine
+                # that has only Claude -- which is every machine we hand a panel
+                # to. The Codex choices still do the full transaction.
+                if providers in {"codex", "both"}:
+                    self.assertEqual(len(runner.calls), 13)
+                    self.assertEqual(
+                        [call[0] for call in runner.calls[5:10]],
+                        setup.plan_codex_install(
+                            ROOT, Path(sys.executable), Path("/codex")))
+                    self.assertIn("/hooks", out.getvalue())
+                else:
+                    self.assertEqual(
+                        [call for call in runner.calls
+                         if "codex" in " ".join(str(a) for a in call[0]).lower()],
+                        [], "a Claude-only install must issue no Codex commands")
+                    # Nothing to review in a program the user may not have.
+                    self.assertNotIn("/hooks", out.getvalue())
 
             path = Path(tmp) / "detail" / "config.json"
             setup.main(

--- a/test/test_vibepulse_setup_claude_only.py
+++ b/test/test_vibepulse_setup_claude_only.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""A Claude-only install must not require a Codex CLI (#65).
+
+`docs/agent-setup.md` offers `claude` as a first-class provider choice, but the
+install path demanded a Codex executable unconditionally, so the documented flow
+was unreachable on any machine without the Codex CLI — which is every friend's
+machine that runs Claude and nothing else. The combined error also blamed Python
+for a missing Codex.
+
+These tests drive `main()` with `codex=None`, the honest simulation of such a
+host: the executable is absent everywhere, not merely off `PATH`. On a developer
+Mac that distinction matters, because `resolve_codex_executable` also finds
+`/Applications/ChatGPT.app/Contents/Resources/codex`, so hiding `codex` from
+`PATH` proves nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_setup():
+    spec = importlib.util.spec_from_file_location(
+        "vibepulse_setup", REPO_ROOT / "tools" / "vibepulse_setup.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vibepulse_setup"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+setup = _load_setup()
+
+
+class _Completed:
+    def __init__(self, stdout=""):
+        self.returncode = 0
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _no_codex_run(argv, **kwargs):
+    """Answer the Python probe; treat any Codex command as a failure.
+
+    A Claude-only install owns no Codex resources, so it must issue no Codex
+    commands. Raising here is what proves the marketplace/plugin/MCP steps were
+    skipped rather than merely tolerated.
+    """
+    joined = " ".join(str(a) for a in argv)
+    if "codex" in joined.lower():
+        raise AssertionError(
+            f"Claude-only install issued a Codex command: {argv!r}")
+    if len(argv) >= 2 and argv[1] == "-c":
+        return _Completed("vibepulse-python-3.11+\n")
+    return _Completed()
+
+
+class ClaudeOnlyInstallWithoutCodex(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.config = Path(self._tmp.name) / "config.json"
+        self.addCleanup(self._tmp.cleanup)
+
+    def _run(self, argv, run=_no_codex_run):
+        out = io.StringIO()
+        code = setup.main(
+            argv, config_path=self.config, codex=None, run=run,
+            stdout=out, stdin_isatty=False)
+        return code, out.getvalue()
+
+    def test_claude_only_install_succeeds_without_codex(self):
+        code, text = self._run(
+            ["install", "--providers", "claude", "--no-detail"])
+        self.assertEqual(code, 0, text)
+        self.assertIn("PASS", text)
+        saved = json.loads(self.config.read_text())
+        self.assertTrue(saved.get("claude_interactions"), saved)
+        self.assertFalse(saved.get("codex_interactions"), saved)
+
+    def test_claude_only_install_mutates_no_codex_resources(self):
+        # _no_codex_run raises on any subprocess, so reaching PASS proves the
+        # marketplace/plugin/MCP steps were skipped rather than merely tolerated.
+        code, text = self._run(
+            ["install", "--providers", "claude", "--no-detail"])
+        self.assertEqual(code, 0, text)
+
+    def test_claude_only_success_does_not_mention_codex_hooks(self):
+        # Telling someone to trust hooks in a program they do not have reads as
+        # a failed step.
+        _, text = self._run(
+            ["install", "--providers", "claude", "--no-detail"])
+        self.assertNotIn("/hooks", text)
+
+    def test_codex_install_still_fails_clearly_without_codex(self):
+        code, text = self._run(
+            ["install", "--providers", "codex", "--no-detail"], run=None)
+        self.assertEqual(code, 1, text)
+        self.assertIn("Codex", text)
+        self.assertNotIn("Claude: ON", text)
+
+    def test_missing_codex_message_does_not_blame_python(self):
+        _, text = self._run(
+            ["install", "--providers", "codex", "--no-detail"], run=None)
+        # The original message named Python first for a missing Codex, sending
+        # people to reinstall a Python that was present and valid.
+        self.assertNotIn("Python or Codex", text)
+
+    def test_both_providers_require_codex(self):
+        code, _ = self._run(
+            ["install", "--providers", "both", "--no-detail"], run=None)
+        self.assertEqual(code, 1)
+
+    def test_providers_need_codex_predicate(self):
+        self.assertFalse(setup._providers_need_codex("claude"))
+        self.assertFalse(setup._providers_need_codex("off"))
+        self.assertTrue(setup._providers_need_codex("codex"))
+        self.assertTrue(setup._providers_need_codex("both"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1917,11 +1917,22 @@ def _failed_step_with_publish_state(
     return failed_step
 
 
+def _providers_need_codex(providers: str) -> bool:
+    """Whether this provider choice touches Codex resources at all."""
+    return providers in {"codex", "both"}
+
+
 def _install_transaction(
         *, path: Path, providers: str, detail: bool,
         legacy_claude_panel_v1: bool, repo_root: Path,
-        python: Path, codex: Path, run, stdout) -> bool:
-    """Mutate owned Codex resources and publish routing transactionally."""
+        python: Path, codex: Path | None, run, stdout) -> bool:
+    """Mutate owned Codex resources and publish routing transactionally.
+
+    A Claude-only install owns no Codex resources, so it mutates none: the
+    marketplace/plugin/MCP steps are skipped and `codex` may be None. Running
+    them anyway was harmless in effect but fatal in practice, because it made
+    a Codex CLI a hard prerequisite of a Claude-only panel (#65).
+    """
     with config_lock(_setup_transaction_path(path)):
         with config_lock(path):
             snapshot = load_config(path)
@@ -1934,10 +1945,18 @@ def _install_transaction(
                 print("FIX Python executable: install Python 3.11 or newer",
                       file=stdout)
                 return False
-            if not _codex_probe_ok(codex, run):
+            if _providers_need_codex(providers) and not _codex_probe_ok(
+                    codex, run):
                 print("FIX Codex executable: candidate is not Codex",
                       file=stdout)
                 return False
+            if not _providers_need_codex(providers):
+                # Nothing external to mutate, so nothing to compensate: go
+                # straight to publishing the chosen configuration.
+                failed_step = "configuration publish"
+                _publish_config(path, snapshot, target)
+                return True
+
             failed_step = "resource ownership preflight"
             before = _inspect_external(
                 repo_root=repo_root, python=python, codex=codex, run=run,
@@ -2165,8 +2184,18 @@ def main(
             print("FIX --legacy-claude-panel-v1 requires Claude in "
                   "--providers", file=output)
             return 1
-        if codex_path is None or python_path is None:
-            print("FIX Python or Codex executable not found", file=output)
+        # Codex is a requirement of the CODEX half only. Demanding it for a
+        # Claude-only install made the documented "choose claude" flow
+        # unreachable on a machine that has no Codex CLI, and the single
+        # combined message blamed Python for a missing Codex (#65). Report
+        # them apart, and ask only for what the chosen providers need.
+        if python_path is None:
+            print("FIX Python executable not found: install Python 3.11 "
+                  "or newer", file=output)
+            return 1
+        if _providers_need_codex(providers) and codex_path is None:
+            print(f"FIX Codex executable not found, and --providers "
+                  f"{providers} needs it", file=output)
             return 1
         if not _install_transaction(
                 path=path, providers=providers, detail=detail,
@@ -2175,8 +2204,12 @@ def main(
                 codex=codex_path, run=run, stdout=output):
             return 1
         print("PASS Installed the local VibePulse package", file=output)
-        print("Review and trust the exact VibePulse commands in Codex /hooks.",
-              file=output)
+        # Only say this when it is true: a Claude-only install on a machine
+        # with no Codex CLI has no /hooks to review, and telling someone to go
+        # trust hooks in a program they do not have reads as a failed step.
+        if _providers_need_codex(providers):
+            print("Review and trust the exact VibePulse commands in "
+                  "Codex /hooks.", file=output)
         print("If the panel is unavailable, Codex uses computer fallback.",
               file=output)
         return 0


### PR DESCRIPTION
Closes #65.

`docs/agent-setup.md` offers `claude` as a first-class provider choice, but the install path required a Codex executable unconditionally, so that documented flow is unreachable on a machine without the Codex CLI. The error also names Python first for a missing Codex, which sends people to reinstall a Python that was present and valid.

## What changed

- Both Codex requirements are gated on the chosen providers (`vibepulse_setup.py:2168` and the `_install_transaction` preflight), and the messages are split so a missing Python and a missing Codex report separately.
- A Claude-only install owns no Codex resources, so it now mutates none: the marketplace / plugin / MCP steps are skipped and `codex` may be `None`.
- The success output no longer tells a Claude-only user to review hooks in Codex, which reads as a failed step on a machine that has no Codex.

## On testing this honestly

The new tests drive `main()` with `codex=None` rather than hiding `codex` from `PATH`. That distinction matters: on a developer Mac `resolve_codex_executable` also finds `/Applications/ChatGPT.app/Contents/Resources/codex`, so a `PATH` trick proves nothing — it was how I first "confirmed" the fix, and it was wrong. One test fails the run if any subprocess command mentions codex at all, which is what proves the steps are skipped rather than merely tolerated.

`test_vibepulse_codex_plugin.py` encoded the old behaviour (13 subprocess calls for every provider choice). It now asserts the full transaction for `codex`/`both` and no Codex commands for `off`/`claude`.

## Verification

`test/test_vibepulse_setup_claude_only.py` — 7 tests, and `test_vibepulse_codex_plugin.py` — 137 tests, both green against this branch.

Found while setting the project up on a machine that runs Claude and not Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1rbyetdyQx632JT3Ut7Hw