### PR TITLE
chore(lint): add ruff with bug-shaped rules and fix its first sweep (OBS-25)

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/mcp_server.py
@@ -99,7 +99,7 @@ def _write(value):
             encoded = (_compact(_error(None, -32603, "Internal error")) + "\n").encode()
         sys.stdout.buffer.write(encoded)
         sys.stdout.buffer.flush()
-    except Exception:
+    except Exception:  # noqa: S110 - a broken stdout has no channel left to report on
         pass
 
 

--- a/.agents/plugins/plugins/vibepulse/scripts/permission_hook.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/permission_hook.py
@@ -85,7 +85,7 @@ def main():
                 "\n").encode("utf-8")
             sys.stdout.buffer.write(encoded)
             sys.stdout.buffer.flush()
-    except Exception:
+    except Exception:  # noqa: S110 - a hook must exit 0 quietly; Codex treats any noise as a failure
         pass
     return 0
 

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "f2e2a6edb1c3"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "09ea41e4c7b4"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "f2e2a6edb1c3"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside
@@ -233,7 +233,7 @@ def main():
             "\n").encode("utf-8")
         sys.stdout.buffer.write(encoded)
         sys.stdout.buffer.flush()
-    except Exception:
+    except Exception:  # noqa: S110 - a hook must exit 0 quietly; Codex treats any noise as a failure
         pass
     return 0
 

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "72b051a141be"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -233,7 +233,7 @@ def main():
             "\n").encode("utf-8")
         sys.stdout.buffer.write(encoded)
         sys.stdout.buffer.flush()
-    except Exception:
+    except Exception:  # noqa: S110 - a hook must never fail the session start; stdout is the only channel and it just broke
         pass
     return 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,23 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- **A linter, at last (OBS-25).** `ruff` is pinned in `requirements-dev.txt`,
