### PR TITLE
test(max-tracker): stamp synthetic records by local day, not a fixed UTC hour (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **The host gate could not go green anywhere but Europe.** Every Max
+  Tracker test stamped its synthetic records at a fixed UTC hour such as
+  `T10:00:00Z` and expected the store to file them under that same calendar
+  date. The store deliberately owns a record by its *local* day
+  (`max_tracker.py`: "dygnsgränsen är Macens, inte UTC:s"), so west of
+  UTC-10 the record was the previous evening and at UTC+12 a noon stamp was
+  already the next morning. Issue #66 reported the seeded ownership test
+  from Los Angeles; the same class took down thirteen more tests in
+  Pacific/Pago_Pago and one in Auckland, and one in `test_tokenserver.py`.
+  A `_local_stamp(day, hour)` helper now builds every stamp from local
+  wall-clock time and converts it to UTC, so expectation and store apply
+  one rule. The seeded test records ground truth against the local owning
+  day of the stamp it actually wrote. Verified green in seven zones from
+  UTC-11 to UTC+14. No user-facing data was ever affected: the store was
+  right, the expectations were not.
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/tools/tokenserver/test_max_tracker.py
+++ b/tools/tokenserver/test_max_tracker.py
@@ -6,7 +6,7 @@ import tempfile
 import threading
 import time
 import unittest
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -38,7 +38,25 @@ def _index_for_date(today: str, target_date: str) -> int:
     return window.index([77, 2])
 
 
-def _rollout_event(rate_limits, timestamp="2026-08-07T10:00:00Z"):
+def _local_stamp(day: str, hour: int = 12) -> str:
+    """A UTC ``...Z`` timestamp that the store files under LOCAL day
+    ``day`` on every host.
+
+    The store owns a backfilled record by the local calendar day of its
+    timestamp (``_handle_claude_event``: "dygnsgränsen är Macens, inte
+    UTC:s"), so a fixed ``"<day>T10:00:00Z"`` only lands on ``<day>`` for
+    hosts within ten hours east of UTC: west of UTC-10 it is the evening
+    before, and at UTC+12 a ``T12:00:00Z`` stamp is already the next
+    morning. Issue #66's report came from America/Los_Angeles; the same
+    class failed in Pacific/Pago_Pago and Pacific/Auckland. Build the
+    stamp from local wall-clock time instead so the expectation and the
+    store apply the same rule wherever the suite runs.
+    """
+    local = datetime.fromisoformat(f"{day}T{hour:02d}:00:00").astimezone()
+    return local.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _rollout_event(rate_limits, timestamp=_local_stamp("2026-08-07", 10)):
     """Mirror test_tokenserver.py's CodexLimitLogTests._event fixture shape:
     a real Codex rollout ``event_msg``/``token_count`` line."""
     return {
@@ -150,7 +168,7 @@ class MaxTrackerStoreCodexBackfillTests(unittest.TestCase):
             store, codex_root, _ = _new_store(directory)
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(primary_pct=42.0),
-                               "2026-08-07T10:00:00Z"),
+                               _local_stamp("2026-08-07", 10)),
             ])
 
             _drain(store)
@@ -163,9 +181,9 @@ class MaxTrackerStoreCodexBackfillTests(unittest.TestCase):
             store, codex_root, _ = _new_store(directory)
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(secondary_pct=87.0),
-                               "2026-08-07T10:00:00Z"),
+                               _local_stamp("2026-08-07", 10)),
                 _rollout_event(_rollout_limits(secondary_pct=100.0),
-                               "2026-08-08T10:00:00Z"),
+                               _local_stamp("2026-08-08", 10)),
             ])
 
             _drain(store)
@@ -203,7 +221,7 @@ class MaxTrackerStoreCodexBackfillTests(unittest.TestCase):
                 _rollout_event(_rollout_limits(
                     primary_pct=99.0, secondary_pct=100.0,
                     limit_name="GPT-5.3-Codex-Spark"),
-                    "2026-08-07T10:00:00Z"),
+                    _local_stamp("2026-08-07", 10)),
             ])
 
             _drain(store)
