### PR TITLE
Define contribution reviews and required merge checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@
 ## Verification
 
 - [ ] Relevant focused tests pass.
+- [ ] New tests are registered in the host runner and relevant CI steps;
+      optional-feature changes cover enabled and disabled paths where relevant.
 - [ ] `./test/run.sh` passes, or the exact omission and reason are stated.
 - [ ] No secret, credential, raw session content, production payload, or
       `torget.bin` is included.
@@ -35,3 +37,6 @@
 ## Not tested / remaining risk
 
 <!-- Be explicit. “None” is acceptable only after checking. -->
+
+<!-- A documented local omission does not waive required GitHub checks.
+     See CONTRIBUTING.md for the review and merge process. -->

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,44 @@
+{
+  "name": "protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {"context": "Host gate (./test/run.sh)", "integration_id": 15368},
+          {"context": "Encrypted interaction Worker", "integration_id": 15368},
+          {"context": "Numbers relay Worker", "integration_id": 15368},
+          {"context": "Tokenserver tests (ubuntu-latest)", "integration_id": 15368},
+          {"context": "Tokenserver tests (macos-latest)", "integration_id": 15368},
+          {"context": "Tokenserver tests (windows-latest)", "integration_id": 15368},
+          {"context": "Snapshot tool (ubuntu-latest)", "integration_id": 15368},
+          {"context": "Snapshot tool (macos-latest)", "integration_id": 15368},
+          {"context": "ESP32-S3 firmware build", "integration_id": 15368}
+        ]
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ AMOLED-skillen och mäts på panelen.
   Tokenmätaren, blev andra användaren — det är mallen).
 - **Ärlighetsinvarianten:** aldrig påhittade nollor — utan data visas
   streck; räknare backar aldrig; copyn säger vad siffran faktiskt mäter.
+- **Bidrag och merge:** följ `CONTRIBUTING.md` och
+  `docs/maintaining-contributions.md`. Även egna ändringar går via PR med
+  gröna obligatoriska kontroller. Dokumenterade testundantag ersätter inte
+  GitHubs mergekrav.
 - **Snapshot före allt som skriver om historik.** `tools/snapshot.sh` före
   rebase, filter-repo eller force-push. Den vägrar på en shallow klon, av
   skäl som står i `docs/lessons.md`. Push till GitHub är backup för det

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 Read `README.md` for the repository structure and build workflow.
 
+Follow `CONTRIBUTING.md` and `docs/maintaining-contributions.md` for contributions
+and merging. Maintainer changes also go through a PR with passing required
+checks. Documented local test omissions do not waive GitHub's merge requirements.
+
 Setting this repo up for someone (secrets, build, flash, tokenserver)? Follow
 `docs/agent-setup.md` — step-by-step, with verifications and a symptom→fix
 table. Never flash the board without the user explicitly asking you to.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,53 @@ workflow described in `AGENTS.md`. Simulator approval never authorizes a flash.
 
 ## Pull requests
 
+Open a pull request against `main` from a focused branch in your fork. A small
+bug fix can go straight to a PR; discuss a substantial feature or redesign in an
+issue first so we can agree on scope before you invest time in it.
+
 Explain the user-visible outcome, the root cause, the exact commands/tests that
 passed, and anything not tested. Link real-host or physical evidence when the
 change affects a public support claim. Keep release artifacts free of
 `torget.bin`: it contains local Wi-Fi and device material.
+
+For bug fixes, include a regression test that demonstrates the failure when
+practical. Make sure new tests are actually invoked by `test/run.sh` and any
+relevant platform-specific CI step. Most host tests are listed explicitly;
+adding a `test_*.py` file alone does not register it. Tokenserver test modules
+belong in `test/tokenserver-suite.txt`. For optional features, cover both enabled
+and disabled behavior where the change affects those paths.
+
+### Review and follow-up
+
+The maintainer reviews the code and test evidence, enables first-time
+contributors' CI runs after inspecting the changes, and leaves actionable
+feedback. Approval to run CI is separate from approval to merge.
+
+If changes are requested, update the same PR; there is no need to close it and
+start over. Explain what changed and rerun the affected tests. Small integration
+fixes may be added by the maintainer when you enable **Allow edits from
+maintainers**. Your authorship and contribution credit are preserved.
+
+Failures already present on `main` are investigated separately by the
+maintainer. Please report the failing command and evidence rather than removing
+checks to make a PR green. A documented local omission explains the evidence;
+it does not waive a required GitHub check.
+
+### Merge rules
+
+Changes to `main`, including maintainer changes, go through a PR. Before merging:
+
+- The maintainer has reviewed the final diff, and requested changes and review
+  conversations have been resolved.
+- All required GitHub Actions checks pass against the latest `main`.
+- The documentation describes the resulting behavior and the verification does
+  not claim more than was tested.
+
+We normally use **Squash and merge** to keep one focused commit per PR, retaining
+the contributor as author and any co-author credits. Merging does not publish a
+release or authorize flashing a device.
+
+The enforced settings are recorded in
+[`.github/rulesets/main.json`](.github/rulesets/main.json). See
+[Maintaining the merge rules](docs/maintaining-contributions.md) for the exact
+checks and the single-maintainer review policy.