+  configured in `pyproject.toml` with bug-shaped rules only (pyflakes, bare
+  `except`, bugbear, `try/except/pass`, pylint errors, `global` declared for
+  a name never assigned) and runs first in `test/run.sh`, so CI's host gate
+  runs it too. The first sweep found 43 things across ~10 k lines. Every
+  remaining `try/except/pass` is now a named boundary (`# noqa: S110 -
+  <why>`) rather than an unexplained swallow, and the one that mattered is
+  fixed: the Max Tracker backfill loop caught every exception and dropped
+  it, so a bad session file could stop the heatmap's history from ever
+  filling in with nothing in the log; it now logs one line per ten minutes.
+  Sixteen closures over loop variables in tests are bound explicitly, three
+  `zip()` calls state `strict=True`, three dead imports and one dead
+  variable are gone, and `_probe_limits` no longer declares `global` for
+  three names it only reads. Catching `Exception` (74 sites, all
+  deliberate) and the `global` statement itself are not enabled; the config
+  says why.
+
 - **`tools/snapshot.sh`** — one verified bundle of every ref, plus the
   pseudo-refs `--all` does not cover (`ORIG_HEAD`, `MERGE_HEAD`, `FETCH_HEAD`
   and the rest, per worktree, including the extra parents a multi-line one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,10 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
-- **A linter, at last (OBS-25).** `ruff` is pinned in `requirements-dev.txt`,
-  configured in `pyproject.toml` with bug-shaped rules only (pyflakes, bare
+- **A linter, at last (OBS-25).** `ruff` is pinned in `requirements-dev.txt`
+  (and `pyproject.toml` carries the same pin as `required-version`, so a
+  venv with another release is refused instead of linting differently from
+  CI), configured in `pyproject.toml` with bug-shaped rules only (pyflakes, bare
   `except`, bugbear, `try/except/pass`, pylint errors, `global` declared for
   a name never assigned) and runs first in `test/run.sh`, so CI's host gate
   runs it too. The first sweep found 43 things across ~10 k lines. Every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ python -m pip install -r requirements-dev.txt \
 ./test/run.sh
 ```
 
+The gate starts with `ruff check .` (bug-shaped rules only; `pyproject.toml`
+explains each). A `try/except/pass` that must stay needs a
+`# noqa: S110 - <why>` naming the boundary it protects.
+
 CI also builds the ESP32-S3 firmware and runs the tokenserver suite on Ubuntu,
 macOS, and Windows. A green platform runner is automated portability evidence,
 not by itself a real-host or physical-panel validation.

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -400,7 +400,20 @@ from the lessons log is guarded only on the maintainer's Mac. The
 **no such issue exists**.
 
 ### OBS-25 · No linting anywhere
-`hygiene · S · open`
+`hygiene · S · done (2026-09-10)` — `ruff` 0.15.8 pinned in
+`requirements-dev.txt`, configured in `pyproject.toml` with bug-shaped
+rules only (`F`, `E722`, `B`, `S110`, `PLE`, `PLW0602`; each explained in
+the file), run first in `test/run.sh` and therefore in CI's host gate. The
+sweep found 43 things: fourteen `try/except/pass` sites (every one is now
+a named boundary with a `# noqa: S110 - <why>`, and the Max Tracker
+backfill loop, which swallowed every error silently, now logs one line per
+ten minutes), sixteen loop-variable closures in tests, three `zip()` calls
+without `strict=`, three dead imports, one dead variable, one
+`assertRaises(Exception)`, one `raise` without `from`, and three names
+declared `global` that the function never assigns. `BLE001` (74 sites,
+all resilience boundaries) and `PLW0603` (the tokenserver's module-state
+style) are deliberately not enabled; see `pyproject.toml`. Original
+problem, for the record:
 No linter config exists for ~10 k lines of Python (the C side at least
 has `-Wall -Wextra -Werror` in the test gate). Several audit findings
 (bare `except`, swallowed exceptions) are exactly what `ruff` rules

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -316,7 +316,9 @@ can be served.
 headers on failure; assemble status into a local and publish once.
 
 ### OBS-19 · Slow-client and backfill blind spots
-`server · S · open`
+`server · S · in progress` — (b) done with OBS-25 (2026-09-10): the
+backfill loop logs one `max-tracker backfill step failed: <class>: <text>`
+line per ten minutes instead of swallowing. (a) still open.
 (a) No handler `timeout`/`protocol_version` on the HTTP handler
 (`tokenserver.py:1465`): a half-open LAN connection parks a worker
 thread in `readline()` forever, uncounted and unlogged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@
 # Run: ruff check .   (test/run.sh and CI's host gate run it for you)
 
 [tool.ruff]
+# Same pin as requirements-dev.txt. A venv carrying another ruff release
+# would run a different rule implementation than CI and pass or fail
+# differently; ruff itself refuses to run when the versions disagree, so
+# the gate cannot silently lint with the wrong binary.
+required-version = "==0.15.8"
 target-version = "py311"
 extend-exclude = [
     ".venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+# Lint only. This file does not make the repository a Python package; the
+# host service stays a plain directory of scripts (see tools/tokenserver/).
+#
+# OBS-25 (docs/observability-backlog.md): ~10 k lines of Python had no
+# linter, and the audit's "bare except / swallowed exception" findings are
+# exactly what ruff flags mechanically. Rule choice is deliberately narrow:
+# bug-shaped rules only, no style rules, so a finding is worth reading.
+#
+#   F       pyflakes: undefined names, unused imports/variables, shadowing
+#   E722    bare `except:`
+#   B       bugbear: loop-variable closures, zip without strict, raise
+#           without from, assertRaises(Exception), mutable defaults ...
+#   S110    try/except/pass -- every remaining one is a named boundary
+#           (`# noqa: S110 - <why>`), never an unexplained swallow
+#   PLE     pylint errors (things that cannot work)
+#   PLW0602 `global` declared for a name the function never assigns
+#
+# Not enabled, on purpose: BLE001 (catching Exception) fires 74 times and
+# every site is a resilience boundary in a service that must not die on a
+# hostile transcript line; PLW0603 (global statement) is the tokenserver's
+# module-state style, tracked by the English/refactor issues, not a bug.
+#
+# Run: ruff check .   (test/run.sh and CI's host gate run it for you)
+
+[tool.ruff]
+target-version = "py311"
+extend-exclude = [
+    ".venv",
+    "build",
+    "managed_components",
+    "sim/build",
+    "third_party",
+]
+
+[tool.ruff.lint]
+select = ["F", "E722", "B", "S110", "PLE", "PLW0602"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0.3
 Pillow==12.3.0
 zeroconf==0.150.0
+ruff==0.15.8

--- a/test/run.sh
+++ b/test/run.sh
@@ -45,6 +45,18 @@ then
   exit 1
 fi
 
+# Lint first: bug-shaped rules only (pyproject.toml explains each). ruff is
+# pinned in requirements-dev.txt, so a missing binary is a stale venv, and
+# the gate says so instead of silently skipping the lint (OBS-25).
+if ! "$PYTHON_BIN" -m ruff --version >/dev/null 2>&1; then
+  printf '%s\n' \
+    'ERROR: ruff saknas i Python-miljön (pinnad i requirements-dev.txt).' \
+    '  .venv/bin/python -m pip install -r requirements-dev.txt' >&2
+  exit 1
+fi
+(cd .. && "$PYTHON_BIN" -m ruff check .)
+echo "OK: ruff hittade inget"
+
 cc -std=c11 -Wall -Wextra -Werror -O1 \
   ../components/torget_fmt/fmt_sv.c \
   ../components/torget_ticker/ticker.c \

--- a/test/run.sh
+++ b/test/run.sh
@@ -47,7 +47,9 @@ fi
 
 # Lint first: bug-shaped rules only (pyproject.toml explains each). ruff is
 # pinned in requirements-dev.txt, so a missing binary is a stale venv, and
-# the gate says so instead of silently skipping the lint (OBS-25).
+# the gate says so instead of silently skipping the lint (OBS-25). A venv
+# with another ruff release is refused by ruff itself: pyproject.toml's
+# `required-version` carries the same pin.
 if ! "$PYTHON_BIN" -m ruff --version >/dev/null 2>&1; then
   printf '%s\n' \
     'ERROR: ruff saknas i Python-miljön (pinnad i requirements-dev.txt).' \

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "f2e2a6edb1c3"
+HOST_SOURCE_FINGERPRINT = "09ea41e4c7b4"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "72b051a141be"
+HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -3449,7 +3449,7 @@ class RelaySetupTests(unittest.TestCase):
                         ["doctor"], repo_root=ROOT, config_path=path,
                         python=Path(sys.executable), codex=Path("/codex"),
                         run=runner,
-                        urlopen=lambda *_args, **_kwargs: response,
+                        urlopen=lambda *_args, _r=response, **_kwargs: _r,
                         stdout=output), 1)
                     self.assertIn("FIX Tokenserver", output.getvalue())
                     self.assertEqual(response.limits,
@@ -3760,7 +3760,7 @@ class RelaySetupTests(unittest.TestCase):
                         ["doctor"], config_path=path,
                         python=Path(sys.executable), codex=None,
                         run=FakeRunner([python_probe_ok()]),
-                        urlopen=lambda *_args, **_kwargs: response,
+                        urlopen=lambda *_args, _r=response, **_kwargs: _r,
                         stdout=output), 1)
                     self.assertIn("FIX Tokenserver", output.getvalue())
 
@@ -3851,7 +3851,9 @@ class RelaySetupTests(unittest.TestCase):
                     real_save = setup.save_config
                     calls = []
 
-                    def post_commit_failure(save_path, config):
+                    def post_commit_failure(save_path, config, calls=calls,
+                                            real_save=real_save,
+                                            restore_ok=restore_ok):
                         calls.append(config)
                         if len(calls) == 1:
                             real_save(save_path, config)

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+HOST_SOURCE_FINGERPRINT = "f2e2a6edb1c3"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -3407,7 +3407,8 @@ class RelaySetupTests(unittest.TestCase):
                         ["doctor"], repo_root=ROOT, config_path=path,
                         python=Path(sys.executable), codex=Path("/codex"),
                         run=runner,
-                        urlopen=lambda *_args, **_kwargs: response,
+                        urlopen=lambda *_args, _response=response,
+                        **_kwargs: _response,
                         stdout=output), 1)
                     self.assertIn("FIX Tokenserver", output.getvalue())
                     self.assertEqual(response.limits,
@@ -3718,7 +3719,8 @@ class RelaySetupTests(unittest.TestCase):
                         ["doctor"], config_path=path,
                         python=Path(sys.executable), codex=None,
                         run=FakeRunner([python_probe_ok()]),
-                        urlopen=lambda *_args, **_kwargs: response,
+                        urlopen=lambda *_args, _response=response,
+                        **_kwargs: _response,
                         stdout=output), 1)
                     self.assertIn("FIX Tokenserver", output.getvalue())
 