@@ -218,7 +236,7 @@ class MaxTrackerStoreCodexBackfillTests(unittest.TestCase):
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(
                     primary_pct=64.0, limit_name=""),
-                    "2026-08-07T10:00:00Z"),
+                    _local_stamp("2026-08-07", 10)),
             ])
 
             _drain(store)
@@ -238,7 +256,7 @@ class MaxTrackerStoreCodexBackfillTests(unittest.TestCase):
             store, codex_root, _ = _new_store(directory)
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(primary_pct=10.0),
-                               "2026-08-07T10:00:00Z"),
+                               _local_stamp("2026-08-07", 10)),
             ])
 
             _drain(store)
@@ -252,9 +270,9 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             store, codex_root, _ = _new_store(directory)
             first_row = _rollout_event(
-                _rollout_limits(primary_pct=10.0), "2026-08-01T10:00:00Z")
+                _rollout_limits(primary_pct=10.0), _local_stamp("2026-08-01", 10))
             second_row = _rollout_event(
-                _rollout_limits(primary_pct=88.0), "2026-08-02T10:00:00Z")
+                _rollout_limits(primary_pct=88.0), _local_stamp("2026-08-02", 10))
             path = codex_root / "rollout-a.jsonl"
             _write_jsonl(path, [first_row, second_row])
             first_line_bytes = len(json.dumps(first_row).encode("utf-8")) + 1
@@ -279,7 +297,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             store, codex_root, _ = _new_store(directory)
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(primary_pct=10.0),
-                               "2026-08-07T10:00:00Z"),
+                               _local_stamp("2026-08-07", 10)),
             ])
             _drain(store)
 
@@ -296,7 +314,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             store, codex_root, _ = _new_store(directory)
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(primary_pct=10.0),
-                               "2026-08-07T10:00:00Z"),
+                               _local_stamp("2026-08-07", 10)),
             ])
             _drain(store)
 
@@ -318,7 +336,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             day = _backfill_date()
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line("m1", 100, f"{day}T10:00:00Z")])
+                _claude_usage_line("m1", 100, _local_stamp(day, 10))])
             _age_into_last_month(path)
             _drain(store)
             self.assertEqual(store._state["claude"]["days"][day]["vol"], 100)
@@ -326,7 +344,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
 
             with path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(_claude_usage_line(
-                    "m2", 50, f"{day}T11:00:00Z")) + "\n")
+                    "m2", 50, _local_stamp(day, 11))) + "\n")
             self.assertEqual(path.stat().st_ino, inode_before)
             _age_into_last_month(path)
 
@@ -339,7 +357,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             store, codex_root, _ = _new_store(directory)
             path = codex_root / "rollout-a.jsonl"
             _write_jsonl(path, [_rollout_event(
-                _rollout_limits(primary_pct=40.0), "2026-08-01T10:00:00Z")])
+                _rollout_limits(primary_pct=40.0), _local_stamp("2026-08-01", 10))])
             _drain(store)
             self.assertEqual(
                 store.snapshot("2026-08-02", {})["codex"]["avgPeakPct"], 40.0)
@@ -347,7 +365,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             with path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(_rollout_event(
                     _rollout_limits(primary_pct=90.0),
-                    "2026-08-02T10:00:00Z")) + "\n")
+                    _local_stamp("2026-08-02", 10))) + "\n")
             _drain(store)
 
             # Two distinct days, each recorded exactly once (40 then 90) --
@@ -362,8 +380,8 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             day2 = _backfill_date(2)
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line("m1", 100, f"{day}T10:00:00Z"),
-                _claude_usage_line("m2", 50, f"{day}T11:00:00Z"),
+                _claude_usage_line("m1", 100, _local_stamp(day, 10)),
+                _claude_usage_line("m2", 50, _local_stamp(day, 11)),
             ])
             _age_into_last_month(path)  # Finding C: else backfill defers it
             _drain(store)
