### PR TITLE
fix(views): the optional GitHub tile leaves a hole, and Value indexes past the end of ui.tiles

### DIFF
--- a/components/app_tokens/app_tokens.h
+++ b/components/app_tokens/app_tokens.h
@@ -7,6 +7,8 @@
 
 #include "torget_app.h"
 
+#include "app_tokens_config.h"   /* TK_GITHUB_SCREEN_ENABLED */
+
 #include "tokens.h"
 #include "agent_status.h"
 #include "github_status.h"
@@ -31,7 +33,19 @@ enum {
   VIEW_TRACKER_CLAUDE = 4,
   VIEW_TRACKER_CODEX = 5,
   VIEW_GITHUB = 6,
-  VIEW_VALUE = 7,
+  /* GitHub-sidan är VALFRI, och indexen måste vara TÄTA: `ui.tiles` är precis
+   * TK_USAGE_SCREEN_VIEWS lång, och tileviewen har ingen tile på index 6 att
+   * svepa förbi när sidan är bortvald.
+   *
+   * Med ett fast VIEW_VALUE 7 blev båda fel så snart GitHub var av — vilket är
+   * standardläget i en färsk klon. TK_USAGE_SCREEN_VIEWS blir då 7, alltså
+   * giltiga index 0-6, och värdesidan hamnade ett steg BORTOM det:
+   * `ui.tiles[VIEW_VALUE]` skrev utanför arrayen, och mellan trackern och
+   * värdesidan fanns ett hål som varken svep eller knapp kunde ta sig över.
+   *
+   * VIEW_GITHUB behåller sitt nummer även när sidan är av: ingen tile skapas
+   * där och ingenting indexerar det. Det är VIEW_VALUE som måste flytta. */
+  VIEW_VALUE = 6 + TK_GITHUB_SCREEN_ENABLED,
 };
 
 /* Ett lyckat /api/tokens-svar. Snappar tickern, stämplar färskhet och

--- a/components/app_tokens/usage_screen.c
+++ b/components/app_tokens/usage_screen.c
@@ -438,6 +438,11 @@ static void apply_github_page(const tk_github_status *status) {
 }
 #endif
 
+/* Varje vy måste rymmas i `ui.tiles`. Det var precis det som inte gällde när
+ * GitHub-sidan var bortvald, och det kostade en skrivning utanför arrayen. */
+_Static_assert(VIEW_VALUE < TK_USAGE_SCREEN_VIEWS,
+               "VIEW_VALUE ligger utanför ui.tiles — indexen är inte täta");
+
 static lv_obj_t *new_tile(int index) {
   lv_dir_t direction = index == 0 ? LV_DIR_RIGHT :
                        index == TK_USAGE_SCREEN_VIEWS - 1 ? LV_DIR_LEFT :
@@ -1127,6 +1132,7 @@ void usage_screen_show_view(int index) {
 int usage_screen_current_view(void) {
   lv_obj_t *active = lv_tileview_get_tile_active(ui.tileview);
   for (int i = 0; i < TK_USAGE_SCREEN_VIEWS; i++) {
+    if (!ui.tiles[i]) continue;   /* bortvald sida: inget index att matcha */
     if (ui.tiles[i] == active) return i;
   }
   return VIEW_CLAUDE_FABLE;

--- a/test/test_github_wiring.py
+++ b/test/test_github_wiring.py
@@ -36,7 +36,12 @@ class GitHubWiringTests(unittest.TestCase):
         # tile: GitHub stays at index 6, Value is the new last tile at 7.
         self.assertIn("(6 + TK_GITHUB_SCREEN_ENABLED + 1)", header)
         self.assertIn("VIEW_GITHUB = 6", app)
-        self.assertIn("VIEW_VALUE = 7", app)
+        # Value must MOVE with the optional GitHub tile rather than sit at a
+        # fixed index past it: a fixed 7 put the tile one slot beyond the end of
+        # ui.tiles whenever GitHub was disabled, which is an out-of-bounds write
+        # plus a hole no swipe could cross.
+        self.assertIn("VIEW_VALUE = 6 + TK_GITHUB_SCREEN_ENABLED", app)
+        self.assertIn("_Static_assert(VIEW_VALUE < TK_USAGE_SCREEN_VIEWS", ui)
         self.assertIn("set_star_hero", ui)
         self.assertIn('"FORKS"', ui)
         self.assertNotIn("ISSUES", ui)

--- a/test/test_vibepulse_layout_wiring.py
+++ b/test/test_vibepulse_layout_wiring.py
@@ -25,7 +25,9 @@ for enum_literal in (
     "VIEW_TRACKER_CLAUDE = 4",
     "VIEW_TRACKER_CODEX = 5",
     "VIEW_GITHUB = 6",
-    "VIEW_VALUE = 7",
+    # Value moves with the optional GitHub tile so the indices stay dense; a
+    # fixed 7 put it past the end of ui.tiles whenever GitHub was disabled.
+    "VIEW_VALUE = 6 + TK_GITHUB_SCREEN_ENABLED",
 ):
     assert enum_literal in app_header
 assert "VIEW_VOLUME" not in app_header


### PR DESCRIPTION
With `TK_GITHUB_SCREEN_ENABLED` at its default `0`, `TK_USAGE_SCREEN_VIEWS` is `(6 + 0 + 1)` = 7, so valid tile indices are `0..6` — but `VIEW_VALUE` is `7`.

Two consequences:

1. **Out-of-bounds write.** `create_value_page()` does `ui.tiles[VIEW_VALUE] = tile` via `new_tile()`, and `ui.tiles` is declared exactly `lv_obj_t *tiles[TK_USAGE_SCREEN_VIEWS]`. Index 7 lands in the struct member that follows it.
2. **An unreachable page.** No tile exists at the skipped index, so nothing can move between the tracker pages and the value page in either direction.

The numbering only ever indexed correctly with the GitHub page **enabled**, which is not the default in a fresh clone.

## The fix

- `VIEW_VALUE = 6 + TK_GITHUB_SCREEN_ENABLED`, so the indices stay dense whether or not the optional page is built. `VIEW_GITHUB` keeps its number either way — no tile is created there when disabled and nothing indexes it.
- A `_Static_assert(VIEW_VALUE < TK_USAGE_SCREEN_VIEWS)` refuses to build if a view ever sits outside `ui.tiles` again.
- `usage_screen_current_view()` skips slots holding no tile instead of comparing `active` against uninitialised memory.

## How it surfaced

On a panel where the physical buttons page through the views, the value page was reachable by neither swipe nor button from the tracker beside it. With the stock build the short press changes *app* rather than page, which is why the gap could sit there unnoticed.

## Verification

Simulator builds clean; `test_vibepulse_layout_wiring.py` and `test_github_wiring.py` updated to assert the density invariant rather than the old literal, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1rbyetdyQx632JT3Ut7Hw