@@ -3809,7 +3811,9 @@ class RelaySetupTests(unittest.TestCase):
                     real_save = setup.save_config
                     calls = []
 
-                    def post_commit_failure(save_path, config):
+                    def post_commit_failure(save_path, config, *,
+                                            calls=calls, real_save=real_save,
+                                            restore_ok=restore_ok):
                         calls.append(config)
                         if len(calls) == 1:
                             real_save(save_path, config)

--- a/tools/agent_assets/build-agent-images.py
+++ b/tools/agent_assets/build-agent-images.py
@@ -133,7 +133,7 @@ def build_codex(canvas_size: int = CANVAS) -> bytes:
                palette_raw[i * 3 + 2]) for i in used]
     remap = {old: new + 1 for new, old in enumerate(used)}
     color_to_index = {}
-    for color, old_index in zip(cloud_pixels, quantized_pixels):
+    for color, old_index in zip(cloud_pixels, quantized_pixels, strict=True):
         color_to_index[color] = remap[old_index]
 
     palette = bytearray(16 * 4)

--- a/tools/test_hardware_registry.py
+++ b/tools/test_hardware_registry.py
@@ -799,7 +799,8 @@ class RepositoryRegistryTests(unittest.TestCase):
                 self.assertEqual(len(row), 5)
                 for heading, cell in zip(
                         ("user value", "conflicts", "privacy",
-                         "no-authorization rationale"), row[1:]):
+                         "no-authorization rationale"), row[1:],
+                        strict=True):
                     self.assertGreaterEqual(
                         len(cell.split()), 4,
                         f"{row[0]} has no substantive {heading}",

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -945,7 +945,7 @@ class AgentStatusService:
         self._last_diagnostic[key] = now
         try:
             self._diagnostic(f"agent-status {context}: {error_name}")
-        except Exception:
+        except Exception:  # noqa: S110 - a failing diagnostic sink must not stop the tailer
             pass
 
     @staticmethod

--- a/tools/tokenserver/discovery.py
+++ b/tools/tokenserver/discovery.py
@@ -103,7 +103,7 @@ class DiscoveryAdvertiser:
             if zc is not None:
                 try:
                     zc.close()
-                except Exception:
+                except Exception:  # noqa: S110 - already on the error path; the warning below carries the cause
                     pass
             self.status = "error"
             self.reason = type(exc).__name__

--- a/tools/tokenserver/interaction_relay.py
+++ b/tools/tokenserver/interaction_relay.py
@@ -666,5 +666,5 @@ class InteractionRelay:
             fields["status"] = status
         try:
             self._audit(event, fields)
-        except Exception:
+        except Exception:  # noqa: S110 - the audit trail must never break the relay loop
             pass

--- a/tools/tokenserver/interactions.py
+++ b/tools/tokenserver/interactions.py
@@ -1339,7 +1339,7 @@ class InteractionStore:
         for request_id, reason in notifications:
             try:
                 listener.on_remove(request_id, reason)
-            except Exception:
+            except Exception:  # noqa: S110 - a listener's failure must not block removal
                 pass
 
     def _notify_relay_park(self, job: RelayPublishJob) -> None:
@@ -1349,7 +1349,7 @@ class InteractionStore:
             return
         try:
             listener.on_park(job)
-        except Exception:
+        except Exception:  # noqa: S110 - a listener's failure must not block parking
             pass
 
     def _log(self, action: str, entry: _Pending,
@@ -1367,8 +1367,8 @@ class InteractionStore:
                 "session": entry.session_key,
                 "verdict": verdict,
             })
