### PR TITLE
fix(agent-status): read Claude's effort from the record, not only the message

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "72b051a141be"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **`effort` was null for every Claude job.** `agent_status.py` read it
+  from inside the API `message`, beside `model`. Claude Code writes it on
+  the transcript *record*, beside `type` and `version`: measured on a live
+  2.1.267 transcript, 125 of 125 assistant records carried `effort` at the
+  top level and none nested, while `model` really does live inside
+  `message`. `/api/agent-status` therefore served `effort: null` for every
+  Claude job since the field was added. The classifier now falls back to the
+  record's own `effort` when the nested one is absent, through the same
+  12-byte control-free bound; `tool_input` is still never a source. Found
+  by the companion-features audit (`docs/companion-features-brainstorm.md`,
+  "Fix first").
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,29 @@ point at the backlog item.
 
 ---
 
+## 2026-09-10 · The parser read a field where the docs put it, not where the writer puts it
+
+**What happened:** `/api/agent-status` served `effort: null` for every
+Claude job since the field was added; the panel had a column for it and
+never a value. **Root cause:** `_claude_event` read `effort` inside the
+API `message` object, beside `model`. Claude Code writes it on the
+transcript *record*, beside `type` and `version`. Nobody had opened a real
+transcript and counted: measured on a live 2.1.267 session, 125 of 125
+assistant records carried `effort` at the top level and none nested, while
+`model` really does live inside `message`. **The rule now:** a new field
+in an upstream file is located by *measurement on a real file* (count the
+records, count where the key appears), never by analogy with a sibling
+field or by the API shape. Write the count into the commit. **Guards:**
+`test_claude_reads_effort_from_the_record_top_level` and its three
+siblings in `test_agent_status.py` (nested still wins, bounded, never from
+`tool_input`); the classifier reads the nested place first and falls back
+to the record, so either layout keeps working. **Watch for:** the same
+mistake on the next Claude Code field; `docs/companion-features-brainstorm.md`
+lists two more measured shapes (`result` records, Codex `payload.info`)
+that code must not assume.
+
+---
+
 ## 2026-09-06 · The panel logged the credential it was told never to print
 
 **What happened:** all three failure paths in `torget_http.c` logged the

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+HOST_SOURCE_FINGERPRINT = "72b051a141be"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -181,6 +181,15 @@ def _claude_event(event: Dict[str, Any], state: str,
     else:
         model = None
         effort = None
+    if effort is None:
+        # Claude Code writes ``effort`` on the transcript RECORD, beside
+        # ``type`` and ``version``, not inside the API ``message`` where
+        # ``model`` lives. Measured on a live 2.1.267 transcript: 125 of
+        # 125 assistant records carried it at the top level, none nested.
+        # Reading only the nested place served ``effort: null`` for every
+        # Claude job. The nested read stays first so a layout that ever
+        # puts it there keeps working; tool_input is still never a source.
+        effort = normalize_effort(event.get("effort"))
     return Event(state, activity, task_id, source_id, project, model, effort)
 
 

--- a/tools/tokenserver/test_agent_status.py
+++ b/tools/tokenserver/test_agent_status.py
@@ -64,6 +64,54 @@ class ClassificationTests(unittest.TestCase):
         self.assertEqual(event.effort, "XHIGH")
         self.assertNotIn("OPUS", repr(event))
 
+    def test_claude_reads_effort_from_the_record_top_level(self):
+        """Where Claude Code actually writes it.
+
+        A real transcript puts ``effort`` beside ``type`` and ``version``
+        on the record, while ``model`` sits inside the API ``message``.
+        Reading only ``message.effort`` served ``effort: null`` for every
+        Claude job while the panel had a column for it.
+        """
+        entry = claude_event(
+            "assistant", tool_name="Bash",
+            tool_input={"command": "git status", "effort": "max"})
+        entry["message"]["model"] = "claude-fable-5"
+        entry["effort"] = "high"
+
+        event = classify_claude(entry)
+
+        self.assertEqual(event.model, "FABLE 5")
+        self.assertEqual(event.effort, "HIGH")
+
+    def test_claude_nested_effort_still_wins_over_the_top_level(self):
+        entry = claude_event("assistant", tool_name="Bash")
+        entry["message"]["effort"] = "xhigh"
+        entry["effort"] = "low"
+
+        event = classify_claude(entry)
+
+        self.assertEqual(event.effort, "XHIGH")
+
+    def test_claude_top_level_effort_is_bounded_and_never_from_tool_input(self):
+        entry = claude_event(
+            "assistant", tool_name="Bash",
+            tool_input={"command": "git status", "effort": "max"})
+        entry["effort"] = "max\n" + "å" * 20
+
+        event = classify_claude(entry)
+
+        self.assertLessEqual(len(event.effort.encode("utf-8")), 12)
+        self.assertNotIn("\n", event.effort)
+        self.assertTrue(event.effort.startswith("MAX"))
+
+    def test_claude_non_string_top_level_effort_is_ignored(self):
+        entry = claude_event("assistant", tool_name="Bash")
+        entry["effort"] = {"level": "high"}
+
+        event = classify_claude(entry)
+
+        self.assertIsNone(event.effort)
+
     def test_claude_does_not_take_model_from_nested_tool_input(self):
         entry = claude_event(
             "assistant", tool_name="Bash",


### PR DESCRIPTION
## Outcome

`/api/agent-status` now carries a real `effort` for Claude jobs instead of `null`. Nothing changes for Codex, whose `turn_context` path already read the right place.

## Root cause / rationale

Claude Code writes `effort` on the transcript **record**, beside `type` and `version`. `model` lives inside the API `message`. `_claude_event` read both from `message`, so `effort` was always absent. This is the first of the three "Fix first" items in `docs/companion-features-brainstorm.md`; that document measured it on Claude Code 2.1.231, and I re-measured it on a live 2.1.267 transcript before changing anything:

| assistant records | `effort` at top level | `effort` inside `message` | `model` inside `message` |
|---|---|---|---|
| 125 | 125 | 0 | 125 |

The fix keeps the nested read first (so a layout that ever puts it there keeps working) and falls back to the record's own field, through the same `normalize_effort` bound (12 UTF-8 bytes, control characters stripped). `tool_input` is still never a source for either field.

## Verification

- [x] Relevant focused tests pass: `tools.tokenserver.test_agent_status`, 104 tests, green. Four new tests: top-level effort is read alongside a nested model; a nested effort still wins over the top level; a top-level effort is bounded and control-free and never taken from `tool_input`; a non-string top-level effort is ignored.
- [x] New tests live in an already-registered module (`test/tokenserver-suite.txt`), so they run in `run.sh` and all three tokenserver CI runners.
- [x] `./test/run.sh --skip-js` was run in full on the sibling branch for #99 on the same base; this branch changes one module and its tests, both re-run green here. CI runs the whole gate.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included. The transcript measurement above is counts only.
- [x] CHANGELOG `Unreleased / Fixed` entry added.

### Platform claims

- [x] This does not change a platform support claim.

### Hardware / UI

- [x] No hardware or UI behavior changed. The panel already had a column for `effort`; it now gets a value.

## Not tested / remaining risk

- Not verified on a physical panel. The wire field and its bound are unchanged, so the firmware parser sees the same shape with a string where it saw `null`.
- `claude-fable-5-1` is not in `MODEL_LABELS`, so it reaches the panel as a raw id. That is OBS-30 in the observability backlog and is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_