### PR TITLE
docs(setup): anchor the secrets.h placeholder check to the URL (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **The `secrets.h` check in the setup runbook failed every correct setup.**
+  Step 1 of `docs/agent-setup.md` verified the host placeholder with an
+  unanchored `grep -q 'DIN-MAC' secrets.h`. `secrets.h.example` says
+  `DIN-MAC` twice: in the `TK_VIBEPULSE_BASE_URL` define and in the comment
+  telling you to replace it. Following the runbook replaces the define and
+  keeps the comment, so the check printed `PLACEHOLDER STILL THERE` on every
+  correct file. This is the guard for the mistake that once cost an evening
+  of network debugging (`docs/lessons.md`, 2026-08-17); a guard that always
+  fires teaches the reader to ignore it. The match is now anchored to the
+  URL (`://DIN-MAC`) rather than to `#define`, because the define spans two
+  lines, and the runbook says why. Reported in issue #64.
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -105,13 +105,19 @@ exactly as before. With it, several computers may advertise simultaneously;
 the panel pins one healthy origin and changes only after failure. On Windows,
 `ipconfig` plus a DHCP reservation still makes the compiled fallback durable.
 
-**Verify:** `secrets.h` has a non-empty SSID and no `DIN-MAC` placeholder:
+**Verify:** `secrets.h` has a non-empty SSID and no `DIN-MAC` placeholder
+left in the URL:
 
 ```sh
-grep -q 'DIN-MAC' secrets.h && echo "PLACEHOLDER STILL THERE" || echo "host set"
+grep -q '://DIN-MAC' secrets.h && echo "PLACEHOLDER STILL THERE" || echo "host set"
 ```
 
-It must print `host set`. If the placeholder is still there,
+It must print `host set`. The match is anchored to `://` on purpose:
+`secrets.h.example` also says `DIN-MAC` in the comment that tells you to
+replace it, and that comment is meant to survive the edit, so an unanchored
+grep cried wolf on every correct setup (issue #64). The define itself spans
+two lines, which is why the anchor is the URL and not `#define`. If the
+placeholder is still there,
 the board's fallback will name a host that does not exist. Discovery may still
 find an advertising service, but a release must not depend on hiding a broken
 fallback. On macOS, replace a raw IP with the Bonjour name. On Windows,


### PR DESCRIPTION
## Outcome

The Step 1 verification in `docs/agent-setup.md` now prints `host set` on a correctly edited `secrets.h` and `PLACEHOLDER STILL THERE` on an untouched copy of the example. Before, it printed `PLACEHOLDER STILL THERE` on every correct setup, which trains the reader to ignore the one guard that protects against the "everything is dashes forever" failure from `docs/lessons.md` (2026-08-17).

Closes #64.

## Root cause / rationale

`secrets.h.example` says `DIN-MAC` twice: in the `TK_VIBEPULSE_BASE_URL` string and in the comment that tells you to replace it. The comment survives a correct edit, so an unanchored `grep -q 'DIN-MAC'` always matched.

The issue suggested anchoring to `#define.*DIN-MAC`. That never matches either, even the untouched example, because the define spans two lines (`#define TK_VIBEPULSE_BASE_URL \` then the string on the next line). The check is now anchored to `://DIN-MAC`, which only appears in the URL, and the runbook explains both the anchor and why it is not `#define`.

## Verification

- [x] Relevant focused tests pass: the four doc-asserting tests that read `docs/agent-setup.md` (`test_relay_boundary`, `test_interaction_relay_docs`, `test_ota_gesture_docs`, `test_docs_frame_drift`) are green.
- [x] Manual check of both outcomes: a copy of `secrets.h.example` with `DIN-MAC.local` replaced prints `host set`; an untouched copy prints `PLACEHOLDER STILL THERE`.
- [x] No new test files; nothing to register.
- [x] `./test/run.sh`: docs-only change; the full gate was run on the sibling branch for #99 on the same base and is not affected by a Markdown edit. CI runs it here.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] CHANGELOG `Unreleased / Fixed` entry added.

### Platform claims

- [x] This does not change a platform support claim.

### Hardware / UI

- [x] No hardware or UI behavior changed.

## Not tested / remaining risk

- If a future `secrets.h.example` moves the placeholder out of a URL, the anchor would need to follow it. The runbook sentence explaining the anchor is the reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_