-        except Exception:
-            pass  # the audit trail must never break the decision path
+        except Exception:  # noqa: S110 - the audit trail must never break the decision path
+            pass
 
 
 def read_device_key(repo_root: Optional[Any] = None) -> Optional[str]:

--- a/tools/tokenserver/test_interaction_relay.py
+++ b/tools/tokenserver/test_interaction_relay.py
@@ -1,6 +1,5 @@
 import json
 import threading
-import time
 import unittest
 from collections import OrderedDict, deque
 from urllib.parse import urlsplit
@@ -206,8 +205,6 @@ class InteractionRelayTests(unittest.TestCase):
         entry = store.park("approval", approval_event(), 30)
 
         relay.run_once()
-        first_put = [call for call in transport.calls
-                     if call["method"] == "PUT"][0]
         relay.run_once()
         self.assertEqual(len([call for call in transport.calls
                               if call["method"] == "PUT"]), 1)

--- a/tools/tokenserver/test_interaction_relay_crypto.py
+++ b/tools/tokenserver/test_interaction_relay_crypto.py
@@ -1,4 +1,3 @@
-import base64
 import hashlib
 import hmac
 import json

--- a/tools/tokenserver/test_interactions.py
+++ b/tools/tokenserver/test_interactions.py
@@ -1159,13 +1159,15 @@ class RelayStoreListenerTests(unittest.TestCase):
             barrier = threading.Barrier(3)
             results = []
 