@@ -373,7 +391,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             # Truncated and rewritten in place (same path, same inode,
             # smaller size) -- simulates a rotated/rewritten log.
             _write_jsonl(path, [
-                _claude_usage_line("m3", 77, f"{day2}T10:00:00Z")])
+                _claude_usage_line("m3", 77, _local_stamp(day2, 10))])
             self.assertEqual(path.stat().st_ino, inode_before)
             _age_into_last_month(path)  # the rewrite also bumped mtime
 
@@ -394,9 +412,9 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             self.assertGreater(
                 junk_line_bytes, MaxTrackerStore._MAX_LINE_BYTES)
             _write_jsonl(path, [
-                _claude_usage_line("m1", 100, f"{day}T10:00:00Z"),
+                _claude_usage_line("m1", 100, _local_stamp(day, 10)),
                 junk,
-                _claude_usage_line("m2", 50, f"{day}T11:00:00Z"),
+                _claude_usage_line("m2", 50, _local_stamp(day, 11)),
             ])
             _age_into_last_month(path)  # Finding C: else backfill defers it
 
@@ -413,7 +431,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             store, codex_root, _ = _new_store(directory)
             event = _rollout_event(
-                _rollout_limits(primary_pct=71.0), "2026-08-07T10:00:00Z")
+                _rollout_limits(primary_pct=71.0), _local_stamp("2026-08-07", 10))
             event["payload"]["info"] = {"padding": "x" * (2 * 1024 * 1024)}
             line_bytes = len(json.dumps(event).encode("utf-8")) + 1
             self.assertGreater(line_bytes, 1024 * 1024)
@@ -429,7 +447,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             store, _, claude_root = _new_store(directory)
             day = _backfill_date()
-            row = _claude_usage_line("m1", 100, f"{day}T10:00:00Z")
+            row = _claude_usage_line("m1", 100, _local_stamp(day, 10))
             row["padding"] = "x" * (2 * 1024 * 1024)
             row_bytes = len(json.dumps(row).encode("utf-8")) + 1
             self.assertGreater(row_bytes, 2 * 1024 * 1024)
@@ -453,7 +471,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             _write_jsonl(codex_root / "rollout-a-first.jsonl", [junk])
             _write_jsonl(codex_root / "rollout-b-second.jsonl", [
                 _rollout_event(_rollout_limits(primary_pct=33.0),
-                               "2026-08-07T10:00:00Z"),
+                               _local_stamp("2026-08-07", 10)),
             ])
             # sorted() must pick the oversized file first for this to be a
             # meaningful test of "doesn't block the sibling forever".
@@ -478,7 +496,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             day = _backfill_date()
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line(f"m{i}", 1, f"{day}T10:00:00Z")
+                _claude_usage_line(f"m{i}", 1, _local_stamp(day, 10))
                 for i in range(257)
             ])
             _age_into_last_month(path)  # Finding C: else backfill defers it
@@ -495,9 +513,9 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             day = _backfill_date()
             day2 = _backfill_date(1)
             complete_line = json.dumps(_claude_usage_line(
-                "m1", 100, f"{day}T10:00:00Z"))
+                "m1", 100, _local_stamp(day, 10)))
             dangling = json.dumps(_claude_usage_line(
-                "m2", 999, f"{day}T11:00:00Z"))
+                "m2", 999, _local_stamp(day, 11)))
             path_a = claude_root / "session-a.jsonl"
             # No trailing newline on the last line -- a writer that
             # crashed or simply hasn't finished this line yet.
@@ -508,7 +526,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             _age_into_last_month(path_a)  # Finding C: else deferred to live
             path_b = claude_root / "session-b.jsonl"
             _write_jsonl(path_b, [_claude_usage_line(
-                "m3", 50, f"{day2}T10:00:00Z")])
+                "m3", 50, _local_stamp(day2, 10))])
             _age_into_last_month(path_b)
 
             _drain(store)
@@ -535,9 +553,9 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
             store, _, claude_root = _new_store(directory)
             day = _backfill_date()
             complete_line = json.dumps(_claude_usage_line(
-                "m1", 100, f"{day}T10:00:00Z"))
+                "m1", 100, _local_stamp(day, 10)))
             dangling = json.dumps(_claude_usage_line(
-                "m2", 999, f"{day}T11:00:00Z"))
+                "m2", 999, _local_stamp(day, 11)))
             path = claude_root / "session.jsonl"
             path.write_text(complete_line + "\n" + dangling)
             _age_into_last_month(path)
