### PR TITLE
docs(labs): clarify the base install and optional additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Codex. You do not need to read this whole page:
    hold opens [SETTINGS](#one-button-one-menu)** on the glass — UPDATE, WIFI and ABOUT today; the
    on-glass feature switches are specified but not built yet (see the spec
    in `docs/superpowers/specs/`). Sound has no verified backend yet.
+4. **Choose what to add later:** [Vibe Labs](docs/labs/README.md) lists the
+   optional integrations, today's installed pages, and the planned simpler
+   base. GitHub Stars is available; standalone reset clocks and coding quotes
+   are concepts. Value, burn rate and Max Tracker are still included today.
 
 ## Latest release: v1.0.0
 

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -8,6 +8,12 @@ deeper documentation is Swedish, which is fine to read as-is.
 Work through **Preflight** first — half of all setup failures are decided
 there.
 
+For installation scope, use the [Vibe Labs catalogue](labs/README.md): it
+separates today's built-in pages from optional integrations and future
+experiments. Start with local Claude/Codex usage. Add interactions, relays or
+GitHub only when the user chooses them. The leaner page profile and on-screen
+feature selector are planned, not setup commands that work today.
+
 For a Windows host, keep
 [Windows host setup and recovery](windows-setup.md) open beside this hardware
 runbook. It covers the standalone Codex CLI, Task Scheduler, Private firewall,

--- a/docs/labs/README.md
+++ b/docs/labs/README.md
@@ -1,0 +1,107 @@
+# Vibe Labs
+
+Optional ways to make VibePulse your own. Start with Claude/Codex usage;
+add the displays and integrations you want when you need them.
+
+**This is a feature catalogue, not a package installer.** Available features
+use the setup paths linked below. The on-screen FEATURES selector and a
+leaner first-install profile are still planned. Labs is optional; each entry
+has its own delivery and verification status.
+
+## What you get when you install today
+
+A fresh checkout builds one app: VibePulse. Its page rotation includes three
+quota pages, burn rate, two Max Tracker pages, and the Value page. Missing
+provider data stays unavailable; it is never turned into a made-up zero.
+Value needs priced usage, and its comparison also needs a plan cost.
+
+Local agent-status and Needs You display support are present; useful activity
+depends on the provider and setup. Answering on the panel is a separate
+opt-in. Cloud relays, GitHub pages/popups and sound are off by default.
+SETTINGS currently offers UPDATE, WIFI and ABOUT.
+
+Use the [setup guide](../agent-setup.md) for the installation and the
+[independent switches](../../README.md#independent-switches) for interaction
+and cloud choices. You do not need GitHub configuration, plan costs, a relay
+account or any Labs experiment to start using quotas.
+
+## The simpler installation we are working toward
+
+The intended base is Claude/Codex quota pages with reset information, local
+activity when available, and device settings. Additional analytics, fun
+displays and integrations belong in Labs and start off for a fresh install.
+Existing users keep their choices when this profile is implemented.
+
+| Feature | Available today | Fresh install today | Intended Labs choice |
+|---|---|---|---|
+| Burn rate | Built; uses quota history | Page included | Optional analytics |
+| Max Tracker | Built; needs usage history and plan identity for relevant labels | Two pages included | Optional analytics |
+| API-equivalent value | Built; needs model prices, plus plan cost for the multiple | Page included; can show missing-price or missing-plan states | Optional analytics |
+| GitHub Stars / forks | Built | Off | Repository page |
+| New-star popup | Built, independent of the GitHub page | Off | Event popup |
+| Reset clock / countdown | Concept | Not available as a standalone view | Ambient display |
+| Coding quotes | Idea; initial copy drafted | Not available | Ambient display |
+| Reset celebration | Idea | Not available | Event popup |
+
+**Included today is not the intended default.** Burn rate, Max Tracker and
+Value do not yet have user-facing off switches. Creating this catalogue does
+not hide those pages, install an experiment, or change an existing device.
+
+## Choose an available add-on
+
+### GitHub Stars and new-star moments
+
+Follow [GitHub project pulse](../../README.md#optional-github-project-pulse) to set a
+public repository on the computer service. The firmware switches
+`TK_GITHUB_SCREEN_ENABLED` and `TK_GITHUB_NOTIFICATIONS_ENABLED` are separate
+and default to `0`. They currently require a firmware build; they are not
+runtime menu switches. Turning the page off does not turn the popup on.
+
+The [page and popup examples](../../README.md#optional-github-project-pulse) distinguish
+live, cached and missing data. Sound is a separate default-off experiment;
+its physical speaker/backend gate is not complete.
+
+### API-equivalent value
+
+This estimates what recorded tokens would cost at list API prices, then
+compares that estimate with the configured subscription cost. It is **not an
+API invoice, actual spend, or a measured saving**.
+
+Follow [Value setup and price maintenance](../value-multiple.md). The page is
+already included today. `UNPRICED` / `SOME MODELS ARE NOT PRICED` means more
+than 2% of the counted tokens lack a known model price; refresh and verify the
+price snapshot before trusting a comparison. A missing plan cost is a
+different condition. Neither should prompt a board reset or firmware flash.
+
+### Answering from the panel and using it away from home
+
+These are independent opt-ins, not prerequisites for Labs:
+
+- [Claude and Codex interactions](../agent-setup.md): set up the providers
+  you use; adding a plugin alone does not enable them.
+- [Numbers relay](../relay.md): carry quota and other supported numbers
+  between separate networks.
+- [Encrypted interaction and live-status relays](../interaction-relay.md):
+  separate choices for questions/answers and activity.
+
+Their guides own setup, privacy and platform verification. A Labs label does
+not imply physical validation on another machine or panel.
+
+## Ideas to try later
+
+[Display experiments](display-experiments.md) records the reset clock,
+countdown, quotes and reset moments. None is a shipped feature or a promised
+release. Home Assistant remains an idea in the
+[onboarding design](../superpowers/specs/2026-09-04-vibepulse-onboarding-core-and-settings-design.md).
+
+## Where additions belong
+
+This catalogue is the entry point. Existing firmware and host implementations
+stay in place. New optional firmware components may use `components/labs_*`
+and new optional host modules `tools/labs/` when they are actually needed;
+there are no empty runtime packages or new plugin loader to install.
+
+[Adding a Labs feature](adding-a-feature.md) defines the entry and delivery
+checklist. Next delivery steps are the runtime feature switches, measurements
+and first-install defaults described in the
+[onboarding design](../superpowers/specs/2026-09-04-vibepulse-onboarding-core-and-settings-design.md).

--- a/docs/labs/adding-a-feature.md
+++ b/docs/labs/adding-a-feature.md
@@ -1,0 +1,32 @@
+# Adding a Vibe Labs feature
+
+Add a catalogue entry before advertising an optional feature as available.
+Keep the feature's real implementation and verification status visible.
+
+Each entry states:
+
+| Field | What to record |
+|---|---|
+| Purpose | The one useful thing the user sees or does |
+| Status | Idea, concept, implemented with evidence limits, or verified on named hardware/revision |
+| Default | What a fresh install does today; intended default separately when different |
+| Enable and disable | Existing setup path, dependencies and whether rebuild/restart is required |
+| Data | Source, freshness, missing-data behaviour, network and privacy needs |
+| Display | Passive page or interrupting event; dismissal and priority |
+| Evidence | Relevant tests, native captures and exact physical review, when available |
+
+An experiment is not enabled by installing VibePulse. New optional features
+should start off; preserve existing user choices. A page and a popup are
+separate choices. Optional failure must not block quota updates or questions.
+
+Keep existing code in place. Introduce `components/labs_<feature>` or
+`tools/labs/<feature>` only when the feature needs its own module; reuse the
+app's existing interfaces and source ownership. Do not build a package loader
+or framework ahead of a concrete requirement.
+
+When implementation changes defaults or activation, update this catalogue,
+the feature guide and the setup/README instructions in the same change. The
+feature must have a working disable path before it can be described as a
+user-selectable add-on. Follow repository PR, test and physical-review rules.
+
+Return to the [Labs catalogue](README.md).

--- a/docs/labs/display-experiments.md
+++ b/docs/labs/display-experiments.md
@@ -1,0 +1,69 @@
+# Labs display experiments
+
+Concepts recorded on 2026-09-08. These are optional additions to explore,
+not implemented pages, approved LVGL layouts or installed firmware.
+
+## Reset clock and countdown
+
+**Purpose:** see the next quota reset from across the room. One dominant
+piece of information on the 480 × 480 display.
+
+Two presentations of the same known reset timestamp:
+
+- A weekday and large clock time, for example **FRIDAY 17:00**.
+- Time remaining, formatted as days/hours or hours/minutes.
+
+The selected window and provider must remain identifiable. Keep the black
+AMOLED background and provider accents: Codex `#6F78FF`, Claude `#D97757`.
+The examples are fictional; use source timestamps in an implemented view.
+
+Reuse the existing quota data path. The host already carries reset timestamps
+such as `weekResetAt` and `codexWeekResetAt`; the panel can count down locally
+with a synchronized clock between fetches. Do not poll a provider each second.
+The existing reset line on quota pages remains part of the base product.
+
+A reset belongs to a specific quota window. It does not mean every limit
+resets or that an agent is ready to run. At zero, fetch fresh data before
+claiming recovery. Label cached data, show a dash without a known timestamp,
+and never invent a next cycle from an expired cache.
+
+## Coding quotes
+
+**Purpose:** a playful idle page with one short quote, large type and a few
+accent-coloured words. A local, bundled text collection is enough; it does
+not need an AI request or a paid API.
+
+Initial original copy, with no attribution to real people:
+
+- “En sista prompt. Sen lägger jag mig.”
+- “99 % klart. Sedan igår.”
+- “Det fungerar. Ingen rör någonting.”
+- “Jag skriver inte buggar. Jag beställer dem.”
+- “Planen var en enkel app.”
+- “Claude bygger. Codex granskar. Jag tar kaffe.”
+- “It works on my prompt.”
+- “Vibe now. Debug later.”
+
+Explore tap-to-change and a configurable idle rotation. The copy is display
+content, not an instruction to the coding agent. Typography and Swedish
+glyph coverage need native-size review before implementation.
+
+## Reset moments
+
+**Purpose:** briefly show “Nu kör vi igen” after the source confirms a new
+quota window. This is a separate opt-in from the passive reset clock, just
+as the existing new-star popup is separate from the GitHub page.
+
+Do not trigger on startup, reconnect, stale-cache expiry or a local countdown
+alone. Return to the previous page, allow dismissal and avoid repeated
+celebrations of the same reset. Quotes and celebrations must yield to pending
+questions and device maintenance screens. Sound is not a dependency.
+
+## Before any of these ships
+
+Choose one static layout, verify it at 480 × 480 in Studio and shared LVGL,
+exercise missing/stale/live states and widest copy, then follow the existing
+physical-review process. Motion, sound and firmware installation retain
+their own verification and authorization requirements.
+
+Return to the [Labs catalogue](README.md).

--- a/docs/superpowers/specs/2026-09-04-vibepulse-onboarding-core-and-settings-design.md
+++ b/docs/superpowers/specs/2026-09-04-vibepulse-onboarding-core-and-settings-design.md
@@ -746,6 +746,12 @@ image alone, exactly as today.
 
 ## Repository structure: core and add-ons
 
+**2026-09-08 update:** the [Vibe Labs catalogue](../../labs/README.md) now
+records current installation behaviour, intended defaults, activation paths
+and display experiments. The catalogue portion of step 8 is complete; the
+runtime feature selector and leaner defaults are still pending. In particular,
+Value, burn rate and Max Tracker remain included in today's page rotation.
+
 - **Firmware:** existing components stay where they are. New optional
   features live under `components/labs_*`; new optional host code under
   `tools/labs/`.
@@ -803,8 +809,9 @@ reverted alone.
 7. Runtime provisioning for the device key and the relay settings through
    the PAIR window; relay clients compiled into the release image and gated
    at runtime. Only after this does one binary serve every rung.
-8. Later and separately: leaner defaults for fresh installs; `docs/labs/`
-   index; Home Assistant as an add-on; and, if it proves worth a second
+8. The `docs/labs/` index is documented as of 2026-09-08. Later and separately:
+   leaner defaults for fresh installs; Home Assistant as an add-on; and, if it
+   proves worth a second
    authenticated path into the panel, routing a boot proof back to an
    updater that is not the panel's service host (see *The paired upload
    never sends the token*, which today reports an honest **delivered**


### PR DESCRIPTION
VibePulse's setup documentation mixes built-in pages, opt-in integrations and future experiments. Add a Vibe Labs catalogue linked from Start here and the agent setup guide, with today's defaults and the intended simpler installation shown separately.

The catalogue covers GitHub Stars and popups, API-equivalent value, interaction/relay choices, and planned reset clocks, coding quotes and reset moments. It also defines how future Labs entries record activation, source data and verification. The onboarding spec now marks the catalogue complete while leaving runtime switches and leaner defaults pending.

Validation: reviewed against current feature guards and page creation; checked 65 local link destinations and all Labs anchors; `git diff --check` passed. Documentation only; no runtime defaults, firmware or installed services changed by this PR.
