### PR TITLE
test(plugin): isolate SessionStart tests from the developer's Codex config (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **Five SessionStart tests inherited the developer's own Codex settings.**
+  `session_start.py` reads the saved `approval_policy`, `approvals_reviewer`
+  and `sandbox_mode` from `$CODEX_HOME/config.toml`, else
+  `~/.codex/config.toml`, *before* it checks service health, on purpose: a
+  saved `never` is the failure that looks exactly like a broken panel. Run
+  on a machine whose real config says `never`, that same rule turned five
+  service-health tests red on an unchanged checkout (issue #93). The test
+  harness now hands every script an empty `CODEX_HOME` unless a test
+  supplies its own; the explicit permission-mode tests still pass theirs
+  and still prove the production check. A new test poisons the fallback
+  home directory and asserts the isolation wins.
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import atexit
 import importlib.util
 import io
 import hashlib
@@ -187,6 +188,19 @@ def closed_port():
 SCRIPT_HANG_TIMEOUT_SECONDS = 30
 
 
+# Every script run gets an EMPTY Codex home unless a test hands it one.
+# session_start.py reads the saved approval/reviewer/sandbox modes from
+# $CODEX_HOME/config.toml (else ~/.codex/config.toml) BEFORE it checks
+# service health, on purpose: a saved `approval_policy = "never"` is the
+# failure that looks exactly like a broken panel. Inherited from the
+# developer's real machine, that same setting turned five service-health
+# tests red on an unchanged checkout (issue #93). The permission-mode tests
+# pass their own CODEX_HOME explicitly and are unaffected by this default.
+_ISOLATED_CODEX_HOME = tempfile.TemporaryDirectory(
+    prefix="vibepulse-test-codex-home-")
+atexit.register(_ISOLATED_CODEX_HOME.cleanup)
+
+
 def run_script(name, stdin=b"", *, port=None, env=None,
                timeout=SCRIPT_HANG_TIMEOUT_SECONDS):
     process_env = os.environ.copy()
@@ -196,6 +210,7 @@ def run_script(name, stdin=b"", *, port=None, env=None,
     for key in ("VIBEPULSE_PORT", "VIBEPULSE_CWD", "VIBEPULSE_SESSION_ID",
                 "VIBEPULSE_TURN_ID", "_VIBEPULSE_TEST_READ_TIMEOUT"):
         process_env.pop(key, None)
+    process_env["CODEX_HOME"] = _ISOLATED_CODEX_HOME.name
     if port is not None:
         process_env["VIBEPULSE_PORT"] = str(port)
     if env:
@@ -807,6 +822,33 @@ class SessionStartTests(unittest.TestCase):
         self.assertIn("Permission decisions remain subject to Codex policy", context)
         self.assertIn("VibePulse startup health: SERVER UNAVAILABLE", context)
         self.assertNotIn(str(ROOT), context)
+
+    def test_service_health_ignores_the_developers_own_codex_config(self):
+        """Issue #93: the suite must not inherit the machine it runs on.
+
+        A developer whose real ~/.codex/config.toml says
+        approval_policy = "never" saw five service-health tests fail on an
+        unchanged checkout, because session_start.py reports that saved
+        mode BEFORE it looks at the service, exactly as it should for a
+        real user. The harness therefore hands every script an empty
+        CODEX_HOME. This test poisons the home directory the fallback
+        would otherwise read (HOME on POSIX, USERPROFILE on Windows) and
+        checks that the isolated default still wins; the explicit
+        permission-mode tests below keep proving the production check.
+        """
+        payload = {"hook_event_name": "SessionStart", "session_id": "s"}
+        with tempfile.TemporaryDirectory() as home:
+            codex = Path(home, ".codex")
+            codex.mkdir()
+            (codex / "config.toml").write_text(
+                'approval_policy = "never"\n', encoding="utf-8")
+            completed = run_script(
+                "session_start.py", compact(payload).encode(),
+                port=closed_port(), env={"HOME": home, "USERPROFILE": home})
+        context = json.loads(completed.stdout)["hookSpecificOutput"][
+            "additionalContext"]
+        self.assertIn("startup health: SERVER UNAVAILABLE", context)
+        self.assertNotIn("approval_policy is never", context)
 
     def test_startup_health_names_saved_codex_modes_that_hide_cards(self):
         """The failure that looks exactly like a broken panel.


### PR DESCRIPTION
## Outcome

`python test/test_vibepulse_codex_plugin.py` passes regardless of what the developer's own `~/.codex/config.toml` says. Before, a saved `approval_policy = "never"` on the host turned five service-health tests red on an unchanged checkout. The production check is unchanged and still covered by the explicit permission-mode tests.

Closes #93.

## Root cause / rationale

`session_start.py` reads the saved Codex modes from `$CODEX_HOME/config.toml`, falling back to `~/.codex/config.toml`, **before** it checks service health. That order is deliberate: a saved `never` is the failure that looks exactly like a broken panel, and the hook is the only place that can say so. The five affected tests never set `CODEX_HOME`, so they inherited whatever the machine had.

`run_script` now hands every script an empty, per-run `CODEX_HOME` (a module-level temp directory cleaned up at exit). A test that wants a config passes its own `env={"CODEX_HOME": ...}`, exactly as the three permission-mode tests already do; `env` is applied after the default, so those tests are unaffected.

## Verification

- [x] Reproduced first: with `approval_policy = "never"` written to this machine's `~/.codex/config.toml`, `SessionStartTests` failed exactly the five tests named in the issue. With the harness change, 11/11 pass with the poisoned config present and again with it removed.
- [x] New regression test `test_service_health_ignores_the_developers_own_codex_config` poisons `HOME` and `USERPROFILE` with a `never` config and asserts the isolated default wins. Verified it fails when the `CODEX_HOME` default is removed and passes with it.
- [x] Whole file: 138 tests, green.
- [x] The test lives in an already-invoked file (`test/run.sh` and the Windows CI step both run `test/test_vibepulse_codex_plugin.py`).
- [x] `./test/run.sh --skip-js` was run in full on the sibling branch for #99 on the same base; this branch touches one test file, re-run green here. CI runs the whole gate.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] CHANGELOG `Unreleased / Fixed` entry added.

### Platform claims

- [x] This does not change a platform support claim.
- [x] Windows-affecting: the harness change is environment-only. The new test sets both `HOME` and `USERPROFILE` so the fallback path is poisoned on either platform; the Windows tokenserver runner executes this file.

### Hardware / UI

- [x] No hardware or UI behavior changed.

## Not tested / remaining risk

- Only `session_start.py` reads `CODEX_HOME` today. Giving every script the isolated default is forward-looking; if a future script legitimately needs the real Codex home in a test, that test passes its own value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_