@@ -547,7 +565,7 @@ class MaxTrackerStoreBackfillBudgetTests(unittest.TestCase):
 
             # The writer finishes the dangling line and appends another.
             another_line = json.dumps(_claude_usage_line(
-                "m3", 25, f"{day}T12:00:00Z"))
+                "m3", 25, _local_stamp(day, 12)))
             with path.open("a", encoding="utf-8") as handle:
                 handle.write("\n" + another_line + "\n")
             _age_into_last_month(path)
@@ -582,7 +600,7 @@ class MaxTrackerStoreLiveWatermarkTests(unittest.TestCase):
             store, _, claude_root = _new_store(directory)
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line("m1", 100, "2026-07-15T10:00:00Z")])
+                _claude_usage_line("m1", 100, _local_stamp("2026-07-15", 10))])
             file_mtime = path.stat().st_mtime
 
             # Month M: the file's mtime is within the current month, so
@@ -623,7 +641,7 @@ class MaxTrackerStoreLiveWatermarkTests(unittest.TestCase):
             store, _, claude_root = _new_store(directory)
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line("m1", 100, "2026-07-15T10:00:00Z")])
+                _claude_usage_line("m1", 100, _local_stamp("2026-07-15", 10))])
             file_mtime = path.stat().st_mtime
 
             with mock.patch(
@@ -638,7 +656,7 @@ class MaxTrackerStoreLiveWatermarkTests(unittest.TestCase):
             # append's own real mtime, are what actually matter here).
             with path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(_claude_usage_line(
-                    "m2", 50, "2026-08-01T10:00:00Z")) + "\n")
+                    "m2", 50, _local_stamp("2026-08-01", 10))) + "\n")
 
             with mock.patch(
                     "tools.tokenserver.max_tracker._current_month_start_ts",
@@ -662,7 +680,7 @@ class MaxTrackerStoreLiveWatermarkTests(unittest.TestCase):
             store, _, claude_root = _new_store(directory)
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line("m1", 300, "2020-01-15T10:00:00Z")])
+                _claude_usage_line("m1", 300, _local_stamp("2020-01-15", 10))])
             _age_into_last_month(path)
 
             _drain(store)
@@ -723,14 +741,14 @@ class MaxTrackerStoreEventDateOwnershipTests(unittest.TestCase):
             # cap per call).
             backlog_path = claude_root / "a-backlog.jsonl"
             _write_jsonl(backlog_path, [
-                _claude_usage_line(f"m{i}", 1, "2020-01-01T10:00:00Z")
+                _claude_usage_line(f"m{i}", 1, _local_stamp("2020-01-01", 10))
                 for i in range(2000)
             ])
             _age_into_last_month(backlog_path)
 
             live_path = claude_root / "b-live.jsonl"
             _write_jsonl(live_path, [
-                _claude_usage_line("live1", 100, "2020-01-01T10:00:00Z")])
+                _claude_usage_line("live1", 100, _local_stamp("2020-01-01", 10))])
             live_mtime = live_path.stat().st_mtime
 
             with mock.patch(
@@ -775,7 +793,7 @@ class MaxTrackerStoreEventDateOwnershipTests(unittest.TestCase):
             # never 200 (100 doubled), never dropped.
             with live_path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(_claude_usage_line(
-                    "live2", 50, "2020-01-02T10:00:00Z")) + "\n")
+                    "live2", 50, _local_stamp("2020-01-02", 10))) + "\n")
 
             with mock.patch(
                     "tools.tokenserver.max_tracker._current_month_start_ts",
@@ -808,7 +826,7 @@ class MaxTrackerStoreEventDateOwnershipTests(unittest.TestCase):
             # before the real tail is ever reached.
             junk_line = json.dumps({"junk": "x" * (12 * 1024 * 1024)})
             real_tail = json.dumps(_claude_usage_line(
-                "tail", 999, "2020-01-15T10:00:00Z"))
+                "tail", 999, _local_stamp("2020-01-15", 10)))
             path.write_text(junk_line + "\n" + real_tail + "\n")
             _age_into_last_month(path)  # dormant -- backfill-owned from the start
             file_mtime = path.stat().st_mtime