-            def direct():
+            def direct(entry=entry, stamp=stamp, direct_mac=direct_mac,
+                       barrier=barrier, results=results):
                 barrier.wait()
                 results.append(self.store.resolve(
                     entry.request_id, "deny", stamp, direct_mac,
                     provider="claude", view_sha256=entry.view_sha256))
 
-            def relayed():
+            def relayed(relay_result=relay_result, barrier=barrier,
+                        results=results):
                 barrier.wait()
                 results.append(self.store.resolve_relay(
                     relay_result, lambda _job, _result: True))

--- a/tools/tokenserver/test_max_tracker.py
+++ b/tools/tokenserver/test_max_tracker.py
@@ -56,9 +56,12 @@ def _local_stamp(day: str, hour: int = 12) -> str:
     return local.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _rollout_event(rate_limits, timestamp=_local_stamp("2026-08-07", 10)):
+def _rollout_event(rate_limits, timestamp=None):
     """Mirror test_tokenserver.py's CodexLimitLogTests._event fixture shape:
-    a real Codex rollout ``event_msg``/``token_count`` line."""
+    a real Codex rollout ``event_msg``/``token_count`` line. ``timestamp``
+    defaults to local 10:00 on 2026-08-07 (see ``_local_stamp``)."""
+    if timestamp is None:
+        timestamp = _local_stamp("2026-08-07", 10)
     return {
         "timestamp": timestamp,
         "type": "event_msg",

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -3131,6 +3131,36 @@ class MaxTrackerSingleWriterTests(unittest.TestCase):
             self.assertEqual(len(store._backfill["claude"]), 1)
 
 
+class MaxTrackerBackfillLoopTests(unittest.TestCase):
+    def test_the_first_backfill_failure_logs_even_on_a_freshly_booted_host(self):
+        # Codex review of #103: a 0.0 sentinel minus a young monotonic clock
+        # sat inside the throttle window and swallowed the first failure.
+        stop = threading.Event()
+        store = mock.Mock()
+        calls = []
+
+        def failing_step():
+            calls.append(1)
+            if len(calls) >= 3:
+                stop.set()
+            raise RuntimeError("trasig sessionsfil")
+
+        store.backfill_step.side_effect = failing_step
+        with mock.patch.object(tokenserver.time, "monotonic",
+                               return_value=42.0), \
+                mock.patch.object(tokenserver, "MAX_TRACKER_BACKFILL_TICK_S",
+                                  0.0), \
+                self.assertLogs("tokenserver", level="WARNING") as captured:
+            tokenserver._run_max_tracker_backfill(store, stop)
+        lines = [line for line in captured.output
+                 if "backfill step failed" in line]
+        # Logged once, immediately; the two retries inside the window are
+        # throttled.
+        self.assertEqual(len(lines), 1)
+        self.assertIn("RuntimeError: trasig sessionsfil", lines[0])
+        self.assertEqual(len(calls), 3)
+
+
 class MaxTrackerDirtyWriterTests(unittest.TestCase):
     def setUp(self):
         self.previous = (
@@ -3245,7 +3275,7 @@ class MaxTrackerDirtyWriterTests(unittest.TestCase):
         self.assertTrue(tokenserver._max_tracker_dirty)
 
 
-class MaxTrackerBackfillLoopTests(unittest.TestCase):
+class MaxTrackerBackfillFailureLogTests(unittest.TestCase):
     def test_loop_ticks_forever_and_marks_dirty_only_on_progress(self):
         store = mock.Mock()
         store.backfill_step.return_value = True

--- a/tools/tokenserver/test_value_meter.py
+++ b/tools/tokenserver/test_value_meter.py
@@ -482,7 +482,7 @@ class PriceTableTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = pathlib.Path(tmp) / "prices.json"
             path.write_text("{ not json")
-            with self.assertRaises(Exception):
+            with self.assertRaises(ValueError):  # json.JSONDecodeError
                 value_meter.load_prices(path)
 
 

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -3318,7 +3318,11 @@ def _run_max_tracker_backfill(store, stop_event):
     switches itself off; it just keeps discovering newly-appeared rollout/
     session files on its own, without needing a restart.
     """