--- a/docs/maintaining-contributions.md
+++ b/docs/maintaining-contributions.md
@@ -1,0 +1,62 @@
+# Maintaining contributions
+
+The contributor-facing process is in [CONTRIBUTING.md](../CONTRIBUTING.md).
+This page records the GitHub controls that support it.
+
+## Main branch protection
+
+The `protect-main` repository ruleset targets the default branch. Its desired
+configuration is versioned in [main.json](../.github/rulesets/main.json).
+GitHub enforces the live ruleset; committing this JSON does not apply it.
+
+The rules require a pull request, resolved review conversations, and all nine
+named GitHub Actions checks. The PR must be up to date with `main`. Check results
+must come from the GitHub Actions app (integration ID `15368`), rather than an
+arbitrary status publisher. Force pushes and branch deletion remain prohibited,
+and no bypass actors are configured.
+
+This is a single-maintainer repository, so the required approving-review count
+is **zero**. GitHub does not allow authors to approve their own PRs; requiring
+one other approval would block the owner's own maintenance work. The maintainer
+still reviews external contributions before merging and records the decision
+on the PR. This policy does not claim that GitHub enforces an independent human
+review. Revisit the approval count when a second active maintainer joins.
+
+## Applying or updating the rules
+
+The existing repository ruleset ID is `20918258`. After reviewing changes to the
+JSON, apply them from the repository root with an account that can manage rules:
+
+```sh
+gh api --method PUT \
+  repos/niclasvestlund-YT/vibepulse/rulesets/20918258 \
+  --input .github/rulesets/main.json
+gh api repos/niclasvestlund-YT/vibepulse/rulesets/20918258
+```
+
+Inspect the returned configuration to confirm it matches the intended rules.
+Update this file if the ruleset is replaced or the repository moves.
+
+When renaming or adding a required CI job, update the workflow and ruleset
+together. GitHub matches exact check names, including matrix suffixes. Verify a
+real PR run reports each required name before activating a new requirement;
+otherwise a missing check can leave every PR waiting indefinitely. Do not remove
+a failing check simply to merge the change it caught.
+
+## Handling external contributions
+
+1. Read the complete diff, including workflow changes, before enabling a
+   first-time contributor's CI run. The repository requires this approval for
+   first-time contributors; it is not a code review approval.
+2. Thank the contributor and identify concrete defects or missing evidence.
+   Request changes for issues that need fixing before merge; distinguish optional
+   suggestions from requirements.
+3. For a small integration fix, either ask for an update in the same PR or add a
+   commit when maintainer edits are enabled. Explain what was added and preserve
+   authorship. Keep unrelated existing defects in separate work.
+4. Review the final diff after updates, refresh the branch when `main` changes,
+   and wait for required checks. Approve an external PR when it is ready. Squash
+   merge it with an accurate title and retained author/co-author credits.
+
+Green CI is automated evidence. Physical validation and release or flashing
+authorization still follow the project's existing hardware rules.


### PR DESCRIPTION
Changes to main could previously be merged without a pull request or passing CI. This defines a consistent contribution and review process and records an enforceable GitHub ruleset requiring PRs, resolved review conversations, an up-to-date branch, and all nine existing GitHub Actions checks. Existing protections against deletion and force pushes are retained, with no bypass actors.

CONTRIBUTING now explains regression-test registration, coverage of optional paths, actionable review feedback, maintainer edits, preservation of contributor credit, and handling pre-existing failures. The PR template and both agent instruction files point to these requirements.

The approving-review count is deliberately zero for this single-maintainer repository, so the owner's maintenance PRs are not blocked waiting for another person. Maintainer review of external contributions remains documented policy; the configuration does not claim to enforce an independent review.

Validation: all 54 hardware-registry and repository-instruction tests pass locally; the JSON parses and its nine required check names exactly match a real PR run; `git diff --check` passes. Full repository CI runs on this PR. No firmware or runtime code changed. The JSON is applied separately through GitHub's ruleset API and verified against the returned live settings.