@@ -872,6 +890,16 @@ class MaxTrackerStoreEventDateOwnershipTests(unittest.TestCase):
                 # Comfortably pre-rollover under any real-clock cutoff.
                 return (date(2000, 1, 1) + timedelta(days=n)).isoformat()
 
+            def owning_day(stamp: str) -> str:
+                # The store files every backfilled record under the
+                # LOCAL day of its timestamp (_handle_claude_event:
+                # "dygnsgränsen är Macens, inte UTC:s"). Ground truth
+                # has to follow the same rule, or any host west of UTC
+                # sees every pre-08:00Z record land one day earlier
+                # than a UTC-dated expectation claims (issue #66).
+                moment = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+                return moment.astimezone().date().isoformat()
+
             def new_day(n: int) -> str:
                 # Comfortably post-rollover under any real-clock cutoff.
                 return (date(2100, 1, 1) + timedelta(days=n)).isoformat()
@@ -885,10 +913,10 @@ class MaxTrackerStoreEventDateOwnershipTests(unittest.TestCase):
                 for i in range(count):
                     day = old_day(rng.randrange(0, 20))
                     tokens = rng.randrange(1, 50)
+                    stamp = f"{day}T{rng.randrange(0, 23):02d}:00:00Z"
                     lines.append(_claude_usage_line(
-                        f"{path.name}-{i}", tokens,
-                        f"{day}T{rng.randrange(0, 23):02d}:00:00Z"))
-                    record(day, tokens)
+                        f"{path.name}-{i}", tokens, stamp))
+                    record(owning_day(stamp), tokens)
                 _write_jsonl(path, lines)
                 os.utime(path, (pre_mtime, pre_mtime))
 
@@ -936,7 +964,7 @@ class MaxTrackerStoreEventDateOwnershipTests(unittest.TestCase):
                 with mid_path.open("a", encoding="utf-8") as handle:
                     handle.write(json.dumps(_claude_usage_line(
                         "mid-drain-rollover-tail", rollover_tokens,
-                        f"{rollover_day}T10:00:00Z")) + "\n")
+                        _local_stamp(rollover_day, 10))) + "\n")
                 os.utime(mid_path, (post_mtime, post_mtime))
                 store.observe_volume("claude", rollover_day, rollover_tokens)
                 record(rollover_day, rollover_tokens)
@@ -987,8 +1015,8 @@ class MaxTrackerStoreClaudeBackfillTests(unittest.TestCase):
             event_day = _backfill_date()
             path = claude_root / "session.jsonl"
             _write_jsonl(path, [
-                _claude_usage_line("m1", 100, f"{event_day}T10:00:00Z"),
-                _claude_usage_line("m2", 50, f"{event_day}T11:00:00Z"),
+                _claude_usage_line("m1", 100, _local_stamp(event_day, 10)),
+                _claude_usage_line("m2", 50, _local_stamp(event_day, 11)),
             ])
             _age_into_last_month(path)  # Finding C: else backfill defers it
 
@@ -1355,10 +1383,10 @@ class MaxTrackerStorePrivacySchemaTests(unittest.TestCase):
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(
                     primary_pct=61.0, secondary_pct=100.0),
-                    "2026-08-01T10:00:00Z"),
+                    _local_stamp("2026-08-01", 10)),
             ])
             _write_jsonl(claude_root / "session.jsonl", [
-                _claude_usage_line("m1", 500, "2026-08-02T10:00:00Z"),
+                _claude_usage_line("m1", 500, _local_stamp("2026-08-02", 10)),
             ])
             _drain(store)
             store.observe_quota("claude", 300, 55.0,
@@ -1392,7 +1420,7 @@ class MaxTrackerStorePrivacySchemaTests(unittest.TestCase):
             store, codex_root, claude_root = _new_store(directory, path=path)
             _write_jsonl(codex_root / "rollout-a.jsonl", [
                 _rollout_event(_rollout_limits(primary_pct=10.0),
-                               "2026-08-01T10:00:00Z"),
+                               _local_stamp("2026-08-01", 10)),
             ])
             _drain(store)
 

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -16,7 +16,7 @@ import threading
 import time
 import unittest
 import urllib.error