-    last_error_logged = 0.0
+    # None = never logged. Not 0.0: time.monotonic() counts from boot, so
+    # on a machine up for less than the throttle window "now - 0.0" is
+    # below it and the FIRST failure would be swallowed -- the same trap
+    # _last_compute_error_logged already documents (CI's fresh VM).
+    last_error_logged = None
     while not stop_event.is_set():
         try:
             if store.backfill_step():
@@ -3326,9 +3330,10 @@ def _run_max_tracker_backfill(store, stop_event):
         except Exception as exc:
             # The loop must survive a bad file (OBS-08's lesson: a crashed
             # recompute must not freeze the numbers), but not silently:
-            # one line per ten minutes names the failure class.
+            # the first failure logs at once, then one line per ten
+            # minutes names the failure class.
             now = time.monotonic()
-            if now - last_error_logged >= 600:
+            if last_error_logged is None or now - last_error_logged >= 600:
                 last_error_logged = now
                 log.warning("max-tracker backfill step failed: %s: %s",
                             type(exc).__name__, exc)

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -50,7 +50,7 @@ import threading
 import time
 import urllib.request
 import weakref
-from datetime import datetime, timedelta
+from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -1132,8 +1132,7 @@ def _hold_probe_lock():
 def _probe_limits():
     """Ett minimalt API-anrop; returnerar {sessionPct, sessionResetMin,
     weekPct, weekResetMin} eller None om något saknas på vägen."""
-    global _probe_status, _probe_headers, _probe_unknown_buckets, \
-        _probe_cooldown_until
+    global _probe_status
     _load_probe_state()
     if time.time() < _probe_cooldown_until:
         # I nedkylning efter 429 — statusen står kvar på backoff-strängen.
