### PR TITLE
fix(test): the "every output field is written" sweep was tautological on clang

### DIFF
--- a/test/test_key3_arbitration.c
+++ b/test/test_key3_arbitration.c
@@ -286,16 +286,44 @@ static void test_plain_glass(void) {
 
 static void test_outputs_are_always_fully_written(void) {
   /* Anroparen får aldrig läsa skräp: varje fält skrivs varje gång. Svepet ser
-   * hela tabellen, så ett tidigt return skulle synas här. */
+   * hela tabellen, så ett tidigt return skulle synas här.
+   *
+   * Skräpet måste läsas som BYTE, inte via fälten. Fälten är _Bool, och en
+   * oskriven _Bool som bär 0xAA är odefinierad att läsa — kompilatorn räknar
+   * dem som 0 eller 1 och optimerar därefter. Den gamla varianten OR:ade ihop
+   * fälten och jämförde med <= 1, vilket därför var både tautologiskt
+   * (clang bröt bygget på -Werror,-Wtautological-constant-compare) och
+   * overksamt: det villkoret kan inte bli falskt oavsett vad skiljedomen
+   * skriver.
+   *
+   * Vi anropar tg_button_arbitrate direkt i stället för genom arb(), eftersom
+   * arb() returnerar structen per värde — den kopian läser fälten och är alltså
+   * exakt den odefinierade läsning vi försöker upptäcka. */
   for (int k = 0; k < 4; k++) {
     for (int bits = 0; bits < 16; bits++) {
-      tg_button_outputs o =
-          arb(ALL_KEYS[k], bits & 1, bits & 2, bits & 4, bits & 8);
-      /* Bool-fälten är antingen 0 eller 1 — aldrig 0xAA. */
-      check("every output field is written",
-            (o.close_menu | o.menu_foreground | o.close_setup |
-             o.close_maintenance | o.request_setup_open | o.open_menu |
-             o.next_app | o.panic) <= 1);
+      const tg_button_inputs in = {
+          .key = ALL_KEYS[k],
+          .setup_owns_input = bits & 1,
+          .maintenance_open = bits & 2,
+          .notice_visible = bits & 4,
+          .menu_open = bits & 8,
+      };
+      tg_button_outputs out;
+      memset(&out, 0xAA, sizeof out);
+      tg_button_arbitrate(&in, &out);
+
+      /* Structen är åtta bool-fält utan utfyllnad, så varje byte hör till ett
+       * fält. Går den likheten sönder när någon lägger till ett fält av annan
+       * typ säger assert:en det, i stället för att svepet tyst slutar täcka. */
+      _Static_assert(sizeof(tg_button_outputs) == 8,
+                     "byte-svepet förutsätter åtta packade bool-fält");
+
+      const unsigned char *bytes = (const unsigned char *)&out;
+      bool unwritten = false;
+      for (size_t b = 0; b < sizeof out; b++) {
+        if (bytes[b] == 0xAA) unwritten = true;
+      }
+      check("every output field is written", !unwritten);
     }
   }
 }


### PR DESCRIPTION
`test/test_key3_arbitration.c` fails to compile on clang, which halts `test/run.sh` before any Python test runs — so the entire host suite is unavailable on a clang toolchain.

```
test_key3_arbitration.c:298:36: error: result of comparison of constant 1 with
boolean expression is always true [-Werror,-Wtautological-constant-compare]
```

## Why it is also ineffective

The check ORs the eight `_Bool` outputs and compares with `<= 1`. Reading an unwritten `_Bool` still holding the `0xAA` poison is undefined behaviour, and the compiler is entitled to assume a `_Bool` is 0 or 1 — so the condition cannot be false regardless of what `tg_button_arbitrate` writes. It has not been testing what its name says.

## The fix

The poison only survives in the raw bytes, so the sweep reads those. `tg_button_arbitrate` is called directly rather than through `arb()`, because `arb()` returns the struct by value and that copy is itself the undefined read the test exists to detect.

A `_Static_assert` pins the "eight packed bools, no padding" assumption the byte sweep rests on, so adding a field of another type fails loudly instead of quietly ending the coverage.

## Verification

Compiled and run with the exact invocation from `test/run.sh`:

```
cc -std=c11 -Wall -Wextra -Werror -O1 -I../components/torget_ota   ../platform/button_arbitration.c ../components/torget_wifi/wifi_slots.c   test_key3_arbitration.c -o /tmp/k3test && /tmp/k3test
-> OK: KEY3:s skiljedom håller alla åtta invarianterna
```

Found while running the host suite on macOS during setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1rbyetdyQx632JT3Ut7Hw