-from datetime import datetime
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from unittest import mock
@@ -3104,7 +3104,12 @@ class MaxTrackerSingleWriterTests(unittest.TestCase):
                 Path(temp_dir) / "max-tracker.json", codex_root, claude_root)
 
             path = claude_root / "session.jsonl"
-            old_timestamp = "2020-01-15T10:00:00Z"
+            # Local noon, expressed in UTC: the store owns the record by
+            # its LOCAL day, and a fixed "T10:00:00Z" is the previous
+            # evening west of UTC-10 (issue #66).
+            old_timestamp = (
+                datetime.fromisoformat("2020-01-15T12:00:00").astimezone()
+                .astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
             path.write_text(json.dumps({
                 "timestamp": old_timestamp, "sessionId": "session-a",
                 "requestId": "request-old",


### PR DESCRIPTION
## Outcome

`./test/run.sh` goes green on hosts outside Europe. Before this, the host gate failed deterministically in any timezone more than ten hours west of UTC or twelve hours east: one test in Los Angeles (the report in #66), fourteen in Pacific/Pago_Pago, one in Auckland, plus one in `test_tokenserver.py`. No user-facing behaviour changes. The Max Tracker store was always right; the test expectations were not.

Closes #66.

## Root cause / rationale

Every Max Tracker test stamped its synthetic records at a fixed UTC hour (`T10:00:00Z`, `T11:00:00Z`, `T12:00:00Z`) and expected the store to file them under that same calendar date. The store deliberately owns a backfilled record by its **local** day (`max_tracker.py` `_handle_claude_event`: "dygnsgränsen är Macens, inte UTC:s"). West of UTC-10 a `T10:00:00Z` stamp is the previous evening; at UTC+12 a `T12:00:00Z` stamp is already the next morning.

The fix is one helper, `_local_stamp(day, hour)`, that builds the stamp from local wall-clock time and converts it to UTC, so the expectation and the store apply the same rule wherever the suite runs. Every fixed stamp in `test_max_tracker.py` now goes through it; the seeded randomized ownership test records its ground truth against the local owning day of the stamp it actually wrote (the contributor's own proposed fix in the issue thread); the one fixed stamp in `test_tokenserver.py` is built the same way inline.

## Verification

- [x] Relevant focused tests pass: `tools.tokenserver.test_max_tracker` and `tools.tokenserver.test_tokenserver` green under `TZ=` America/Los_Angeles, Europe/Stockholm, UTC, Pacific/Auckland, Asia/Kolkata, Pacific/Pago_Pago (UTC-11) and Pacific/Kiritimati (UTC+14). Before the change: 1 failure in Los Angeles, 13 in Pago_Pago, 1 in Auckland in `test_max_tracker`, and 1 in `test_tokenserver` in Pago_Pago.
- [x] No new test files; nothing to register.
- [x] `./test/run.sh --skip-js` passes locally (814 tokenserver tests, all C binaries, Mbed TLS vectors and the SDL landmarks under xvfb). The JS lane runs in CI's own jobs.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] CHANGELOG `Unreleased / Fixed` entry added.

### Platform claims

- [x] This does not change a platform support claim.
- [x] A green CI runner is described only as automated evidence.
- [x] Windows-affecting: none. The stamps are pure `datetime` arithmetic.
- [x] Linux is not called supported.

### Hardware / UI

- [x] No hardware or UI behavior changed.

## Not tested / remaining risk

- A host whose local timezone has a DST transition exactly at the chosen local hour on one of the fixed test dates would shift a stamp by an hour; the hours used (10, 11, 12) are never DST cut-over hours in any zone in the IANA database, so this is theoretical.
- The JS relay suites were not run locally; they are unaffected by this change and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_