@@ -3295,7 +3294,7 @@ def _configure_interaction_relay(config, secret, *, environ=None,
         if adapter is not None:
             try:
                 adapter.stop()
-            except Exception:
+            except Exception:  # noqa: S110 - best-effort teardown on the failure path
                 pass
         return disable_shared("configuration-invalid")
     if publish_interactions:
@@ -3319,12 +3318,20 @@ def _run_max_tracker_backfill(store, stop_event):
     switches itself off; it just keeps discovering newly-appeared rollout/
     session files on its own, without needing a restart.
     """
+    last_error_logged = 0.0
     while not stop_event.is_set():
         try:
             if store.backfill_step():
                 _mark_max_tracker_dirty(store)
-        except Exception:
-            pass
+        except Exception as exc:
+            # The loop must survive a bad file (OBS-08's lesson: a crashed
+            # recompute must not freeze the numbers), but not silently:
+            # one line per ten minutes names the failure class.
+            now = time.monotonic()
+            if now - last_error_logged >= 600:
+                last_error_logged = now
+                log.warning("max-tracker backfill step failed: %s: %s",
+                            type(exc).__name__, exc)
         if stop_event.wait(MAX_TRACKER_BACKFILL_TICK_S):
             break
 
@@ -3426,7 +3433,7 @@ def main():
             while not _any_provider_dir(Handler.projects_dir):
                 time.sleep(30)
         except KeyboardInterrupt:
-            raise SystemExit(1)
+            raise SystemExit(1) from None
         log.info("hittade en leverantörskatalog — fortsätter starten.")
     if not Handler.projects_dir.is_dir():
         # Startar ändå: Path.glob på en katalog som inte finns ger tomt

--- a/tools/tokenserver/usage_history.py
+++ b/tools/tokenserver/usage_history.py
@@ -210,7 +210,7 @@ class UsageHistory:
         if denominator <= 0:
             return Forecast(state="collecting")
         slope = sum((x - mean_x) * (y - mean_y)
-                    for x, y in zip(xs, ys)) / denominator
+                    for x, y in zip(xs, ys, strict=True)) / denominator
         if not math.isfinite(slope) or slope <= 0:
             return Forecast(state="unavailable")
 

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -976,7 +976,7 @@ def _relay_install(
         except BaseException:
             try:
                 _atomic_private_write(secrets_path, secrets_raw)
-            except BaseException:
+            except BaseException:  # noqa: S110 - best-effort rollback; the original error is re-raised below
                 pass
             try:
                 if Path(token_path).exists() or Path(token_path).is_symlink():
@@ -1139,7 +1139,7 @@ def _relay_uninstall(
                     _atomic_private_write(secrets_path, secrets_raw)
                 if token_raw is not None:
                     _atomic_private_write(token_path, token_raw)
-            except BaseException:
+            except BaseException:  # noqa: S110 - best-effort rollback; the FIX line below reports it
                 pass
             print("FIX Relay uninstall could not safely update local files",
                   file=stdout)
@@ -1845,7 +1845,7 @@ def _reconcile_external(
                 codex=codex):
             try:
                 _invoke(argv, run)
-            except BaseException:
+            except BaseException:  # noqa: S110 - each rollback step is independent; _inspect_external judges the result
                 pass
         try:
             observed = _inspect_external(
@@ -1900,7 +1900,7 @@ def _publish_config(
                 elif current == target:
                     try:
                         save_config(path, snapshot)
-                    except BaseException:
+                    except BaseException:  # noqa: S110 - the reload on the next line decides whether restore worked
                         pass
                     restored = load_config(path) == snapshot
             except BaseException:


### PR DESCRIPTION
## Outcome

The repository has a linter. `ruff` is pinned in `requirements-dev.txt`, configured in `pyproject.toml`, and runs first in `test/run.sh`, so CI's host gate runs it on every push. The rule set is deliberately narrow: bug-shaped rules only (`F`, `E722`, `B`, `S110`, `PLE`, `PLW0602`), each explained in the config, so a finding is worth reading. `BLE001` (catching `Exception`, 74 sites, all deliberate resilience boundaries) and `PLW0603` (the tokenserver's module-state style) are not enabled; the config says why.

One user-visible behaviour change: the Max Tracker backfill loop used to catch every exception and drop it, so a bad session file could stop the heatmap's history from ever filling in with nothing in the log. It now logs one warning per ten minutes naming the failure class. Everything else is test hygiene and named boundaries.

Closes OBS-25 in `docs/observability-backlog.md` (status line updated there).

## Root cause / rationale

OBS-25: ~10 k lines of Python had no linter, and the observability audit's "bare except / swallowed exception" findings are exactly what ruff flags mechanically. The first sweep found 43 things:

| Rule | Count | What was done |
|---|---|---|
| S110 try/except/pass | 14 | Each is now `# noqa: S110 - <why>` naming the boundary it protects (audit trail must never break the decision path, hook must exit 0 quietly, best-effort rollback, ...). The backfill loop is the one that got a real log line instead. |
| B023 loop-variable closure | 16 | Tests only; bound explicitly via default arguments. None was a live bug (each closure ran inside its own iteration), but the class is real. |
| B905 zip without strict | 3 | `strict=True`; in all three the operands are built from the same sequence. |
| F401 / F841 | 4 | Three dead imports, one dead variable removed. |
| B017 assertRaises(Exception) | 1 | Now `ValueError` (what `json.loads` raises). |
| B904 raise without from | 1 | `raise SystemExit(1) from None` on Ctrl-C. |
| PLW0602 global never assigned | 3 | Removed from the `global` statement in `_probe_limits`; they are only read. |
| E722 bare except | 0 | None existed. |

The host source fingerprint (pinned in `session_start.py` and its test) moves because hashed files changed.

## Verification

- [x] `ruff check .` is clean (0.15.8, the pinned version).
- [x] `./test/run.sh --skip-js` passes locally in full, including the new lint step, all C binaries, the Mbed TLS vectors, the SDL landmarks under xvfb, the 814-test tokenserver suite and the 138-test plugin suite.
- [x] No new test files; the lint step is registered in `run.sh` itself, and CI's host-gate job already installs `requirements-dev.txt`.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] CHANGELOG `Unreleased / Added` entry, `CONTRIBUTING.md` note on the lint step and the `noqa` convention, OBS-25 marked done.

### Platform claims

- [x] This does not change a platform support claim.
- [x] Windows-affecting: `test/run.sh` is not run on the Windows runner; the tokenserver suite is, and it is green locally. The `strict=True` zips and the `from None` are pure Python.

### Hardware / UI

- [x] No hardware or UI behavior changed.

## Not tested / remaining risk

- The backfill warning path was not exercised against a real corrupt file; the throttle is a monotonic-clock comparison and the message names only the exception class and text, never a path or session content.
- Ruff's own version pin: 0.15.8 is what was installed here; CI installs the same pin. A future bump may surface new findings in the selected rule families, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_