### PR TITLE
fix(tokenserver): answer /api/tokens at once while the first history scan runs (#62)

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/loopback.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/loopback.py
@@ -205,8 +205,15 @@ def get_json(url: str, *,
         return None
     deadline = _ResponseDeadline(float(read_timeout))
     try:
+        # X-VibePulse-Accepts: this reader understands usageTotals and
+        # will not treat placeholder counters as measurements, so the
+        # service may answer 200 with them during its first history scan
+        # instead of the 503 it gives a client that would apply zeros.
         request = urllib.request.Request(
-            url, method="GET", headers={"Accept": "application/json"})
+            url, method="GET", headers={
+                "Accept": "application/json",
+                "X-VibePulse-Accepts": "usage-totals",
+            })
         opener = urllib.request.build_opener(
             urllib.request.ProxyHandler({}),
             _SplitTimeoutHTTPHandler(float(read_timeout), deadline),

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "bb304d42f5d0"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "bbaf2b6bdd34"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "8e095613a5c1"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8e095613a5c1"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "11d79d23ab9c"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "72b051a141be"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "7ac74140a9f7"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "78eb818013c0"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside
@@ -111,6 +111,17 @@ def classify_startup_health(root, tokens):
             action = "Run the setup doctor and tokenserver smoke test."
         return (f"VibePulse startup health: PROVIDER DATA STALE ({providers}). "
                 f"{action}{risk}")
+
+    totals = tokens.get("usageTotals")
+    if isinstance(totals, dict) and totals.get("state") == "refreshing":
+        # Not stale and not broken: the service is seconds to minutes old
+        # and still reading history. Quota is live; volume is placeholder.
+        since = totals.get("sinceS")
+        since_text = f" for {since} s" if isinstance(since, int) else ""
+        return ("VibePulse startup health: SERVICE WARMING UP; quota data "
+                "is live but the first history scan is still running"
+                f"{since_text}, so volume counters are placeholders, not "
+                f"measurements. Recheck shortly.{risk}")
 
     panel = interactions.get("panel")
     if not isinstance(panel, dict):

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -112,6 +112,25 @@ def classify_startup_health(root, tokens):
         return (f"VibePulse startup health: PROVIDER DATA STALE ({providers}). "
                 f"{action}{risk}")
 
+    # Issue #62: the service answers at once while its first history scan
+    # runs, so a fresh quota can ride beside placeholder volume counters.
+    # A scan that is running is a wait; a recompute that keeps failing
+    # (or froze the totals, OBS-08) is a fault, not "HEALTHY".
+    totals = tokens.get("usageTotals")
+    totals_state = totals.get("state") if isinstance(totals, dict) else None
+    if root.get("usageComputeOk") is False or totals_state == "failing":
+        return ("VibePulse startup health: VOLUME RECOMPUTE FAILING; quota "
+                "data is fresh but the token-volume recompute behind "
+                "/api/tokens is crashing, so the value page shows dashes or "
+                "frozen totals. Read the tokenserver log for "
+                "`usage-omräkningen kraschade` and run the tokenserver smoke "
+                f"test.{risk}")
+    if totals_state == "refreshing":
+        return ("VibePulse startup health: SERVICE WARMING UP; quota data is "
+                "fresh and the first history scan is still running, so the "
+                "volume counters are placeholders for a few minutes. Nothing "
+                f"to fix; recheck shortly.{risk}")
+
     panel = interactions.get("panel")
     if not isinstance(panel, dict):
         return ("VibePulse startup health: PANEL DIAGNOSTICS UNAVAILABLE; "

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "bbaf2b6bdd34"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "b1cb05f46caf"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "78eb818013c0"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "007f92198744"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside
@@ -113,6 +113,13 @@ def classify_startup_health(root, tokens):
                 f"{action}{risk}")
 
     totals = tokens.get("usageTotals")
+    if isinstance(totals, dict) and totals.get("state") == "failing":
+        # A crashing recompute is a broken service, whether or not a
+        # first scan ever completed -- never a warm-up.
+        return ("VibePulse startup health: VOLUME RECOMPUTE FAILING; quota "
+                "data is live but the usage scan keeps crashing, so volume "
+                "counters are placeholders or frozen. Read the tokenserver "
+                f"log and run the smoke test.{risk}")
     if isinstance(totals, dict) and totals.get("state") == "refreshing":
         # Not stale and not broken: the service is seconds to minutes old
         # and still reading history. Quota is live; volume is placeholder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   live quota rings but leaves the value page and the keep-awake burn rate
   untouched during a warm-up: never invented zeros, counters never go
   backwards. The firmware fetch log and the simulator say "volym ej
-  uppmätt än" for such a sample instead of printing `0.00 Mtok idag`. The same block is on `GET /`, the numbers publisher does not
+  uppmätt än" for such a sample instead of printing `0.00 Mtok idag`.
+  When the block says `failing` the recompute is crashing and the
+  measurement is not coming: the firmware then shows dashes on the value
+  page instead of carrying an old figure that would look fresh poll after
+  poll, and logs a warning (fixture `tokens-volume-failing.json`). The same block is on `GET /`, the numbers publisher does not
   send a placeholder to the relay, the SessionStart hook reports `SERVICE
   WARMING UP` (and `VOLUME RECOMPUTE FAILING`) as their own classes, the
   setup doctor prints `WAIT` for a warm-up and `FIX` for a failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   firmware sends the header, parses `usageTotals.placeholder`, applies the
   live quota rings but leaves the value page and the keep-awake burn rate
   untouched during a warm-up: never invented zeros, counters never go
-  backwards. The same block is on `GET /`, the numbers publisher does not
+  backwards. The firmware fetch log and the simulator say "volym ej
+  uppmätt än" for such a sample instead of printing `0.00 Mtok idag`. The same block is on `GET /`, the numbers publisher does not
   send a placeholder to the relay, the SessionStart hook reports `SERVICE
   WARMING UP` (and `VOLUME RECOMPUTE FAILING`) as their own classes, the
   setup doctor prints `WAIT` for a warm-up and `FIX` for a failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **A healthy service restart showed STALE on the glass for minutes.** The
+  tokenserver's first history scan ran *under the cache lock* inside
+  `get_snapshot`, so every `/api/tokens` request queued behind it. On a Mac
+  with a large Claude/Codex history the scan took 211 s, the panel's polls
+  timed out one after another, and the glass went STALE two minutes into
+  every restart of a service whose credentials, discovery and relay were
+  all fine (issue #62). The first request now answers at once: the scan
+  runs in the background, the response carries placeholder zeros for the
+  four volume counters (the firmware contract requires numbers there) and
+  live quota percentages, and a new additive block `usageTotals` says
+  which of three things the counters are: `refreshing` (placeholder,
+  `sinceS` since start), `ready` (`ageS` old) or `failing` (frozen since
+  the recompute began crashing, OBS-08). The completed scan is swapped in
+  atomically; a scan that crashes is retried on the normal thirty-second
+  cadence, never per request. The same block is on `GET /`, the numbers
+  publisher does not send a placeholder to the relay (the far panel keeps
+  its last good values instead of learning zeros), the SessionStart hook
+  reports `SERVICE WARMING UP` as its own class between stale and healthy,
+  the setup doctor prints `WAIT` for a warm-up and `FIX` for frozen totals,
+  and the smoke test warns instead of failing. A full disk is now visible
+  too: `GET /` carries `maxTrackerSaveOk` / `maxTrackerSaveFailingForS`
+  while the state file cannot be written (the observations stay in memory
+  and retry, as OBS-10 already arranged), the doctor and smoke test name
+  it, and a test proves one `ENOSPC` on the atomic write leaves both the
+  previous file and memory intact. Not done here: the glass itself still
+  shows the placeholder zeros as `0` for the length of the scan, because
+  dashing them needs the firmware to read `usageTotals` (OBS-36).
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   backwards. The firmware fetch log and the simulator say "volym ej
   uppmätt än" for such a sample instead of printing `0.00 Mtok idag`.
   When the block says `failing` the recompute is crashing and the
-  measurement is not coming: the firmware then shows dashes on the value
-  page instead of carrying an old figure that would look fresh poll after
-  poll, and logs a warning (fixture `tokens-volume-failing.json`). The same block is on `GET /`, the numbers publisher does not
+  measurement is not coming, whether the counters are placeholders or
+  frozen at the last good scan: the firmware then shows dashes on the
+  value page instead of carrying an old figure that would look fresh poll
+  after poll, keeps the panel asleep rather than waking on a frozen burn
+  rate, and logs a warning (fixture `tokens-volume-failing.json`). The same block is on `GET /`, the numbers publisher does not
   send a placeholder to the relay, the SessionStart hook reports `SERVICE
   WARMING UP` (and `VOLUME RECOMPUTE FAILING`) as their own classes, the
   setup doctor prints `WAIT` for a warm-up and `FIX` for a failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,26 +14,36 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   timed out one after another, and the glass went STALE two minutes into
   every restart of a service whose credentials, discovery and relay were
   all fine (issue #62). The first request now answers at once: the scan
-  runs in the background, the response carries placeholder zeros for the
-  four volume counters (the firmware contract requires numbers there) and
-  live quota percentages, and a new additive block `usageTotals` says
-  which of three things the counters are: `refreshing` (placeholder,
-  `sinceS` since start), `ready` (`ageS` old) or `failing` (frozen since
-  the recompute began crashing, OBS-08). The completed scan is swapped in
+  runs in the background, and the response carries live quota percentages
+  plus a new additive block `usageTotals` that says what the four volume
+  counters are: `refreshing` (placeholder zeros, `placeholder: true`,
+  `sinceS` since start), `ready` (`ageS` old) or `failing` (the recompute
+  is crashing, OBS-08: frozen with `ageS`, or still placeholders if no
+  scan ever completed). The block is captured under the same lock and from
+  the same read as the counters, so it can never describe a different
+  snapshot than the one it rides on. The completed scan is swapped in
   atomically; a scan that crashes is retried on the normal thirty-second
-  cadence, never per request. The same block is on `GET /`, the numbers
-  publisher does not send a placeholder to the relay (the far panel keeps
-  its last good values instead of learning zeros), the SessionStart hook
-  reports `SERVICE WARMING UP` as its own class between stale and healthy,
-  the setup doctor prints `WAIT` for a warm-up and `FIX` for frozen totals,
-  and the smoke test warns instead of failing. A full disk is now visible
-  too: `GET /` carries `maxTrackerSaveOk` / `maxTrackerSaveFailingForS`
-  while the state file cannot be written (the observations stay in memory
-  and retry, as OBS-10 already arranged), the doctor and smoke test name
-  it, and a test proves one `ENOSPC` on the atomic write leaves both the
-  previous file and memory intact. Not done here: the glass itself still
-  shows the placeholder zeros as `0` for the length of the scan, because
-  dashing them needs the firmware to read `usageTotals` (OBS-36).
+  cadence, never per request. **Placeholders never reach a client that
+  would apply them:** the service serves them only to a request carrying
+  `X-VibePulse-Accepts: usage-totals`, and answers everyone else with the
+  contract's error form (HTTP 503, `usageTotals` beside it), which the
+  already-flashed firmware rejects by design and keeps its last good
+  values, going honestly STALE two minutes later exactly as before. New
+  firmware sends the header, parses `usageTotals.placeholder`, applies the
+  live quota rings but leaves the value page and the keep-awake burn rate
+  untouched during a warm-up: never invented zeros, counters never go
+  backwards. The same block is on `GET /`, the numbers publisher does not
+  send a placeholder to the relay, the SessionStart hook reports `SERVICE
+  WARMING UP` (and `VOLUME RECOMPUTE FAILING`) as their own classes, the
+  setup doctor prints `WAIT` for a warm-up and `FIX` for a failing
+  recompute, and the smoke test warns instead of failing. A full disk is
+  visible too: `GET /` carries `maxTrackerSaveOk` /
+  `maxTrackerSaveFailingForS` while the state file cannot be written (the
+  observations stay in memory and retry, as OBS-10 already arranged), the
+  doctor and smoke test name it, and a test proves one `ENOSPC` on the
+  atomic write leaves both the previous file and memory intact. Firmware
+  side built in CI, not flashed: an OTA to this build is what turns the
+  post-restart STALE into a live panel; until then the old behaviour holds.
 - **Five SessionStart tests inherited the developer's own Codex settings.**
   `session_start.py` reads the saved `approval_policy`, `approvals_reviewer`
   and `sandbox_mode` from `$CODEX_HOME/config.toml`, else

--- a/components/app_tokens/app.c
+++ b/components/app_tokens/app.c
@@ -45,10 +45,11 @@ void tokens_apply(const tk_tokens *tokens) {
    * a delayed/starved timer must not leave old STALE copy over fresh values.
    * Do this unconditionally so app/ui bookkeeping can self-heal if they ever
    * drift apart. Source-level stale flags remain owned by each parsed quota. */
-  /* En platshållares brinntakt är ingen mätning: väck inte panelen på den
-   * (issue #62). Färskheten gäller ändå — svaret kom fram och kvoten är
-   * live. */
-  double rate = tokens->volume_placeholder
+  /* En platshållares brinntakt är ingen mätning, och en frusen takt från
+   * en kraschande omräkning (`failing`) är ingen aktuell: väck inte
+   * panelen på någon av dem (issue #62). Färskheten gäller ändå — svaret
+   * kom fram och kvoten är live. */
+  double rate = (tokens->volume_placeholder || tokens->volume_failing)
                     ? 0.0 : tokens->day_tokens_per_hour / 1e6;
 
   app.has_data = true;

--- a/components/app_tokens/app.c
+++ b/components/app_tokens/app.c
@@ -45,7 +45,11 @@ void tokens_apply(const tk_tokens *tokens) {
    * a delayed/starved timer must not leave old STALE copy over fresh values.
    * Do this unconditionally so app/ui bookkeeping can self-heal if they ever
    * drift apart. Source-level stale flags remain owned by each parsed quota. */
-  double rate = tokens->day_tokens_per_hour / 1e6;
+  /* En platshållares brinntakt är ingen mätning: väck inte panelen på den
+   * (issue #62). Färskheten gäller ändå — svaret kom fram och kvoten är
+   * live. */
+  double rate = tokens->volume_placeholder
+                    ? 0.0 : tokens->day_tokens_per_hour / 1e6;
 
   app.has_data = true;
   app.last_success_us = now_us;

--- a/components/app_tokens/net.c
+++ b/components/app_tokens/net.c
@@ -124,7 +124,16 @@ static void net_task(void *arg) {
       /* Utan Claude-källa är volymsiffrorna nollor som inte är mätningar.
        * Loggen säger det i stället för att skriva ut "0.00 Mtok idag",
        * som läses som en dag utan arbete. */
-      if (t.claude_source_present) {
+      if (t.volume_placeholder) {
+        /* Första historikskanningen pågår på datorn (issue #62): volymen
+         * är en platshållare, inte en mätning — skriv inte ut nollor. */
+        ESP_LOGI(TAG,
+                 "hämtning ok (volym ej uppmätt än — datorn skannar "
+                 "historiken, tidigare värden står kvar; "
+                 "stale claude=%d fable=%d codex=%d)",
+                 t.claude_week.stale, t.claude_model_week.stale,
+                 t.codex_week.stale);
+      } else if (t.claude_source_present) {
         ESP_LOGI(TAG,
                  "hämtning ok (%.2f Mtok idag, %d sessioner; "
                  "stale claude=%d fable=%d codex=%d)",

--- a/components/app_tokens/net.c
+++ b/components/app_tokens/net.c
@@ -124,11 +124,13 @@ static void net_task(void *arg) {
       /* Utan Claude-källa är volymsiffrorna nollor som inte är mätningar.
        * Loggen säger det i stället för att skriva ut "0.00 Mtok idag",
        * som läses som en dag utan arbete. */
-      if (t.volume_placeholder && t.volume_failing) {
+      if (t.volume_failing) {
         ESP_LOGW(TAG,
                  "hämtning ok (volymomräkningen på datorn kraschar — "
-                 "värdesidan visar streck; kvoten är live, stale "
+                 "värdesidan visar streck, %s; kvoten är live, stale "
                  "claude=%d fable=%d codex=%d)",
+                 t.volume_placeholder ? "ingen skanning har lyckats än"
+                                      : "räknarna är frysta",
                  t.claude_week.stale, t.claude_model_week.stale,
                  t.codex_week.stale);
       } else if (t.volume_placeholder) {

--- a/components/app_tokens/net.c
+++ b/components/app_tokens/net.c
@@ -124,7 +124,14 @@ static void net_task(void *arg) {
       /* Utan Claude-källa är volymsiffrorna nollor som inte är mätningar.
        * Loggen säger det i stället för att skriva ut "0.00 Mtok idag",
        * som läses som en dag utan arbete. */
-      if (t.volume_placeholder) {
+      if (t.volume_placeholder && t.volume_failing) {
+        ESP_LOGW(TAG,
+                 "hämtning ok (volymomräkningen på datorn kraschar — "
+                 "värdesidan visar streck; kvoten är live, stale "
+                 "claude=%d fable=%d codex=%d)",
+                 t.claude_week.stale, t.claude_model_week.stale,
+                 t.codex_week.stale);
+      } else if (t.volume_placeholder) {
         /* Första historikskanningen pågår på datorn (issue #62): volymen
          * är en platshållare, inte en mätning — skriv inte ut nollor. */
         ESP_LOGI(TAG,

--- a/components/app_tokens/tokens.h
+++ b/components/app_tokens/tokens.h
@@ -104,6 +104,17 @@ typedef struct {
    * null och renderas som streck. */
   int claude_source_present;
 
+  /* 1 när tjänsten säger att volymräknarna och värdeblocket är
+   * PLATSHÅLLARE (första historikskanningen pågår eller kraschar:
+   * `usageTotals.placeholder == true`, issue #62). Kvotprocenten i samma
+   * svar är live. Skärmen rör då inte värdesidan och brinntakten väcker
+   * inte panelen — det som mätts senast står kvar. Saknas nyckeln (äldre
+   * tjänst) är räknarna mätningar, som förr. Tjänsten skickar bara
+   * platshållare till klienter som säger X-VibePulse-Accepts:
+   * usage-totals (torget_http.c gör det); äldre firmware får felformen och
+   * behåller sina värden. */
+  int volume_placeholder;
+
   /* taken (null-bara). claude_model_week är veckofönstret för tyngsta
    * modellen (Fable/Opus) — tredje raden i Claudes egen usage-panel. */
   tk_limit claude_session, claude_week, claude_model_week;

--- a/components/app_tokens/tokens.h
+++ b/components/app_tokens/tokens.h
@@ -114,6 +114,11 @@ typedef struct {
    * usage-totals (torget_http.c gör det); äldre firmware får felformen och
    * behåller sina värden. */
   int volume_placeholder;
+  /* 1 när samma block säger `state: "failing"`: omräkningen på datorn
+   * kraschar och värdet kommer inte av sig självt. Skärmen visar då streck
+   * på värdesidan i stället för gamla siffror som ser färska ut (Codex-
+   * granskning av #104). Bara meningsfull ihop med volume_placeholder. */
+  int volume_failing;
 
   /* taken (null-bara). claude_model_week är veckofönstret för tyngsta
    * modellen (Fable/Opus) — tredje raden i Claudes egen usage-panel. */

--- a/components/app_tokens/tokens.h
+++ b/components/app_tokens/tokens.h
@@ -117,7 +117,9 @@ typedef struct {
   /* 1 när samma block säger `state: "failing"`: omräkningen på datorn
    * kraschar och värdet kommer inte av sig självt. Skärmen visar då streck
    * på värdesidan i stället för gamla siffror som ser färska ut (Codex-
-   * granskning av #104). Bara meningsfull ihop med volume_placeholder. */
+   * granskning av #104). Gäller oavsett volume_placeholder: efter en
+   * lyckad skanning serverar tjänsten FRYSTA räknare med placeholder
+   * false och state failing (OBS-08), och de är lika lite en mätning. */
   int volume_failing;
 
   /* taken (null-bara). claude_model_week är veckofönstret för tyngsta

--- a/components/app_tokens/tokens_parse.c
+++ b/components/app_tokens/tokens_parse.c
@@ -440,6 +440,20 @@ bool tk_tokens_parse(const char *json, size_t len, tk_tokens *out) {
                       &t.claude_model_week)) goto done;
   if (!optional_stale(root, "codexWeekStale", &t.codex_week)) goto done;
 
+  /* Additiv, valfri: usageTotals.placeholder (issue #62). Bara en riktig
+   * boolean true gör räknarna till platshållare; ett saknat, felformat
+   * eller icke-booleskt block betyder "mätningar" — samma öppna hand som
+   * för alla frivilliga nycklar, och aldrig ett skäl att avvisa svaret. */
+  {
+    const cJSON *totals = cJSON_GetObjectItemCaseSensitive(
+        root, "usageTotals");
+    if (cJSON_IsObject(totals)) {
+      const cJSON *placeholder = cJSON_GetObjectItemCaseSensitive(
+          totals, "placeholder");
+      t.volume_placeholder = cJSON_IsTrue(placeholder) ? 1 : 0;
+    }
+  }
+
   optional_label(root, trust_optional_strings, "claudeModelWeekLabel",
                  t.claude_model_week_label,
                  sizeof t.claude_model_week_label,

--- a/components/app_tokens/tokens_parse.c
+++ b/components/app_tokens/tokens_parse.c
@@ -451,6 +451,10 @@ bool tk_tokens_parse(const char *json, size_t len, tk_tokens *out) {
       const cJSON *placeholder = cJSON_GetObjectItemCaseSensitive(
           totals, "placeholder");
       t.volume_placeholder = cJSON_IsTrue(placeholder) ? 1 : 0;
+      const cJSON *state = cJSON_GetObjectItemCaseSensitive(totals, "state");
+      t.volume_failing = (cJSON_IsString(state) && state->valuestring &&
+                          strcmp(state->valuestring, "failing") == 0)
+                             ? 1 : 0;
     }
   }
 

--- a/components/app_tokens/usage_screen.c
+++ b/components/app_tokens/usage_screen.c
@@ -1041,13 +1041,26 @@ void usage_screen_create(lv_obj_t *root) {
 
 void usage_screen_apply_tokens(const tk_tokens *tokens) {
   if (!tokens) return;
-  ui.last_tokens = *tokens;
-  for (int i = 0; i < 3; i++) apply_quota(&ui.quotas[i], tokens);
+  /* Platshållare (issue #62): kvoten är live och appliceras; värdesidan
+   * bygger på volymräknarna, som då är nollor som inte är mätningar, så
+   * den lämnas som den var — senast uppmätta värdet, eller startläget om
+   * inget mätts än. Ärlighetsinvarianten: aldrig påhittade nollor, och
+   * räknare backar aldrig. */
+  tk_tokens merged = *tokens;
+  if (tokens->volume_placeholder) {
+    merged.day_tokens = ui.last_tokens.day_tokens;
+    merged.day_tokens_per_hour = ui.last_tokens.day_tokens_per_hour;
+    merged.day_sessions = ui.last_tokens.day_sessions;
+    merged.month_tokens = ui.last_tokens.month_tokens;
+    merged.value = ui.last_tokens.value;
+  }
+  ui.last_tokens = merged;
+  for (int i = 0; i < 3; i++) apply_quota(&ui.quotas[i], &merged);
   usage_forecast_page_view forecasts = {0};
-  usage_presenter_build_forecasts(tokens, &forecasts);
+  usage_presenter_build_forecasts(&merged, &forecasts);
   for (int i = 0; i < 2; i++)
     apply_forecast_row(&ui.forecast_rows[i], &forecasts.rows[i]);
-  apply_value(tokens);
+  if (!tokens->volume_placeholder) apply_value(&merged);
 }
 
 void usage_screen_apply_max_tracker(const tk_max_tracker *t) {

--- a/components/app_tokens/usage_screen.c
+++ b/components/app_tokens/usage_screen.c
@@ -1053,15 +1053,17 @@ void usage_screen_apply_tokens(const tk_tokens *tokens) {
     merged.day_sessions = ui.last_tokens.day_sessions;
     merged.month_tokens = ui.last_tokens.month_tokens;
     merged.value = ui.last_tokens.value;
-    if (tokens->volume_failing) {
-      /* Omräkningen på datorn kraschar (`usageTotals.state: failing`):
-       * mätningen kommer inte av sig självt, och ett gammalt värde som
-       * står kvar poll efter poll ser färskt ut fast ingen mätt det på
-       * länge. Streck är det ärliga svaret — samma "vet inte" som när
-       * blocket saknas helt. Räknarna ovan står kvar (de ritas inte). */
-      memset(&merged.value, 0, sizeof merged.value);
-      merged.value.state = TK_VALUE_UNAVAILABLE;
-    }
+  }
+  if (tokens->volume_failing) {
+    /* Omräkningen på datorn kraschar (`usageTotals.state: failing`) —
+     * med platshållare om ingen skanning lyckats, eller med FRYSTA
+     * siffror från den senaste lyckade (då är placeholder false).
+     * Mätningen kommer inte av sig självt, och ett gammalt värde som
+     * står kvar poll efter poll ser färskt ut fast ingen mätt det på
+     * länge. Streck är det ärliga svaret — samma "vet inte" som när
+     * blocket saknas helt. Räknarna står kvar (de ritas inte). */
+    memset(&merged.value, 0, sizeof merged.value);
+    merged.value.state = TK_VALUE_UNAVAILABLE;
   }
   ui.last_tokens = merged;
   for (int i = 0; i < 3; i++) apply_quota(&ui.quotas[i], &merged);

--- a/components/app_tokens/usage_screen.c
+++ b/components/app_tokens/usage_screen.c
@@ -1053,6 +1053,15 @@ void usage_screen_apply_tokens(const tk_tokens *tokens) {
     merged.day_sessions = ui.last_tokens.day_sessions;
     merged.month_tokens = ui.last_tokens.month_tokens;
     merged.value = ui.last_tokens.value;
+    if (tokens->volume_failing) {
+      /* Omräkningen på datorn kraschar (`usageTotals.state: failing`):
+       * mätningen kommer inte av sig självt, och ett gammalt värde som
+       * står kvar poll efter poll ser färskt ut fast ingen mätt det på
+       * länge. Streck är det ärliga svaret — samma "vet inte" som när
+       * blocket saknas helt. Räknarna ovan står kvar (de ritas inte). */
+      memset(&merged.value, 0, sizeof merged.value);
+      merged.value.state = TK_VALUE_UNAVAILABLE;
+    }
   }
   ui.last_tokens = merged;
   for (int i = 0; i < 3; i++) apply_quota(&ui.quotas[i], &merged);
@@ -1060,7 +1069,8 @@ void usage_screen_apply_tokens(const tk_tokens *tokens) {
   usage_presenter_build_forecasts(&merged, &forecasts);
   for (int i = 0; i < 2; i++)
     apply_forecast_row(&ui.forecast_rows[i], &forecasts.rows[i]);
-  if (!tokens->volume_placeholder) apply_value(&merged);
+  if (!tokens->volume_placeholder || tokens->volume_failing)
+    apply_value(&merged);
 }
 
 void usage_screen_apply_max_tracker(const tk_max_tracker *t) {

--- a/components/torget_net/torget_http.c
+++ b/components/torget_net/torget_http.c
@@ -97,6 +97,16 @@ static bool http_get_timeout(const char *url, char *buf, size_t cap,
   client = esp_http_client_init(&cfg);
   if (!client) goto done;
 
+  /* This firmware understands usageTotals and never applies placeholder
+   * counters as measurements (tokens_parse.c / usage_screen.c), so the
+   * service may answer with them during its first history scan instead of
+   * the error form it gives older panels (issue #62). Content-free, so it
+   * is sent on every fetch, relay included; delivery never depends on it. */
+  if (esp_http_client_set_header(
+          client, "X-VibePulse-Accepts", "usage-totals") != ESP_OK) {
+    ESP_LOGW(TAG, "kunde inte sätta Accepts-headern");
+  }
+
   /* Content-free post-restart evidence for the local health endpoint. Never
    * send it to a public relay, and never make data delivery depend on this
    * optional diagnostic header. */

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,33 @@ point at the backlog item.
 
 ---
 
+## 2026-09-10 · A background scan still blocked every request through the lock
+
+**What happened:** after a restart on a Mac with a large Claude/Codex
+history, the light health endpoints answered but every `/api/tokens` request
+timed out for 211 s, and the panel went STALE two minutes into a restart of
+a perfectly healthy service (issue #62). **Root cause:** the first usage
+scan had been moved *off* the startup thread in August (lesson 2026-08-26),
+but `get_snapshot` still ran it inline, under `_cache_lock`, whenever no
+result existed yet. Every HTTP worker took the same lock to read the result
+and queued behind the one doing the scan. The warm-up thread did not help:
+it was just the first caller to take that lock. **The rule now:** a request
+handler never does the expensive thing under the lock that serves the
+cheap thing. If there is no result yet, say so in the response and let one
+background thread produce it; readers take the lock only to copy. And the
+"no result yet" state is *named* (`usageTotals.state`), so a placeholder
+never looks like a measurement to the doctor, the hook, the smoke test or
+the relay publisher. **Guards:** `StartupSnapshotTests` in
+`test_tokenserver.py` time the first request with the scan blocked, prove
+one scan for many requests and the cadence-bounded retry after a crash;
+`test_publisher.py` proves a placeholder is not sent; the doctor, hook and
+smoke suites each classify the state. **Watch for:** a new producer that
+computes under `_cache_lock`, and any consumer that reads the four volume
+counters without checking `usageTotals.state`. The glass is that consumer
+today (OBS-36).
+
+---
+
 ## 2026-09-06 · The panel logged the credential it was told never to print
 
 **What happened:** all three failure paths in `torget_http.c` logged the

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -37,14 +37,19 @@ cheap thing. If there is no result yet, say so in the response and let one
 background thread produce it; readers take the lock only to copy. And the
 "no result yet" state is *named* (`usageTotals.state`), so a placeholder
 never looks like a measurement to the doctor, the hook, the smoke test or
-the relay publisher. **Guards:** `StartupSnapshotTests` in
-`test_tokenserver.py` time the first request with the scan blocked, prove
-one scan for many requests and the cadence-bounded retry after a crash;
-`test_publisher.py` proves a placeholder is not sent; the doctor, hook and
-smoke suites each classify the state. **Watch for:** a new producer that
-computes under `_cache_lock`, and any consumer that reads the four volume
-counters without checking `usageTotals.state`. The glass is that consumer
-today (OBS-36).
+the relay publisher. And a placeholder is only handed to a client that
+said it understands one (`X-VibePulse-Accepts: usage-totals`); the
+already-flashed firmware would have applied the zeros as fresh data, which
+a Codex review caught on the first draft, so everyone else gets the error
+form the old firmware already rejects. **Guards:** `StartupSnapshotTests`
+in `test_tokenserver.py` time the first request with the scan blocked,
+prove one scan for many requests, the cadence-bounded retry after a crash,
+that the block is captured under the lock with the counters it describes,
+and the header gate; `test_publisher.py` proves a placeholder is not sent;
+`test_tokens.c` proves the firmware flag; the doctor, hook and smoke suites
+each classify the state. **Watch for:** a new producer that computes under
+`_cache_lock`, and a new `/api/tokens` reader that forgets the header and
+mistakes the 503 for a dead service.
 
 ---
 

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -494,20 +494,24 @@ valve currently fails silently.
 `LV_USE_LOG` routed to `ESP_LOG`.
 
 ### OBS-36 · The glass shows placeholder zeros as measurements during the first scan
-`firmware · S · open`
+`firmware · S · done in source (2026-09-10), physically unverified` —
+closed in the same PR as issue #62 after a Codex review made the point
+that a payload old firmware would apply is a payload old firmware WILL
+apply. Two halves: the service serves placeholder counters only to a
+request carrying `X-VibePulse-Accepts: usage-totals` and answers every
+other client with the contract's error form (503), so an already-flashed
+panel keeps its last values; firmware from this date sends the header,
+parses `usageTotals.placeholder`, applies the live quota rings and leaves
+the value page and the keep-awake burn rate untouched while the counters
+are placeholders. No new visual state was designed: the value page simply
+keeps what it last showed (the pre-data dashes on a cold boot). Original
+problem, for the record:
 Since issue #62 the tokenserver answers `/api/tokens` at once while its
 first history scan runs, with the four volume counters at zero and an
-additive `usageTotals.state == "refreshing"` block saying so. The firmware
-contract requires numbers for the counters (`tokens_parse.c`:
-`if (!num(root, "dayTokens", &day)) goto done;`), so the server cannot
-send `null`, and the parser ignores the new block, so the panel prints
-`0.00 Mtok idag` for the length of the scan — minutes on a large history.
-Same honesty gap as `claudeSourcePresent` had before the flag existed.
-**Fix:** parse `usageTotals.state` (optional, default `ready` for older
-servers); when `refreshing`, draw the volume counters as dashes and keep
-the quota rings live. Visual change → AMOLED skill gate applies. Until
-then the server side is honest (`GET /`, the hook, the doctor, the smoke
-test and the relay publisher all read the block).
+additive `usageTotals` block saying so. The firmware contract requires
+numbers for the counters, so the server cannot send `null`, and a parser
+that ignores the block would print `0.00 Mtok idag` for the length of the
+scan.
 
 ### OBS-35 · A raised log level puts the relay secret back on the wire
 `firmware · S · open`

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -493,6 +493,22 @@ valve currently fails silently.
 (with the same style of comment the file already uses), enable
 `LV_USE_LOG` routed to `ESP_LOG`.
 
+### OBS-36 · The glass shows placeholder zeros as measurements during the first scan
+`firmware · S · open`
+Since issue #62 the tokenserver answers `/api/tokens` at once while its
+first history scan runs, with the four volume counters at zero and an
+additive `usageTotals.state == "refreshing"` block saying so. The firmware
+contract requires numbers for the counters (`tokens_parse.c`:
+`if (!num(root, "dayTokens", &day)) goto done;`), so the server cannot
+send `null`, and the parser ignores the new block, so the panel prints
+`0.00 Mtok idag` for the length of the scan — minutes on a large history.
+Same honesty gap as `claudeSourcePresent` had before the flag existed.
+**Fix:** parse `usageTotals.state` (optional, default `ready` for older
+servers); when `refreshing`, draw the volume counters as dashes and keep
+the quota rings live. Visual change → AMOLED skill gate applies. Until
+then the server side is honest (`GET /`, the hook, the doctor, the smoke
+test and the relay publisher all read the block).
+
 ### OBS-35 · A raised log level puts the relay secret back on the wire
 `firmware · S · open`
 The panel's own fetch logs are redacted: `torget_http.c` hands every

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -179,14 +179,19 @@ Returns live server state, added after real debugging nights:
   are frozen at their last good value while *looking* fresh; the smoke
   test turns this into a FAIL, and the log has the cause
   (`usage-omräkningen kraschade`).
-- `usageTotals` — `{state, sinceS|ageS}`: what the four volume counters on
-  `/api/tokens` are right now. `refreshing` = the first history scan is
-  still running and the counters are placeholder zeros (`sinceS` since
-  start; quota percentages in the same payload are live); `ready` = the
-  last completed scan, `ageS` old; `failing` = frozen, see the two fields
-  above. The same block rides on `/api/tokens` itself (additive; the
-  firmware ignores it, OBS-36). Smoke: `refreshing` is a VARN, never a
-  FAIL. Doctor: `WAIT` for `refreshing`, `FIX` for `failing`.
+- `usageTotals` — `{state, placeholder, sinceS|ageS}`: what the four
+  volume counters on `/api/tokens` are right now. `refreshing` = the first
+  history scan is still running and the counters are placeholder zeros
+  (`placeholder: true`, `sinceS` since start; quota percentages in the
+  same payload are live); `ready` = the last completed scan, `ageS` old;
+  `failing` = the recompute is crashing: frozen (`ageS`) or, if no scan
+  ever completed, still placeholders. The same block rides on
+  `/api/tokens`, but **only to a client that sends `X-VibePulse-Accepts:
+  usage-totals`**; any other client gets HTTP 503 in the error form with
+  the block beside it, so an older panel keeps its last values instead of
+  applying zeros. Firmware from 2026-09-10 sends the header and leaves the
+  value page alone while `placeholder` is true. Smoke: `refreshing` is a
+  VARN, never a FAIL. Doctor: `WAIT` for `refreshing`, `FIX` for `failing`.
 - `maxTrackerSaveOk` / `maxTrackerSaveFailingForS` — whether the Max
   Tracker state file can be written. `false` (typically `ENOSPC` or a
   permissions change) means observations are held in memory and retried

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -179,6 +179,19 @@ Returns live server state, added after real debugging nights:
   are frozen at their last good value while *looking* fresh; the smoke
   test turns this into a FAIL, and the log has the cause
   (`usage-omräkningen kraschade`).
+- `usageTotals` — `{state, sinceS|ageS}`: what the four volume counters on
+  `/api/tokens` are right now. `refreshing` = the first history scan is
+  still running and the counters are placeholder zeros (`sinceS` since
+  start; quota percentages in the same payload are live); `ready` = the
+  last completed scan, `ageS` old; `failing` = frozen, see the two fields
+  above. The same block rides on `/api/tokens` itself (additive; the
+  firmware ignores it, OBS-36). Smoke: `refreshing` is a VARN, never a
+  FAIL. Doctor: `WAIT` for `refreshing`, `FIX` for `failing`.
+- `maxTrackerSaveOk` / `maxTrackerSaveFailingForS` — whether the Max
+  Tracker state file can be written. `false` (typically `ENOSPC` or a
+  permissions change) means observations are held in memory and retried
+  on the next mark (OBS-10); the smoke test warns, the doctor prints FIX,
+  the log has the cause throttled to one line per five minutes.
 - `interactions.relay` / `interactions.agentStatusRelay` — independent saved readiness for
   encrypted approvals and encrypted live rows. `off` is the safe default;
   `disabled` includes a content-free reason, never agent/project text.

--- a/sim-fixtures/README.md
+++ b/sim-fixtures/README.md
@@ -18,6 +18,7 @@ Regler som fixturerna låser:
 |---|---|---|
 | `tokens.json` | SYNTETISK, godkänd statisk AMOLED-layout | Fullt v2-svar: 73/47/21-ringarna, volym, värde, prognoser. |
 | `tokens-missing.json` | SYNTETISK | Alla kvoter `null`: streck, aldrig påhittade procent. |
+| `tokens-volume-failing.json` | SYNTETISK (issue #62) | Som ovan men `usageTotals.state: "failing"`: omräkningen på datorn kraschar. Firmwaren applicerar kvoten, visar streck på värdesidan (inte gamla siffror som ser färska ut) och loggar en varning. |
 | `tokens-warming-up.json` | SYNTETISK (issue #62) | Tjänstens första historikskanning pågår: räknarna är noll med `usageTotals.placeholder: true`, kvoten live. Firmwaren applicerar kvoten men rör inte värdesidan; äldre firmware får aldrig det här svaret (tjänsten kräver `X-VibePulse-Accepts: usage-totals`). |
 
 ## Max Tracker-fixturer

--- a/sim-fixtures/README.md
+++ b/sim-fixtures/README.md
@@ -12,6 +12,14 @@ Regler som fixturerna låser:
 - Före FÖRSTA lyckade svaret: streck, aldrig påhittade nollor.
 - Efter fel: senaste goda datat kvarstår, stale-markering efter 120 s.
 
+## Tokens-fixturer
+
+| Fil | Ursprung | Testar |
+|---|---|---|
+| `tokens.json` | SYNTETISK, godkänd statisk AMOLED-layout | Fullt v2-svar: 73/47/21-ringarna, volym, värde, prognoser. |
+| `tokens-missing.json` | SYNTETISK | Alla kvoter `null`: streck, aldrig påhittade procent. |
+| `tokens-warming-up.json` | SYNTETISK (issue #62) | Tjänstens första historikskanning pågår: räknarna är noll med `usageTotals.placeholder: true`, kvoten live. Firmwaren applicerar kvoten men rör inte värdesidan; äldre firmware får aldrig det här svaret (tjänsten kräver `X-VibePulse-Accepts: usage-totals`). |
+
 ## Max Tracker-fixturer
 
 Konstruerade `/api/max-tracker`-svar i dense form (kontraktet ligger i

--- a/sim-fixtures/tokens-volume-failing.json
+++ b/sim-fixtures/tokens-volume-failing.json
@@ -1,0 +1,29 @@
+{
+  "v": 2,
+  "dayTokens": 0,
+  "dayTokensPerHour": 0,
+  "daySessions": 0,
+  "monthTokens": 0,
+  "claudeSessionPct": 21.0,
+  "claudeSessionResetMin": 256,
+  "claudeSessionHourDeltaPct": 4.0,
+  "claudeWeekPct": 47.0,
+  "claudeWeekResetMin": 9120,
+  "claudeWeekTodayDeltaPct": 8.0,
+  "claudeModelWeekPct": 73.0,
+  "claudeModelWeekResetMin": 3120,
+  "claudeModelWeekLabel": "FABLE · WEEK",
+  "claudeModelWeekTodayDeltaPct": 12.0,
+  "codexSessionPct": null,
+  "codexSessionResetMin": null,
+  "codexWeekPct": 35.0,
+  "codexWeekResetMin": 2317,
+  "codexWeekTodayDeltaPct": 5.0,
+  "claudeForecastState": "collecting",
+  "codexForecastState": "collecting",
+  "usageTotals": {
+    "state": "failing",
+    "sinceS": 912,
+    "placeholder": true
+  }
+}

--- a/sim-fixtures/tokens-warming-up.json
+++ b/sim-fixtures/tokens-warming-up.json
@@ -1,0 +1,29 @@
+{
+  "v": 2,
+  "dayTokens": 0,
+  "dayTokensPerHour": 0,
+  "daySessions": 0,
+  "monthTokens": 0,
+  "claudeSessionPct": 21.0,
+  "claudeSessionResetMin": 256,
+  "claudeSessionHourDeltaPct": 4.0,
+  "claudeWeekPct": 47.0,
+  "claudeWeekResetMin": 9120,
+  "claudeWeekTodayDeltaPct": 8.0,
+  "claudeModelWeekPct": 73.0,
+  "claudeModelWeekResetMin": 3120,
+  "claudeModelWeekLabel": "FABLE \u00b7 WEEK",
+  "claudeModelWeekTodayDeltaPct": 12.0,
+  "codexSessionPct": null,
+  "codexSessionResetMin": null,
+  "codexWeekPct": 35.0,
+  "codexWeekResetMin": 2317,
+  "codexWeekTodayDeltaPct": 5.0,
+  "claudeForecastState": "collecting",
+  "codexForecastState": "collecting",
+  "usageTotals": {
+    "state": "refreshing",
+    "sinceS": 41,
+    "placeholder": true
+  }
+}

--- a/sim/main.c
+++ b/sim/main.c
@@ -352,9 +352,11 @@ static void feed_tokens_file(const char *file) {
   tk_tokens t;
   if (json && tk_tokens_parse(json, len, &t)) {
     tokens_apply(&t);
-    if (t.volume_placeholder && t.volume_failing) {
+    if (t.volume_failing) {
       printf("tokens: volymomräkningen på datorn kraschar — värdesidan "
-             "visar streck, kvoten är live\n");
+             "visar streck (%s), kvoten är live\n",
+             t.volume_placeholder ? "ingen skanning har lyckats än"
+                                  : "räknarna är frysta");
     } else if (t.volume_placeholder) {
       /* Värddatorn skannar historiken (issue #62): platshållare, inte
          mätning — samma ärlighet som net.c. */

--- a/sim/main.c
+++ b/sim/main.c
@@ -352,7 +352,10 @@ static void feed_tokens_file(const char *file) {
   tk_tokens t;
   if (json && tk_tokens_parse(json, len, &t)) {
     tokens_apply(&t);
-    if (t.volume_placeholder) {
+    if (t.volume_placeholder && t.volume_failing) {
+      printf("tokens: volymomräkningen på datorn kraschar — värdesidan "
+             "visar streck, kvoten är live\n");
+    } else if (t.volume_placeholder) {
       /* Värddatorn skannar historiken (issue #62): platshållare, inte
          mätning — samma ärlighet som net.c. */
       printf("tokens: volym ej uppmätt än — datorn skannar historiken, "

--- a/sim/main.c
+++ b/sim/main.c
@@ -352,7 +352,12 @@ static void feed_tokens_file(const char *file) {
   tk_tokens t;
   if (json && tk_tokens_parse(json, len, &t)) {
     tokens_apply(&t);
-    if (t.claude_source_present) {
+    if (t.volume_placeholder) {
+      /* Värddatorn skannar historiken (issue #62): platshållare, inte
+         mätning — samma ärlighet som net.c. */
+      printf("tokens: volym ej uppmätt än — datorn skannar historiken, "
+             "tidigare värden står kvar\n");
+    } else if (t.claude_source_present) {
       printf("tokens: %.2f Mtok idag, %d sessioner, takt %.2f Mtok/h\n",
              t.day_tokens / 1e6, t.day_sessions,
              t.day_tokens_per_hour / 1e6);

--- a/test/test_tokens.c
+++ b/test/test_tokens.c
@@ -163,6 +163,13 @@ int main(void) {
               "\"daySessions\":1,\"monthTokens\":5," BASE_NULLS
               ",\"usageTotals\":{\"state\":\"ready\",\"ageS\":2,"
               "\"placeholder\":false}}", &t) && t.volume_placeholder == 0);
+  memset(&t, 0, sizeof t);
+  check("failing utan platshållare (frysta räknare) sätter bara failing",
+        PARSE("{\"v\":2,\"dayTokens\":5,\"dayTokensPerHour\":0,"
+              "\"daySessions\":1,\"monthTokens\":5," BASE_NULLS
+              ",\"usageTotals\":{\"state\":\"failing\",\"ageS\":900,"
+              "\"placeholder\":false}}", &t) &&
+        t.volume_placeholder == 0 && t.volume_failing == 1);
   check("usageTotals som sträng avvisar inte och är ingen platshållare",
         PARSE("{\"v\":2,\"dayTokens\":5,\"dayTokensPerHour\":0,"
               "\"daySessions\":1,\"monthTokens\":5," BASE_NULLS

--- a/test/test_tokens.c
+++ b/test/test_tokens.c
@@ -125,6 +125,44 @@ int main(void) {
         && t.has_ota_available_version
         && strcmp(t.ota_available_version, "v0.2.1-36-g911b2bf") == 0);
 
+  /* Platshållare (issue #62): tjänstens första skanning pågår, räknarna
+   * är nollor som INTE är mätningar och kvoten är live. Flaggan sätts
+   * bara av en riktig boolean true i usageTotals; allt annat är
+   * mätningar, och inget av det avvisar svaret. */
+  json = read_file(FIXTURES_DIR "/tokens-warming-up.json", &len);
+  if (json) {
+    memset(&t, 0, sizeof t);
+    check("uppvärmningsfixturen parsar", tk_tokens_parse(json, len, &t));
+    check("platshållarflaggan sätts", t.volume_placeholder == 1);
+    check("kvoten är live trots platshållare",
+          t.claude_week.has_pct && t.claude_week.pct == 47.0);
+    check("platshållarens räknare är noll", t.day_tokens == 0);
+    free(json);
+  }
+  json = read_file(FIXTURES_DIR "/tokens.json", &len);
+  if (json) {
+    memset(&t, 0, sizeof t);
+    check("riktiga fixturen är ingen platshållare",
+          tk_tokens_parse(json, len, &t) && t.volume_placeholder == 0);
+    free(json);
+  }
+  memset(&t, 0, sizeof t);
+  check("usageTotals.placeholder false = mätningar",
+        PARSE("{\"v\":2,\"dayTokens\":5,\"dayTokensPerHour\":0,"
+              "\"daySessions\":1,\"monthTokens\":5," BASE_NULLS
+              ",\"usageTotals\":{\"state\":\"ready\",\"ageS\":2,"
+              "\"placeholder\":false}}", &t) && t.volume_placeholder == 0);
+  check("usageTotals som sträng avvisar inte och är ingen platshållare",
+        PARSE("{\"v\":2,\"dayTokens\":5,\"dayTokensPerHour\":0,"
+              "\"daySessions\":1,\"monthTokens\":5," BASE_NULLS
+              ",\"usageTotals\":\"refreshing\"}", &t) &&
+        t.volume_placeholder == 0);
+  check("placeholder som sträng \"true\" är ingen platshållare",
+        PARSE("{\"v\":2,\"dayTokens\":5,\"dayTokensPerHour\":0,"
+              "\"daySessions\":1,\"monthTokens\":5," BASE_NULLS
+              ",\"usageTotals\":{\"placeholder\":\"true\"}}", &t) &&
+        t.volume_placeholder == 0);
+
   /* En vilande dag med alla limits null är giltig: nollor och streck är
    * ärliga när inget brunnit och inga källor svarar. */
   check("nollor + null ok",

--- a/test/test_tokens.c
+++ b/test/test_tokens.c
@@ -137,6 +137,17 @@ int main(void) {
     check("kvoten är live trots platshållare",
           t.claude_week.has_pct && t.claude_week.pct == 47.0);
     check("platshållarens räknare är noll", t.day_tokens == 0);
+    check("pågående skanning är inte 'failing'", t.volume_failing == 0);
+    free(json);
+  }
+  json = read_file(FIXTURES_DIR "/tokens-volume-failing.json", &len);
+  if (json) {
+    memset(&t, 0, sizeof t);
+    check("failing-fixturen parsar", tk_tokens_parse(json, len, &t));
+    check("failing sätter både platshållare och failing",
+          t.volume_placeholder == 1 && t.volume_failing == 1);
+    check("kvoten är live trots kraschande omräkning",
+          t.claude_week.has_pct && t.claude_week.pct == 47.0);
     free(json);
   }
   json = read_file(FIXTURES_DIR "/tokens.json", &len);

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -992,6 +992,57 @@ class SessionStartTests(unittest.TestCase):
         self.assertIn("active Claude probe is live", context)
         self.assertNotIn("DEVICE PATH STALE", context)
 
+    def test_startup_health_names_a_warming_up_and_a_failing_recompute(self):
+        # Issue #62: /api/tokens answers during the first history scan with
+        # placeholder counters; the hook must not call that HEALTHY.
+        payload = {"hook_event_name": "SessionStart", "session_id": "s"}
+        root = {
+            "service": "torget-tokenserver",
+            "srcFingerprint": HOST_SOURCE_FINGERPRINT,
+            "claudeProbe": "usage_http_200 + ok",
+            "claudeCredential": {"status": "ready", "expiresInMin": 480},
+            "usageComputeOk": True,
+            "interactions": {
+                "claude": True, "codex": True,
+                "panel": {"status": "ready", "ageS": 3},
+            },
+        }
+        fresh = {
+            "claudeWeekStale": False,
+            "claudeModelWeekStale": False,
+            "codexWeekStale": False,
+        }
+        cases = [
+            (dict(root), dict(fresh, usageTotals={
+                "state": "refreshing", "sinceS": 12, "placeholder": True}),
+             "SERVICE WARMING UP"),
+            (dict(root), dict(fresh, usageTotals={
+                "state": "failing", "sinceS": 900, "placeholder": True}),
+             "VOLUME RECOMPUTE FAILING"),
+            (dict(root, usageComputeOk=False), dict(fresh, usageTotals={
+                "state": "failing", "ageS": 300, "placeholder": False}),
+             "VOLUME RECOMPUTE FAILING"),
+            (dict(root), dict(fresh, usageTotals={
+                "state": "ready", "ageS": 5, "placeholder": False}),
+             "HEALTHY"),
+        ]
+        for root_body, tokens_body, expected in cases:
+            with self.subTest(expected=expected):
+                routes = {
+                    "/": {"body": compact(root_body).encode()},
+                    "/api/tokens": {"body": compact(tokens_body).encode()},
+                }
+                with LocalServer(routes=routes) as server:
+                    completed = run_script(
+                        "session_start.py", compact(payload).encode(),
+                        port=server.port)
+                context = json.loads(completed.stdout)["hookSpecificOutput"][
+                    "additionalContext"]
+                self.assertIn(expected, context)
+                if expected != "HEALTHY":
+                    self.assertNotIn("HEALTHY", context)
+                self.assertNotIn("sinceS", context)
+
     def test_startup_health_reports_ready_and_credential_risk_separately(self):
         payload = {"hook_event_name": "SessionStart", "session_id": "s"}
         root = {

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+HOST_SOURCE_FINGERPRINT = "78eb818013c0"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -949,6 +949,61 @@ class SessionStartTests(unittest.TestCase):
         self.assertIn("PROVIDER DATA STALE (Claude)", context)
         self.assertIn("active Claude probe is live", context)
         self.assertNotIn("DEVICE PATH STALE", context)
+
+    def test_startup_health_names_a_warming_service_as_neither_stale_nor_broken(self):
+        """Issue #62: the first history scan can run for minutes after a
+        restart. Quota is live, volume counters are placeholders, nothing is
+        broken -- and none of the existing classes says that."""
+        payload = {"hook_event_name": "SessionStart", "session_id": "s"}
+        root = {
+            "service": "torget-tokenserver",
+            "srcFingerprint": HOST_SOURCE_FINGERPRINT,
+            "claudeProbe": "usage_http_200 + ok",
+            "interactions": {"claude": True, "codex": True,
+                             "panel": {"status": "ready", "ageS": 1}},
+        }
+        tokens = {
+            "claudeWeekStale": False,
+            "claudeModelWeekStale": False,
+            "codexWeekStale": False,
+            "usageTotals": {"state": "refreshing", "sinceS": 48},
+        }
+        routes = {
+            "/": {"body": compact(root).encode()},
+            "/api/tokens": {"body": compact(tokens).encode()},
+        }
+        with LocalServer(routes=routes) as server:
+            completed = run_script(
+                "session_start.py", compact(payload).encode(), port=server.port)
+        context = json.loads(completed.stdout)["hookSpecificOutput"][
+            "additionalContext"]
+        self.assertIn("SERVICE WARMING UP", context)
+        self.assertIn("for 48 s", context)
+        self.assertIn("quota data is live", context)
+        self.assertNotIn("PROVIDER DATA STALE", context)
+        self.assertNotIn("HEALTHY", context)
+        self.assertNotIn("sinceS", context)
+
+        # Stale provider data still outranks the warm-up: it names a repair.
+        stale = dict(tokens, claudeWeekStale=True)
+        routes["/api/tokens"] = {"body": compact(stale).encode()}
+        with LocalServer(routes=routes) as server:
+            completed = run_script(
+                "session_start.py", compact(payload).encode(), port=server.port)
+        context = json.loads(completed.stdout)["hookSpecificOutput"][
+            "additionalContext"]
+        self.assertIn("PROVIDER DATA STALE (Claude)", context)
+        self.assertNotIn("SERVICE WARMING UP", context)
+
+        # Once the scan is done the ordinary classes apply again.
+        ready = dict(tokens, usageTotals={"state": "ready", "ageS": 2})
+        routes["/api/tokens"] = {"body": compact(ready).encode()}
+        with LocalServer(routes=routes) as server:
+            completed = run_script(
+                "session_start.py", compact(payload).encode(), port=server.port)
+        context = json.loads(completed.stdout)["hookSpecificOutput"][
+            "additionalContext"]
+        self.assertIn("startup health: HEALTHY", context)
 
     def test_startup_health_reports_ready_and_credential_risk_separately(self):
         payload = {"hook_event_name": "SessionStart", "session_id": "s"}
@@ -2901,6 +2956,54 @@ class RelaySetupTests(unittest.TestCase):
                     if status != "ready":
                         self.assertIn("relay-only use may still be healthy",
                                       output.getvalue())
+
+    def test_doctor_separates_warm_up_from_frozen_totals_and_failed_saves(self):
+        # Issue #62: three different things, three different verdicts.
+        setup = load_setup()
+        cases = (
+            ({"usageTotals": {"state": "refreshing", "sinceS": 41}},
+             "WAIT Tokenserver usage totals: the first history scan is "
+             "still running for 41 s", False),
+            ({"usageTotals": {"state": "ready", "ageS": 3}}, None, False),
+            ({"usageTotals": {"state": "failing", "ageS": 900}},
+             "FIX Tokenserver usage totals: the recompute is failing, so "
+             "the served volume counters are frozen (900 s old)", True),
+            ({"maxTrackerSaveOk": False, "maxTrackerSaveFailingForS": 77},
+             "FIX Max Tracker save: the state file cannot be written for "
+             "77 s", True),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            setup.save_config(path, setup.VibePulseConfig(
+                codex_interactions=True))
+            for extra, expected, is_fix in cases:
+                with self.subTest(extra=extra):
+                    output = io.StringIO()
+                    diagnostics = json.loads(healthy_diagnostics())
+                    diagnostics.update(extra)
+                    body = json.dumps(diagnostics).encode()
+                    setup.main(
+                        ["doctor"], config_path=path,
+                        python=Path(sys.executable), codex=Path("/codex"),
+                        run=FakeRunner([
+                            python_probe_ok(), codex_probe_ok(),
+                            json_result(plugin_listing()),
+                            json_result([owned_mcp()]),
+                        ]),
+                        urlopen=lambda *_args, _body=body, **_kwargs:
+                            BytesResponse(_body),
+                        stdout=output)
+                    text = output.getvalue()
+                    self.assertIn("PASS Tokenserver", text)
+                    if expected is None:
+                        self.assertNotIn("usage totals", text)
+                        self.assertNotIn("Max Tracker save", text)
+                    else:
+                        self.assertIn(expected, text)
+                    self.assertEqual(
+                        ("FIX Tokenserver usage totals" in text or
+                         "FIX Max Tracker save" in text), is_fix)
+                    self.assertNotIn(str(tmp), text)
 
     def test_disable_and_uninstall_preserve_non_target_state(self):
         setup = load_setup()

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "72b051a141be"
+HOST_SOURCE_FINGERPRINT = "7ac74140a9f7"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
+HOST_SOURCE_FINGERPRINT = "8e095613a5c1"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8e095613a5c1"
+HOST_SOURCE_FINGERPRINT = "11d79d23ab9c"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "78eb818013c0"
+HOST_SOURCE_FINGERPRINT = "007f92198744"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -1008,7 +1008,8 @@ class SessionStartTests(unittest.TestCase):
             "claudeWeekStale": False,
             "claudeModelWeekStale": False,
             "codexWeekStale": False,
-            "usageTotals": {"state": "refreshing", "sinceS": 48},
+            "usageTotals": {"state": "refreshing", "sinceS": 48,
+                            "placeholder": True},
         }
         routes = {
             "/": {"body": compact(root).encode()},
@@ -1025,6 +1026,18 @@ class SessionStartTests(unittest.TestCase):
         self.assertNotIn("PROVIDER DATA STALE", context)
         self.assertNotIn("HEALTHY", context)
         self.assertNotIn("sinceS", context)
+
+        # A crashing scan is never a warm-up, with or without a result.
+        failing = dict(tokens, usageTotals={"state": "failing", "sinceS": 90,
+                                            "placeholder": True})
+        routes["/api/tokens"] = {"body": compact(failing).encode()}
+        with LocalServer(routes=routes) as server:
+            completed = run_script(
+                "session_start.py", compact(payload).encode(), port=server.port)
+        context = json.loads(completed.stdout)["hookSpecificOutput"][
+            "additionalContext"]
+        self.assertIn("VOLUME RECOMPUTE FAILING", context)
+        self.assertNotIn("WARMING UP", context)
 
         # Stale provider data still outranks the warm-up: it names a repair.
         stale = dict(tokens, claudeWeekStale=True)

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "bb304d42f5d0"
+HOST_SOURCE_FINGERPRINT = "bbaf2b6bdd34"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "bbaf2b6bdd34"
+HOST_SOURCE_FINGERPRINT = "b1cb05f46caf"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -441,6 +441,20 @@ De nya delta- och prognosfälten är frivilliga för äldre skärmkod och `null`
 när underlaget saknas. Prognosen blir först aktiv efter minst tre punkter,
 90 minuters spann och en procents faktisk rörelse i samma resetcykel.
 
+## Uppstart: platshållare tills första skanningen är klar
+
+Första historikskanningen kan ta minuter på en stor `~/.claude`/`~/.codex`.
+Den körs i bakgrunden; under tiden svarar `/api/tokens` direkt med
+volymräknarna på noll och kvotprocenten live, och blocket
+`usageTotals` säger vad räknarna är: `{"state": "refreshing", "sinceS": N}`
+tills skanningen gått i mål, sedan `{"state": "ready", "ageS": N}`, och
+`{"state": "failing", "ageS": N}` om omräkningen kraschar efter en lyckad
+första körning (då är räknarna frysta; `usageComputeOk` på `GET /` har
+detaljen). Samma block finns på `GET /`. Relä-publiceraren skickar inga
+platshållare, så en panel bakom reläet behåller sina senaste riktiga
+värden. Panelen på LAN visar nollorna tills firmwaren läser blocket
+(OBS-36 i `docs/observability-backlog.md`).
+
 ## Kvotcache och stale-kontrakt
 
 Senaste auktoritativa Claude- och Codex-värden för generell vecka och

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -444,16 +444,23 @@ när underlaget saknas. Prognosen blir först aktiv efter minst tre punkter,
 ## Uppstart: platshållare tills första skanningen är klar
 
 Första historikskanningen kan ta minuter på en stor `~/.claude`/`~/.codex`.
-Den körs i bakgrunden; under tiden svarar `/api/tokens` direkt med
-volymräknarna på noll och kvotprocenten live, och blocket
-`usageTotals` säger vad räknarna är: `{"state": "refreshing", "sinceS": N}`
-tills skanningen gått i mål, sedan `{"state": "ready", "ageS": N}`, och
-`{"state": "failing", "ageS": N}` om omräkningen kraschar efter en lyckad
-första körning (då är räknarna frysta; `usageComputeOk` på `GET /` har
-detaljen). Samma block finns på `GET /`. Relä-publiceraren skickar inga
-platshållare, så en panel bakom reläet behåller sina senaste riktiga
-värden. Panelen på LAN visar nollorna tills firmwaren läser blocket
-(OBS-36 i `docs/observability-backlog.md`).
+Den körs i bakgrunden; under tiden svarar `/api/tokens` direkt, med
+kvotprocenten live och blocket `usageTotals` som säger vad volymräknarna
+är: `{"state": "refreshing", "sinceS": N, "placeholder": true}` tills
+skanningen gått i mål, sedan `{"state": "ready", "ageS": N,
+"placeholder": false}`, och `"failing"` om omräkningen kraschar (frysta
+räknare med `ageS`, eller platshållare om ingen skanning hunnit lyckas;
+`usageComputeOk` på `GET /` har detaljen). Samma block finns på `GET /`.
+
+**Platshållare serveras bara till den som sagt att den förstår dem.**
+En klient som skickar `X-VibePulse-Accepts: usage-totals` får svaret ovan
+med nollor och blocket; alla andra får `503 {"error": ..., "usageTotals":
+{...}}`, kontraktets felform, som firmwaren avvisar och behåller sina
+senaste värden på — så en redan flashad panel lär sig aldrig nollor.
+Firmware från 2026-09-10 skickar headern, läser `placeholder` och
+applicerar kvoten men rör inte värdesidan förrän räknarna är mätta.
+Relä-publiceraren skickar inga platshållare, så en panel bakom reläet
+behåller sina senaste riktiga värden.
 
 ## Kvotcache och stale-kontrakt
 

--- a/tools/tokenserver/publisher.py
+++ b/tools/tokenserver/publisher.py
@@ -78,7 +78,7 @@ def is_startup_placeholder(payload) -> bool:
     """True while ``/api/tokens`` serves placeholder volume counters.
 
     The tokenserver answers at once during its first history scan with
-    zeros and ``usageTotals.state == "refreshing"`` (issue #62). A relay
+    zeros and ``usageTotals.placeholder == true`` (issue #62). A relay
     mailbox must not learn those zeros as the day's numbers: the panel on
     the far side keeps its last good values instead, exactly as it does
     across a LAN outage, and the first real scan is published the moment
@@ -87,7 +87,7 @@ def is_startup_placeholder(payload) -> bool:
     if not isinstance(payload, dict):
         return False
     totals = payload.get("usageTotals")
-    return isinstance(totals, dict) and totals.get("state") == "refreshing"
+    return isinstance(totals, dict) and totals.get("placeholder") is True
 
 
 def stale_fields(payload) -> frozenset[str]:

--- a/tools/tokenserver/publisher.py
+++ b/tools/tokenserver/publisher.py
@@ -74,6 +74,22 @@ def payload_fingerprint(payload) -> str:
     return hashlib.sha256(body).hexdigest()
 
 
+def is_startup_placeholder(payload) -> bool:
+    """True while ``/api/tokens`` serves placeholder volume counters.
+
+    The tokenserver answers at once during its first history scan with
+    zeros and ``usageTotals.state == "refreshing"`` (issue #62). A relay
+    mailbox must not learn those zeros as the day's numbers: the panel on
+    the far side keeps its last good values instead, exactly as it does
+    across a LAN outage, and the first real scan is published the moment
+    it lands.
+    """
+    if not isinstance(payload, dict):
+        return False
+    totals = payload.get("usageTotals")
+    return isinstance(totals, dict) and totals.get("state") == "refreshing"
+
+
 def stale_fields(payload) -> frozenset[str]:
     """Return only explicit top-level stale flags from a numbers payload."""
     if not isinstance(payload, dict):
@@ -155,6 +171,8 @@ class Publisher:
             except Exception:
                 log.exception("publicering: %s-producenten föll", path)
                 continue
+            if path == "/api/tokens" and is_startup_placeholder(payload):
+                continue  # första skanningen pågår: inget att publicera än
             fingerprint = payload_fingerprint(payload)
             current_stale = stale_fields(payload)
             last_fingerprint, sent_at, last_stale = self._state.get(

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -244,6 +244,20 @@ def check_server(base_url, checkout_rev=None, checkout_src=None):
         results.append((FAIL, f"usage-omräkningen har kraschat (i {secs} s) "
                               f"— /api/tokens serverar frysta siffror som "
                               f"ser färska ut; läs loggfilen"))
+    totals = root.get("usageTotals")
+    if isinstance(totals, dict) and totals.get("state") == "refreshing":
+        secs = totals.get("sinceS")
+        secs = secs if isinstance(secs, int) else "?"
+        results.append((VARN, f"första skanningen pågår ({secs} s) — "
+                              f"/api/tokens serverar platshållare "
+                              f"(usageTotals=refreshing); kvoten är live, "
+                              f"volymen inte mätt än"))
+    if root.get("maxTrackerSaveOk") is False:
+        secs = root.get("maxTrackerSaveFailingForS") or 0
+        results.append((VARN, f"max-tracker kan inte spara (i {secs} s) — "
+                              f"observationerna står kvar i minnet och "
+                              f"nästa försök kommer; kontrollera "
+                              f"diskutrymme och rättigheter"))
     return results
 
 

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -127,8 +127,13 @@ def _get_json(url, timeout=5):
     allt utom 200 (torget_http.c), så en proxy eller cache som svarar 502
     med frisk-seende kropp får inte bli grönt här. Serverns egna 500 bär
     kontraktets {"error": ...}-kropp och parsas också."""
+    # X-VibePulse-Accepts: röktestet förstår usageTotals och räknar aldrig
+    # platshållare som mätningar, så tjänsten får svara 200 med dem under
+    # första skanningen (en klient utan headern får 503 i felformen).
+    request = urllib.request.Request(
+        url, headers={"X-VibePulse-Accepts": "usage-totals"})
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
             return resp.status, json.loads(
                 resp.read().decode("utf-8", errors="replace"))
     except urllib.error.HTTPError as e:

--- a/tools/tokenserver/test_max_tracker.py
+++ b/tools/tokenserver/test_max_tracker.py
@@ -1284,6 +1284,34 @@ class MaxTrackerStorePersistenceTests(unittest.TestCase):
             if os.name == "posix":
                 self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
 
+    def test_a_full_disk_leaves_the_previous_file_and_memory_intact(self):
+        # Issue #62: one ENOSPC on the atomic write must neither crash the
+        # store nor erase what was on disk, and the next save must succeed
+        # with everything observed in between.
+        import errno
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "max-tracker.json"
+            store, codex_root, claude_root = _new_store(directory, path=path)
+            store.observe_volume("claude", "2026-08-07", 400)
+            store.save()
+            before = path.read_bytes()
+
+            store.observe_volume("claude", "2026-08-08", 250)
+            with mock.patch("os.replace", side_effect=OSError(
+                    errno.ENOSPC, "No space left on device")):
+                with self.assertRaises(OSError):
+                    store.save()
+
+            self.assertEqual(path.read_bytes(), before)
+            leftovers = [p for p in path.parent.iterdir() if p != path]
+            self.assertEqual(leftovers, [])
+            self.assertEqual(
+                store._state["claude"]["days"]["2026-08-08"]["vol"], 250)
+
+            store.save()
+            reloaded = MaxTrackerStore(path, codex_root, claude_root)
+            self.assertIn("2026-08-08", reloaded._state["claude"]["days"])
+
     def test_reloaded_store_produces_an_identical_snapshot(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "max-tracker.json"

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -196,6 +196,11 @@ class CodexOnlyEndToEndTest(unittest.TestCase):
                                   "_persist_quota_records_async"):
             tokenserver._last_result = None
             tokenserver._last_computed = 0.0
+            # Since issue #62 the first request answers with a placeholder
+            # (or, without the Accepts header, the error form) while the
+            # scan runs in the background. This test is about what the
+            # completed Codex-only scan serves, so run that scan first.
+            tokenserver._refresh_usage_totals(self.claude_absent)
             handler.do_GET()
 
         handler._send.assert_called_once()

--- a/tools/tokenserver/test_publisher.py
+++ b/tools/tokenserver/test_publisher.py
@@ -162,12 +162,15 @@ class PublisherTests(unittest.TestCase):
         # zeros marked usageTotals=refreshing. A relay mailbox must not
         # learn those as the day's numbers; the far panel keeps its last
         # good values, and the first real payload goes out at once.
-        payloads = [{"dayTokens": 0, "usageTotals": {"state": "refreshing",
-                                                     "sinceS": 3}},
-                    {"dayTokens": 0, "usageTotals": {"state": "refreshing",
-                                                     "sinceS": 33}},
-                    {"dayTokens": 4321, "usageTotals": {"state": "ready",
-                                                        "ageS": 1}}]
+        payloads = [{"dayTokens": 0, "usageTotals": {
+                        "state": "refreshing", "sinceS": 3,
+                        "placeholder": True}},
+                    {"dayTokens": 0, "usageTotals": {
+                        "state": "failing", "sinceS": 33,
+                        "placeholder": True}},
+                    {"dayTokens": 4321, "usageTotals": {
+                        "state": "ready", "ageS": 1,
+                        "placeholder": False}}]
         p, sent, clock = self._publisher({
             "/api/tokens": lambda: payloads.pop(0),
             "/api/github": lambda: {"stars": 5},

--- a/tools/tokenserver/test_publisher.py
+++ b/tools/tokenserver/test_publisher.py
@@ -157,6 +157,30 @@ class PublisherTests(unittest.TestCase):
         self.assertEqual(p.publish_once(), 0)
         self.assertEqual(len(sent), 1)
 
+    def test_a_startup_placeholder_is_not_published(self):
+        # Issue #62: the tokenserver answers its first history scan with
+        # zeros marked usageTotals=refreshing. A relay mailbox must not
+        # learn those as the day's numbers; the far panel keeps its last
+        # good values, and the first real payload goes out at once.
+        payloads = [{"dayTokens": 0, "usageTotals": {"state": "refreshing",
+                                                     "sinceS": 3}},
+                    {"dayTokens": 0, "usageTotals": {"state": "refreshing",
+                                                     "sinceS": 33}},
+                    {"dayTokens": 4321, "usageTotals": {"state": "ready",
+                                                        "ageS": 1}}]
+        p, sent, clock = self._publisher({
+            "/api/tokens": lambda: payloads.pop(0),
+            "/api/github": lambda: {"stars": 5},
+        })
+        self.assertEqual(p.publish_once(), 1)
+        self.assertEqual([url for url, _ in sent],
+                         ["https://relay.example/u/s3cret/api/github"])
+        clock["now"] += 30
+        self.assertEqual(p.publish_once(), 0)
+        clock["now"] += 30
+        self.assertEqual(p.publish_once(), 1)
+        self.assertIn(b'"dayTokens": 4321', sent[-1][1])
+
     def test_a_broken_producer_does_not_stop_the_others(self):
         def broken():
             raise RuntimeError("boom")

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -189,6 +189,30 @@ class ServerCheckTests(unittest.TestCase):
         self.assertIn("frysta siffror", fails[0])
         self.assertIn("612", fails[0])
 
+    def test_first_scan_in_progress_is_a_warning_not_a_failure(self):
+        # Issue #62: placeholder counters during the first scan are named,
+        # bounded and expected -- the smoke test says so, and says the
+        # quota is live, without escalating to FAIL.
+        root = dict(HEALTHY_ROOT,
+                    usageTotals={"state": "refreshing", "sinceS": 41})
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        warnings = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("första skanningen pågår", warnings[0])
+        self.assertIn("41", warnings[0])
+        self.assertNotIn(smoke.FAIL, levels(results))
+
+    def test_a_failing_state_save_is_a_warning_with_its_duration(self):
+        root = dict(HEALTHY_ROOT, maxTrackerSaveOk=False,
+                    maxTrackerSaveFailingForS=77)
+        with canned_server({"/": root}) as base:
+            results = smoke.check_server(base, checkout_rev="abc1234")
+        warnings = [text for level, text in results if level == smoke.VARN]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("kan inte spara", warnings[0])
+        self.assertIn("77", warnings[0])
+
     def test_older_server_without_compute_field_is_not_judged(self):
         root = {k: v for k, v in HEALTHY_ROOT.items()
                 if not k.startswith("usageCompute")}

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -1016,8 +1016,11 @@ class ClaudeLimitHeaderTests(unittest.TestCase):
                                   return_value={}), \
                 mock.patch.object(
                     tokenserver, "_persist_quota_records_async"):
-            tokenserver._last_result = None
-            tokenserver._last_computed = 0.0
+            # Seed a completed first scan: since issue #62 a None result
+            # is answered with a placeholder while the scan runs in the
+            # background, and these tests are about the quota fields.
+            tokenserver._last_result = tokenserver._compute(Path("/unused"))
+            tokenserver._last_computed = time.monotonic()
             snapshot = tokenserver.get_snapshot(
                 Path("/unused"), history=StubHistory(),
                 now_ts=1_800_000_000,
@@ -1599,8 +1602,11 @@ class UsageSnapshotTests(unittest.TestCase):
                                   return_value=claude or {}), \
                 mock.patch.object(tokenserver, "_read_codex_limits",
                                   return_value=codex or {}):
-            tokenserver._last_result = None
-            tokenserver._last_computed = 0.0
+            # Seed a completed first scan: since issue #62 a None result
+            # is answered with a placeholder while the scan runs in the
+            # background, and these tests are about the quota fields.
+            tokenserver._last_result = tokenserver._compute(Path("/unused"))
+            tokenserver._last_computed = time.monotonic()
             return tokenserver.get_snapshot(
                 Path("/unused"), history=history, now_ts=now_ts,
                 quota_cache=quota_cache)
@@ -2872,8 +2878,11 @@ class MaxTrackerLiveHookTests(unittest.TestCase):
                                   return_value=claude or {}), \
                 mock.patch.object(tokenserver, "_read_codex_limits",
                                   return_value=codex or {}):
-            tokenserver._last_result = None
-            tokenserver._last_computed = 0.0
+            # Seed a completed first scan: since issue #62 a None result
+            # is answered with a placeholder while the scan runs in the
+            # background, and these tests are about the quota fields.
+            tokenserver._last_result = tokenserver._compute(Path("/unused"))
+            tokenserver._last_computed = time.monotonic()
             return tokenserver.get_snapshot(
                 Path("/unused"), history=StubHistory(), now_ts=now_ts,
                 quota_cache=QuotaCache(Path(temp_dir) / "quota.json",
@@ -3126,12 +3135,183 @@ class MaxTrackerSingleWriterTests(unittest.TestCase):
             self.assertEqual(len(store._backfill["claude"]), 1)
 
 
+class StartupSnapshotTests(unittest.TestCase):
+    """Issue #62: a 211 s first history scan used to run UNDER the cache
+    lock inside get_snapshot, so every /api/tokens request queued behind
+    it and timed out, and a healthy service restart showed STALE on the
+    glass. The first request must now answer at once with a placeholder
+    that says what it is, the scan runs in the background, its result is
+    swapped in atomically, and a crashing scan is retried on the normal
+    cadence rather than per request."""
+
+    def setUp(self):
+        self.previous = (
+            tokenserver._last_result, tokenserver._last_computed,
+            tokenserver._snapshot_refreshing, tokenserver._last_result_at,
+            tokenserver._compute_failing_since,
+            tokenserver._last_compute_error_logged,
+        )
+        tokenserver._last_result = None
+        tokenserver._last_computed = 0.0
+        tokenserver._snapshot_refreshing = False
+        tokenserver._last_result_at = None
+        tokenserver._compute_failing_since = None
+        tokenserver._last_compute_error_logged = None
+
+    def tearDown(self):
+        (tokenserver._last_result, tokenserver._last_computed,
+         tokenserver._snapshot_refreshing, tokenserver._last_result_at,
+         tokenserver._compute_failing_since,
+         tokenserver._last_compute_error_logged) = self.previous
+
+    def _snapshot(self, temp_dir, projects_dir=Path("/unused")):
+        return tokenserver.get_snapshot(
+            projects_dir, history=StubHistory(), now_ts=1_800_000_000,
+            quota_cache=QuotaCache(Path(temp_dir) / "quota.json"))
+
+    def _wait_until_not_refreshing(self):
+        for _ in range(200):
+            if not tokenserver._snapshot_refreshing:
+                return
+            time.sleep(0.01)
+        self.fail("first scan never finished")
+
+    def test_first_request_answers_at_once_with_a_marked_placeholder(self):
+        started = threading.Event()
+        release = threading.Event()
+        computed = {"v": 1, "dayTokens": 4321, "dayTokensPerHour": 7,
+                    "daySessions": 2, "monthTokens": 99999,
+                    "claudeSourcePresent": True, "value": {"state": "ok"}}
+
+        def slow_compute(_projects_dir, _store=None):
+            started.set()
+            release.wait(timeout=2)
+            return computed
+
+        with mock.patch.object(tokenserver, "_compute",
+                               side_effect=slow_compute), \
+                mock.patch.object(tokenserver, "get_limits",
+                                  return_value={}), \
+                mock.patch.object(tokenserver, "_read_codex_limits",
+                                  return_value={}), \
+                mock.patch.object(
+                    tokenserver, "_persist_quota_records_async"), \
+                tempfile.TemporaryDirectory() as temp_dir:
+            before = time.perf_counter()
+            first = self._snapshot(temp_dir)
+            elapsed = time.perf_counter() - before
+            self.assertTrue(started.wait(timeout=1))
+
+            # Within the two-second acceptance bound, by a wide margin.
+            self.assertLess(elapsed, 0.5)
+            # The placeholder is a complete v2 payload the firmware parser
+            # accepts: numeric counters, the quota fields, the additive
+            # marker saying the counters are not measurements.
+            self.assertEqual(first["v"], 2)
+            for key in ("dayTokens", "dayTokensPerHour", "daySessions",
+                        "monthTokens"):
+                self.assertEqual(first[key], 0)
+            self.assertFalse(first["claudeSourcePresent"])
+            self.assertEqual(first["usageTotals"]["state"], "refreshing")
+            self.assertIsInstance(first["usageTotals"]["sinceS"], int)
+            self.assertIn("claudeWeekStale", first)
+            self.assertEqual(first["value"]["state"], "no_plan_cost")
+            self.assertTrue(tokenserver._snapshot_refreshing)
+
+            # A second request while the scan runs does NOT start another.
+            second = self._snapshot(temp_dir)
+            self.assertEqual(second["usageTotals"]["state"], "refreshing")
+            self.assertEqual(tokenserver._compute.call_count, 1)
+
+            release.set()
+            self._wait_until_not_refreshing()
+            third = self._snapshot(temp_dir)
+            self.assertEqual(third["dayTokens"], 4321)
+            self.assertEqual(third["usageTotals"]["state"], "ready")
+            self.assertIsInstance(third["usageTotals"]["ageS"], int)
+            self.assertEqual(tokenserver._compute.call_count, 1)
+
+    def test_a_crashing_first_scan_is_retried_on_the_cadence_not_per_request(self):
+        with mock.patch.object(tokenserver, "_compute",
+                               side_effect=RuntimeError("boom")), \
+                mock.patch.object(tokenserver, "get_limits",
+                                  return_value={}), \
+                mock.patch.object(tokenserver, "_read_codex_limits",
+                                  return_value={}), \
+                mock.patch.object(
+                    tokenserver, "_persist_quota_records_async"), \
+                tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertLogs("tokenserver", level="ERROR"):
+                first = self._snapshot(temp_dir)
+                self._wait_until_not_refreshing()
+            self.assertEqual(first["usageTotals"]["state"], "refreshing")
+            self.assertEqual(tokenserver._compute.call_count, 1)
+            self.assertIsNone(tokenserver._last_result)
+
+            # Straight after the crash: still a placeholder, no new thread.
+            second = self._snapshot(temp_dir)
+            self.assertEqual(second["usageTotals"]["state"], "refreshing")
+            self.assertEqual(tokenserver._compute.call_count, 1)
+
+            # Once the normal recompute cadence has passed, one retry (its
+            # error line is throttled by OBS-08's window, so no assertLogs).
+            tokenserver._last_computed -= tokenserver.RECOMPUTE_EVERY_S + 1
+            self._snapshot(temp_dir)
+            self._wait_until_not_refreshing()
+            self.assertEqual(tokenserver._compute.call_count, 2)
+
+    def test_root_payload_names_the_three_usage_total_states(self):
+        handler = tokenserver.Handler.__new__(tokenserver.Handler)
+        handler.path = "/"
+        handler._send = mock.Mock()
+
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertEqual(payload["usageTotals"]["state"], "refreshing")
+        self.assertIsInstance(payload["usageTotals"]["sinceS"], int)
+        self.assertTrue(payload["usageComputeOk"])
+
+        tokenserver._last_result = {"v": 1}
+        tokenserver._last_result_at = time.monotonic() - 12
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertEqual(payload["usageTotals"]["state"], "ready")
+        self.assertGreaterEqual(payload["usageTotals"]["ageS"], 12)
+
+        tokenserver._compute_failing_since = time.monotonic() - 5
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertEqual(payload["usageTotals"]["state"], "failing")
+        self.assertFalse(payload["usageComputeOk"])
+
+    def test_placeholder_satisfies_the_smoke_shape_and_the_device_budget(self):
+        from tools.tokenserver import smoke
+        with mock.patch.object(tokenserver, "_compute",
+                               side_effect=RuntimeError("never")), \
+                mock.patch.object(tokenserver, "get_limits",
+                                  return_value={}), \
+                mock.patch.object(tokenserver, "_read_codex_limits",
+                                  return_value={}), \
+                mock.patch.object(
+                    tokenserver, "_persist_quota_records_async"), \
+                tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertLogs("tokenserver", level="ERROR"):
+                snapshot = self._snapshot(temp_dir)
+                self._wait_until_not_refreshing()
+        expected_v, required, shape = smoke.ENDPOINT_SHAPE["/api/tokens"]
+        self.assertEqual(snapshot["v"], expected_v)
+        self.assertTrue(set(required) <= set(snapshot))
+        self.assertIsNone(shape(snapshot))
+        self.assertNotIn("error", snapshot)
+
+
 class MaxTrackerDirtyWriterTests(unittest.TestCase):
     def setUp(self):
         self.previous = (
             tokenserver._max_tracker_dirty,
             tokenserver._max_tracker_writer_running,
             tokenserver._last_save_error_logged,
+            tokenserver._max_tracker_save_failing_since,
         )
         tokenserver._max_tracker_dirty = False
         tokenserver._max_tracker_writer_running = False
@@ -3139,11 +3319,47 @@ class MaxTrackerDirtyWriterTests(unittest.TestCase):
         # med kort uptime, eftersom monotonic räknar från boot (CI fällde
         # exakt det).
         tokenserver._last_save_error_logged = None
+        tokenserver._max_tracker_save_failing_since = None
 
     def tearDown(self):
         (tokenserver._max_tracker_dirty,
          tokenserver._max_tracker_writer_running,
-         tokenserver._last_save_error_logged) = self.previous
+         tokenserver._last_save_error_logged,
+         tokenserver._max_tracker_save_failing_since) = self.previous
+
+    def test_a_failing_save_is_visible_on_the_root_payload_until_it_recovers(self):
+        # Issue #62: ENOSPC on the state file is degraded health, not a
+        # log line nobody reads. GET / carries the episode.
+        store = mock.Mock()
+        store.save.side_effect = OSError(28, "No space left on device")
+        handler = tokenserver.Handler.__new__(tokenserver.Handler)
+        handler.path = "/"
+        handler._send = mock.Mock()
+
+        with self.assertLogs("tokenserver", level="ERROR"):
+            tokenserver._mark_max_tracker_dirty(store)
+            for _ in range(50):
+                if store.save.called:
+                    break
+                time.sleep(0.01)
+            self._wait_for_writer_stop()
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertFalse(payload["maxTrackerSaveOk"])
+        self.assertIsInstance(payload["maxTrackerSaveFailingForS"], int)
+
+        store.save.side_effect = None
+        with self.assertLogs("tokenserver", level="INFO"):
+            tokenserver._mark_max_tracker_dirty(store)
+            for _ in range(50):
+                if store.save.call_count == 2:
+                    break
+                time.sleep(0.01)
+            self._wait_for_writer_stop()
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertTrue(payload["maxTrackerSaveOk"])
+        self.assertIsNone(payload["maxTrackerSaveFailingForS"])
 
     def _wait_for_writer_stop(self):
         for _ in range(50):

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -3218,6 +3218,7 @@ class StartupSnapshotTests(unittest.TestCase):
                 self.assertEqual(first[key], 0)
             self.assertFalse(first["claudeSourcePresent"])
             self.assertEqual(first["usageTotals"]["state"], "refreshing")
+            self.assertTrue(first["usageTotals"]["placeholder"])
             self.assertIsInstance(first["usageTotals"]["sinceS"], int)
             self.assertIn("claudeWeekStale", first)
             self.assertEqual(first["value"]["state"], "no_plan_cost")
@@ -3233,8 +3234,80 @@ class StartupSnapshotTests(unittest.TestCase):
             third = self._snapshot(temp_dir)
             self.assertEqual(third["dayTokens"], 4321)
             self.assertEqual(third["usageTotals"]["state"], "ready")
+            self.assertFalse(third["usageTotals"]["placeholder"])
             self.assertIsInstance(third["usageTotals"]["ageS"], int)
             self.assertEqual(tokenserver._compute.call_count, 1)
+
+    def test_the_totals_block_describes_the_counters_it_rides_on(self):
+        """Codex review of #104: the block used to be computed AFTER the
+        lock was released, so a first scan landing in between labelled
+        placeholder zeros `ready` and the publisher would have relayed
+        them. Simulate exactly that: the scan completes while the quota
+        part of the payload is being built."""
+        computed = {"v": 1, "dayTokens": 4321, "dayTokensPerHour": 7,
+                    "daySessions": 2, "monthTokens": 99999,
+                    "claudeSourcePresent": True, "value": {"state": "ok"}}
+
+        def scan_lands_now():
+            with tokenserver._cache_lock:
+                tokenserver._last_result = computed
+                tokenserver._last_result_at = time.monotonic()
+                tokenserver._snapshot_refreshing = False
+            return {}
+
+        with mock.patch.object(tokenserver, "_start_usage_refresh"), \
+                mock.patch.object(tokenserver, "get_limits",
+                                  side_effect=scan_lands_now), \
+                mock.patch.object(tokenserver, "_read_codex_limits",
+                                  return_value={}), \
+                mock.patch.object(
+                    tokenserver, "_persist_quota_records_async"), \
+                tempfile.TemporaryDirectory() as temp_dir:
+            snapshot = self._snapshot(temp_dir)
+        self.assertEqual(snapshot["dayTokens"], 0)
+        self.assertTrue(snapshot["usageTotals"]["placeholder"])
+        self.assertEqual(snapshot["usageTotals"]["state"], "refreshing")
+        self.assertTrue(tokenserver.usage_totals_are_placeholders(snapshot))
+
+    def test_placeholders_go_only_to_clients_that_declared_they_understand(self):
+        """An already-flashed panel applies whatever parses; it never sent
+        the header, so it gets the contract's error form and keeps its last
+        good values (honestly STALE later) instead of learning zeros."""
+        placeholder = {"v": 2, "dayTokens": 0,
+                       "usageTotals": {"state": "refreshing", "sinceS": 3,
+                                       "placeholder": True}}
+        measured = {"v": 2, "dayTokens": 4321,
+                    "usageTotals": {"state": "ready", "ageS": 2,
+                                    "placeholder": False}}
+        for accepts, payload, expected_code in (
+                (None, placeholder, 503),
+                ("usage-totals", placeholder, 200),
+                ("agent-rows, USAGE-TOTALS", placeholder, 200),
+                ("something-else", placeholder, 503),
+                (None, measured, 200)):
+            with self.subTest(accepts=accepts, code=expected_code):
+                handler = tokenserver.Handler.__new__(tokenserver.Handler)
+                handler.path = "/api/tokens"
+                handler.headers = {}
+                if accepts is not None:
+                    handler.headers = {"X-VibePulse-Accepts": accepts}
+                handler.projects_dir = Path("/unused")
+                handler.max_tracker_store = None
+                handler._send = mock.Mock()
+                handler._record_panel_poll = mock.Mock()
+                with mock.patch.object(tokenserver, "get_snapshot",
+                                       return_value=dict(payload)):
+                    handler.do_GET()
+                code, body = handler._send.call_args.args
+                self.assertEqual(code, expected_code)
+                if expected_code == 503:
+                    self.assertIn("error", body)
+                    self.assertEqual(body["usageTotals"],
+                                     payload["usageTotals"])
+                    self.assertNotIn("dayTokens", body)
+                else:
+                    self.assertNotIn("error", body)
+                    self.assertEqual(body["dayTokens"], payload["dayTokens"])
 
     def test_a_crashing_first_scan_is_retried_on_the_cadence_not_per_request(self):
         with mock.patch.object(tokenserver, "_compute",
@@ -3249,13 +3322,22 @@ class StartupSnapshotTests(unittest.TestCase):
             with self.assertLogs("tokenserver", level="ERROR"):
                 first = self._snapshot(temp_dir)
                 self._wait_until_not_refreshing()
-            self.assertEqual(first["usageTotals"]["state"], "refreshing")
+            # The scan thread may already have crashed while the first
+            # payload was being built; either name is honest, and both
+            # say placeholder.
+            self.assertIn(first["usageTotals"]["state"],
+                          ("refreshing", "failing"))
+            self.assertTrue(first["usageTotals"]["placeholder"])
             self.assertEqual(tokenserver._compute.call_count, 1)
             self.assertIsNone(tokenserver._last_result)
 
-            # Straight after the crash: still a placeholder, no new thread.
+            # Straight after the crash: still a placeholder, no new thread,
+            # and the state says FAILING, not "still running" (a crashed
+            # scan is not a warm-up).
             second = self._snapshot(temp_dir)
-            self.assertEqual(second["usageTotals"]["state"], "refreshing")
+            self.assertEqual(second["usageTotals"]["state"], "failing")
+            self.assertTrue(second["usageTotals"]["placeholder"])
+            self.assertIsInstance(second["usageTotals"]["sinceS"], int)
             self.assertEqual(tokenserver._compute.call_count, 1)
 
             # Once the normal recompute cadence has passed, one retry (its
@@ -3273,20 +3355,32 @@ class StartupSnapshotTests(unittest.TestCase):
         handler.do_GET()
         payload = handler._send.call_args.args[1]
         self.assertEqual(payload["usageTotals"]["state"], "refreshing")
+        self.assertTrue(payload["usageTotals"]["placeholder"])
         self.assertIsInstance(payload["usageTotals"]["sinceS"], int)
         self.assertTrue(payload["usageComputeOk"])
+
+        # Crashing before any scan completed: failing, still a placeholder.
+        tokenserver._compute_failing_since = time.monotonic() - 5
+        handler.do_GET()
+        payload = handler._send.call_args.args[1]
+        self.assertEqual(payload["usageTotals"]["state"], "failing")
+        self.assertTrue(payload["usageTotals"]["placeholder"])
+        self.assertFalse(payload["usageComputeOk"])
+        tokenserver._compute_failing_since = None
 
         tokenserver._last_result = {"v": 1}
         tokenserver._last_result_at = time.monotonic() - 12
         handler.do_GET()
         payload = handler._send.call_args.args[1]
         self.assertEqual(payload["usageTotals"]["state"], "ready")
+        self.assertFalse(payload["usageTotals"]["placeholder"])
         self.assertGreaterEqual(payload["usageTotals"]["ageS"], 12)
 
         tokenserver._compute_failing_since = time.monotonic() - 5
         handler.do_GET()
         payload = handler._send.call_args.args[1]
         self.assertEqual(payload["usageTotals"]["state"], "failing")
+        self.assertFalse(payload["usageTotals"]["placeholder"])
         self.assertFalse(payload["usageComputeOk"])
 
     def test_placeholder_satisfies_the_smoke_shape_and_the_device_budget(self):

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -120,6 +120,9 @@ else:  # direktkörning: python3 tools/tokenserver/tokenserver.py
     import value_meter
 
 RECOMPUTE_EVERY_S = 30
+# Hur länge uppvärmningstråden väntar på en skanning som en tidig
+# HTTP-förfrågan hann starta före den, innan den ger upp loggraden.
+FIRST_SCAN_WAIT_S = 600
 LIMITS_EVERY_S = 240  # rate-limit-proben: 15 anrop/h — kontots bucket delas
 AUTH_RECOVERY_EVERY_S = 15.0  # lokal tokenkontroll; ingen upstream vid väntan
                       # med Claude Code självt, och kvoten rör sig långsamt;
@@ -402,6 +405,11 @@ _price_table = None
 _last_result = None
 _last_computed = 0.0
 _snapshot_refreshing = False
+# När den senaste LYCKADE omräkningen blev klar (monotonic). None tills
+# första skanningen gått i mål: det är den som skiljer "platshållare" från
+# "frysta siffror" i usageTotals-blocket nedan.
+_last_result_at = None
+_SERVER_STARTED_MONO = time.monotonic()
 # Omräkningens hälsa: kraschar _compute serveras förra snapshotet vidare —
 # rätt beteende, men det får inte ske TYST (då fryser siffrorna för alltid
 # och ser färska ut). failing_since driver usageComputeOk på GET / och
@@ -1891,6 +1899,7 @@ _max_tracker_writer_lock = threading.Lock()
 _max_tracker_dirty = False
 _max_tracker_writer_running = False
 _ERROR_LOG_THROTTLE_S = 300.0  # ihållande fel: en loggrad per 5 min räcker
+_max_tracker_save_failing_since = None  # monotonic; None = sparar fint
 _last_save_error_logged = None  # None = aldrig loggat (0.0 sväljer första
                                 # felet på en nystartad maskin — monotonic
                                 # räknar från boot)
@@ -1898,7 +1907,7 @@ _last_save_error_logged = None  # None = aldrig loggat (0.0 sväljer första
 
 def _max_tracker_writer(store):
     global _max_tracker_dirty, _max_tracker_writer_running, \
-        _last_save_error_logged
+        _last_save_error_logged, _max_tracker_save_failing_since
     while True:
         with _max_tracker_writer_lock:
             if not _max_tracker_dirty:
@@ -1911,14 +1920,23 @@ def _max_tracker_writer(store):
                 # Lyckad skrivning stänger felepisoden: logga slutet och
                 # nollställ strypningen, så nästa fel (en NY episod) loggar
                 # direkt i stället för att ärva gamla fönstret.
-                log.info("max-tracker: save lyckades igen")
+                log.info("max-tracker: save lyckades igen efter %.0f s",
+                         time.monotonic()
+                         - (_max_tracker_save_failing_since
+                            or time.monotonic()))
                 _last_save_error_logged = None
+            _max_tracker_save_failing_since = None
         except Exception:
             # En misslyckad skrivning får inte tappa dirty-signalen: markera
             # om och avsluta, så NÄSTA observation (eller slutflushen)
             # försöker igen — ingen het loop, ingen tyst dataförlust.
             # Loggen är strypt: ett trasigt skrivmål ska inte fylla filen.
+            # Episoden syns på GET / (maxTrackerSaveOk) så en full disk
+            # (ENOSPC, issue #62) är degraderad hälsa, inte en loggrad
+            # ingen läser.
             now = time.monotonic()
+            if _max_tracker_save_failing_since is None:
+                _max_tracker_save_failing_since = now
             if (_last_save_error_logged is None or
                     now - _last_save_error_logged >= _ERROR_LOG_THROTTLE_S):
                 _last_save_error_logged = now
@@ -2016,7 +2034,7 @@ def _add_forecast(result, prefix, forecast):
 
 def _refresh_usage_totals(projects_dir, max_tracker_store=None):
     global _last_result, _last_computed, _snapshot_refreshing, \
-        _compute_failing_since, _last_compute_error_logged
+        _last_result_at, _compute_failing_since, _last_compute_error_logged
     try:
         refreshed = _compute(projects_dir, max_tracker_store)
     except Exception:
@@ -2040,8 +2058,84 @@ def _refresh_usage_totals(projects_dir, max_tracker_store=None):
     with _cache_lock:
         if refreshed is not None:
             _last_result = refreshed
+            _last_result_at = time.monotonic()
         _last_computed = time.monotonic()
         _snapshot_refreshing = False
+
+
+def _usage_totals_state():
+    """The additive ``usageTotals`` block, on ``/api/tokens`` and ``GET /``.
+
+    Three states, so a reader never has to guess what the four volume
+    counters mean (issue #62):
+
+    ``refreshing``
+        The first history scan has not finished. The counters are
+        PLACEHOLDER ZEROS, not measurements; ``sinceS`` is how long the
+        service has been up. Quota percentages in the same payload are
+        live: they come from the probe and the quota cache, not the scan.
+    ``ready``
+        The counters are the last completed scan, ``ageS`` seconds old.
+    ``failing``
+        A scan has completed once, but the recompute has been crashing
+        since (OBS-08): the counters are frozen at ``ageS`` seconds old.
+        ``usageComputeOk``/``usageComputeFailingForS`` on ``GET /`` carry
+        the detail; this block only names the class.
+
+    Reads the module state without the cache lock, like
+    ``_compute_failing_since`` already is: every field is a single
+    reference read, and a reader that races a swap sees either the old
+    or the new state, never a torn one.
+    """
+    now = time.monotonic()
+    if _last_result is None:
+        return {"state": "refreshing",
+                "sinceS": int(now - _SERVER_STARTED_MONO)}
+    age = (int(now - _last_result_at)
+           if _last_result_at is not None else None)
+    return {"state": ("failing" if _compute_failing_since is not None
+                      else "ready"),
+            "ageS": age}
+
+
+def _startup_totals_placeholder(projects_dir):
+    """What ``/api/tokens`` serves for the volume counters until the first
+    scan completes.
+
+    The firmware contract requires the four counters to be numbers
+    (tokens_parse.c: ``if (!num(root, "dayTokens", &day)) goto done;``),
+    so an honest ``null`` is not an option there. Zeros it is, with
+    ``usageTotals.state == "refreshing"`` saying so in the same payload;
+    ``claudeSourcePresent`` keeps its own meaning (is there a Claude
+    directory at all). The value block is the real builder fed zero
+    volume, so its ``state``/``cost_source`` are exactly what a genuinely
+    empty month would produce.
+    """
+    return {
+        "v": 1,
+        "dayTokens": 0,
+        "dayTokensPerHour": 0,
+        "daySessions": 0,
+        "monthTokens": 0,
+        "claudeSourcePresent": projects_dir.is_dir(),
+        "value": value_meter.build_payload(
+            0.0, 0, 0,
+            claude_plan=_claude_plan, codex_plan=_codex_plan,
+            plan_costs=_plan_costs, table=_price_table,
+            claude_usd=0.0, codex_usd=0.0),
+        "at": datetime.now().astimezone().isoformat(timespec="seconds"),
+    }
+
+
+def _start_usage_refresh(projects_dir, max_tracker_store, name):
+    """Start one background recompute. Caller holds ``_cache_lock`` and has
+    already set ``_snapshot_refreshing``; this only spawns the thread."""
+    threading.Thread(
+        target=_refresh_usage_totals,
+        args=(projects_dir, max_tracker_store),
+        name=name,
+        daemon=True,
+    ).start()
 
 
 def get_snapshot(projects_dir: Path, history=None, now_ts=None,
@@ -2058,18 +2152,28 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     global _last_result, _last_computed, _snapshot_refreshing
     with _cache_lock:
         if _last_result is None:
-            _last_result = _compute(projects_dir, max_tracker_store)
-            _last_computed = time.monotonic()
-        elif (time.monotonic() - _last_computed > RECOMPUTE_EVERY_S and
-              not _snapshot_refreshing):
-            _snapshot_refreshing = True
-            threading.Thread(
-                target=_refresh_usage_totals,
-                args=(projects_dir, max_tracker_store),
-                name="usage-total-refresh",
-                daemon=True,
-            ).start()
-        result = dict(_last_result)
+            # Första skanningen låg här, UNDER låset, och tog 211 s på en
+            # Mac med stor historik: varje /api/tokens-anrop köade bakom
+            # den och gick i timeout, så panelen blev STALE efter varje
+            # omstart av en frisk tjänst (issue #62). Nu startas den i
+            # bakgrunden och svaret är en platshållare som säger vad den
+            # är (usageTotals nedan). Kraschar den startas den om först
+            # efter RECOMPUTE_EVERY_S — inte per anrop.
+            now = time.monotonic()
+            if (not _snapshot_refreshing and
+                    (_last_computed == 0.0 or
+                     now - _last_computed > RECOMPUTE_EVERY_S)):
+                _snapshot_refreshing = True
+                _start_usage_refresh(projects_dir, max_tracker_store,
+                                     "usage-total-first-scan")
+            result = _startup_totals_placeholder(projects_dir)
+        else:
+            if (time.monotonic() - _last_computed > RECOMPUTE_EVERY_S and
+                    not _snapshot_refreshing):
+                _snapshot_refreshing = True
+                _start_usage_refresh(projects_dir, max_tracker_store,
+                                     "usage-total-refresh")
+            result = dict(_last_result)
 
     # null = ärlig frånvaro (nyckelring/probe/loggar otillgängliga) — skärmen
     # visar streck, aldrig hittade procent. Samma regel som sharePct.
@@ -2219,6 +2323,9 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     # OTA-annonsen rider på kvotpollen: noll ny infrastruktur, och enheten
     # avgör själv (mot sin körande version) om notisen ska visas.
     result["otaAvailableVersion"] = _ota_available_version()
+    # Additiv nyckel (tokens_parse.c hoppar över okända toppnivånycklar):
+    # säger om volymräknarna ovan är mätningar, platshållare eller frysta.
+    result["usageTotals"] = _usage_totals_state()
     result["v"] = 2
     return result
 
@@ -2899,6 +3006,7 @@ class Handler(BaseHTTPRequestHandler):
         # emellan ge None i subtraktionen (500 på själva diagnostikrutten)
         # och en nystartad episod ge ok=true med varaktighet bredvid.
         failing_since = _compute_failing_since
+        save_failing_since = _max_tracker_save_failing_since
         endpoints = ["/api/tokens", "/api/agent-status",
                      "/api/max-tracker", "/api/github"]
         return {"service": "torget-tokenserver",
@@ -2921,6 +3029,11 @@ class Handler(BaseHTTPRequestHandler):
                 "usageComputeFailingForS":
                     (int(time.monotonic() - failing_since)
                      if failing_since is not None else None),
+                "usageTotals": _usage_totals_state(),
+                "maxTrackerSaveOk": save_failing_since is None,
+                "maxTrackerSaveFailingForS":
+                    (int(time.monotonic() - save_failing_since)
+                     if save_failing_since is not None else None),
                 "discovery": {
                     "status": self.discovery_status,
                     **({"reason": self.discovery_reason}
@@ -3447,12 +3560,32 @@ def main():
     # svarar meningsfullt på en gång, /api/tokens svarar när skanningen är
     # klar (skärmen visar streck/stale tills dess, precis som vid nätfel).
     def _first_scan_warmup():
+        global _snapshot_refreshing
         t0 = time.monotonic()
-        try:
-            snap = get_snapshot(Handler.projects_dir)
-        except Exception:
-            log.exception("förstaskanningen kraschade — /api/tokens värmer "
-                          "vid första anropet i stället")
+        # Gör själva skanningen här, i den här tråden, i stället för att
+        # gå via get_snapshot: den svarar numera direkt med en platshållare
+        # (issue #62) och startar skanningen i bakgrunden, och en logg-
+        # rad byggd på platshållaren hade sagt "0 tokens idag". Anspråket
+        # görs under låset så en tidig /api/tokens och uppvärmningen
+        # aldrig kör _compute samtidigt; förlorar vi kapplöpningen väntar
+        # vi in den trådens resultat i stället.
+        with _cache_lock:
+            claimed = _last_result is None and not _snapshot_refreshing
+            if claimed:
+                _snapshot_refreshing = True
+        if claimed:
+            _refresh_usage_totals(Handler.projects_dir)
+        else:
+            while (_last_result is None and
+                   time.monotonic() - t0 < FIRST_SCAN_WAIT_S):
+                time.sleep(0.2)
+        snap = _last_result
+        if snap is None:
+            # _refresh_usage_totals har redan loggat kraschen (strypt) och
+            # usageTotals på GET / står på refreshing tills nästa försök.
+            log.warning("förstaskanningen gav inget resultat på %.0f s — "
+                        "/api/tokens serverar platshållare tills en "
+                        "omräkning lyckas", time.monotonic() - t0)
             return
         # Samma ärlighet som net.c och simulatorn: utan Claude-källa är
         # nollorna inte mätningar, och "0 tokens idag" i starthändelsen

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -2172,7 +2172,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     so live percentages/volume only ever reach the on-disk history for
     actual requests, never for a caller that didn't ask for it.
     """
-    global _last_result, _last_computed, _snapshot_refreshing
+    global _snapshot_refreshing
     with _cache_lock:
         if _last_result is None:
             # Första skanningen låg här, UNDER låset, och tog 211 s på en

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -2063,39 +2063,63 @@ def _refresh_usage_totals(projects_dir, max_tracker_store=None):
         _snapshot_refreshing = False
 
 
-def _usage_totals_state():
+def _usage_totals_state_locked(have_result):
     """The additive ``usageTotals`` block, on ``/api/tokens`` and ``GET /``.
 
-    Three states, so a reader never has to guess what the four volume
-    counters mean (issue #62):
+    ``have_result`` is whether the counters in the payload being built
+    are a completed scan (True) or placeholder zeros (False). The caller
+    decides that UNDER ``_cache_lock`` from the same read that picked the
+    counters, so the block can never describe a different snapshot than
+    the one it rides on (a first scan that landed between the two reads
+    used to label zeros ``ready``, and the publisher would have sent
+    them). Three states plus one honest flag (issue #62):
 
     ``refreshing``
-        The first history scan has not finished. The counters are
-        PLACEHOLDER ZEROS, not measurements; ``sinceS`` is how long the
-        service has been up. Quota percentages in the same payload are
+        The first history scan has not finished. ``placeholder`` is true:
+        the counters are zeros, not measurements. ``sinceS`` is how long
+        the service has been up. Quota percentages in the same payload are
         live: they come from the probe and the quota cache, not the scan.
     ``ready``
         The counters are the last completed scan, ``ageS`` seconds old.
     ``failing``
-        A scan has completed once, but the recompute has been crashing
-        since (OBS-08): the counters are frozen at ``ageS`` seconds old.
-        ``usageComputeOk``/``usageComputeFailingForS`` on ``GET /`` carry
-        the detail; this block only names the class.
-
-    Reads the module state without the cache lock, like
-    ``_compute_failing_since`` already is: every field is a single
-    reference read, and a reader that races a swap sees either the old
-    or the new state, never a torn one.
+        The recompute is crashing (OBS-08). With a completed scan behind
+        it the counters are frozen at ``ageS`` old; without one they are
+        still placeholders (``placeholder`` true, ``sinceS``), and the
+        state says *failing*, not refreshing, so a hook or doctor does not
+        call a broken scan a warm-up. ``usageComputeOk`` /
+        ``usageComputeFailingForS`` on ``GET /`` carry the detail.
     """
     now = time.monotonic()
-    if _last_result is None:
-        return {"state": "refreshing",
-                "sinceS": int(now - _SERVER_STARTED_MONO)}
+    failing = _compute_failing_since is not None
+    if not have_result:
+        return {"state": "failing" if failing else "refreshing",
+                "sinceS": int(now - _SERVER_STARTED_MONO),
+                "placeholder": True}
     age = (int(now - _last_result_at)
            if _last_result_at is not None else None)
-    return {"state": ("failing" if _compute_failing_since is not None
-                      else "ready"),
-            "ageS": age}
+    return {"state": "failing" if failing else "ready",
+            "ageS": age,
+            "placeholder": False}
+
+
+def _usage_totals_state():
+    """``GET /``'s view of the block: one consistent read under the lock."""
+    with _cache_lock:
+        return _usage_totals_state_locked(_last_result is not None)
+
+
+def usage_totals_are_placeholders(payload):
+    """True when a ``/api/tokens`` payload's counters are not measurements.
+
+    The one question every consumer has to ask before treating the volume
+    counters as numbers: the publisher (never relay a placeholder), the
+    handler (never hand one to a client that would apply it), and any
+    tool reading the endpoint.
+    """
+    if not isinstance(payload, dict):
+        return False
+    totals = payload.get("usageTotals")
+    return isinstance(totals, dict) and totals.get("placeholder") is True
 
 
 def _startup_totals_placeholder(projects_dir):
@@ -2167,6 +2191,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
                 _start_usage_refresh(projects_dir, max_tracker_store,
                                      "usage-total-first-scan")
             result = _startup_totals_placeholder(projects_dir)
+            totals = _usage_totals_state_locked(have_result=False)
         else:
             if (time.monotonic() - _last_computed > RECOMPUTE_EVERY_S and
                     not _snapshot_refreshing):
@@ -2174,6 +2199,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
                 _start_usage_refresh(projects_dir, max_tracker_store,
                                      "usage-total-refresh")
             result = dict(_last_result)
+            totals = _usage_totals_state_locked(have_result=True)
 
     # null = ärlig frånvaro (nyckelring/probe/loggar otillgängliga) — skärmen
     # visar streck, aldrig hittade procent. Samma regel som sharePct.
@@ -2325,7 +2351,8 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     result["otaAvailableVersion"] = _ota_available_version()
     # Additiv nyckel (tokens_parse.c hoppar över okända toppnivånycklar):
     # säger om volymräknarna ovan är mätningar, platshållare eller frysta.
-    result["usageTotals"] = _usage_totals_state()
+    # Fångad under låset ovan, från SAMMA läsning som valde räknarna.
+    result["usageTotals"] = totals
     result["v"] = 2
     return result
 
@@ -2699,6 +2726,35 @@ class Handler(BaseHTTPRequestHandler):
             quota_snapshot.get("codexWeekStale"))
         return payload
 
+    # The header a client sends to say it understands ``usageTotals`` and
+    # will not apply placeholder counters as measurements. Firmware from
+    # 2026-09-10 on sends it on every fetch; the hook and the smoke test
+    # send it too. A client without it gets the contract's error form
+    # instead of a placeholder, so an already-flashed panel keeps its last
+    # good values (and goes honestly STALE) rather than learning zeros.
+    ACCEPTS_HEADER = "X-VibePulse-Accepts"
+    ACCEPTS_USAGE_TOTALS = "usage-totals"
+
+    def _accepts_usage_totals(self):
+        headers = getattr(self, "headers", None)
+        accepts = (headers.get(self.ACCEPTS_HEADER) if headers else None) or ""
+        return self.ACCEPTS_USAGE_TOTALS in accepts.lower()
+
+    class _NotMeasuredYet(Exception):
+        """Raised by _tokens_payload for a client that must not see zeros."""
+
+        def __init__(self, totals):
+            super().__init__("usage totals not measured yet")
+            self.totals = totals
+
+    def _tokens_payload(self):
+        payload = get_snapshot(self.projects_dir,
+                               max_tracker_store=self.max_tracker_store)
+        if (usage_totals_are_placeholders(payload) and
+                not self._accepts_usage_totals()):
+            raise self._NotMeasuredYet(payload["usageTotals"])
+        return payload
+
     def _reply(self, produce):
         """Svara 200 med produce(), annars 500 {"error": ...} — skärmen
         avvisar error-formen per kontrakt och behåller senaste goda värden.
@@ -2708,9 +2764,20 @@ class Handler(BaseHTTPRequestHandler):
         Producenten och svarsskrivningen bedöms VAR FÖR SIG: ett
         ConnectionError/TimeoutError från producenten är ett serverfel som
         ska loggas och bli 500 — bara under själva skrivningen betyder det
-        att klienten försvann."""
+        att klienten försvann.
+
+        Ett undantag: platshållare (issue #62) till en klient som inte sagt
+        att den förstår dem är inget serverfel utan ett 503 i felformen,
+        med usageTotals-blocket bredvid så den som läser vet varför."""
         try:
             payload = produce()
+        except self._NotMeasuredYet as pending:
+            try:
+                self._send(503, {"error": "usage totals not measured yet",
+                                 "usageTotals": pending.totals})
+            except OSError:
+                pass
+            return
         except Exception:
             log.exception("500 på %s", self.path)
             try:
@@ -2984,9 +3051,7 @@ class Handler(BaseHTTPRequestHandler):
                          "/api/max-tracker", "/api/github"):
             self._record_panel_poll()
         if self.path == "/api/tokens":
-            self._reply(lambda: get_snapshot(
-                self.projects_dir,
-                max_tracker_store=self.max_tracker_store))
+            self._reply(self._tokens_payload)
         elif self.path == "/api/agent-status":
             self._reply(self._agent_status_payload)
         elif self.path == "/api/max-tracker":

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1653,10 +1653,47 @@ def _doctor(
                 print("PASS Tokenserver source: live fingerprint matches "
                       "this checkout", file=stdout)
             _doctor_panel_lan_contact(interactions, stdout)
+            if not _doctor_usage_totals(payload, stdout):
+                fixes = True
             if config.claude_interactions and not _doctor_claude_quota(
                     payload, stdout):
                 fixes = True
     return not fixes
+
+
+def _doctor_usage_totals(payload: dict, stdout) -> bool:
+    """Classify the served volume counters and the state writer.
+
+    Startup refresh, frozen recompute and a failing save are three
+    different things (issue #62): only the last two are FIX. Prints
+    durations only, never paths or figures.
+    """
+    healthy = True
+    totals = payload.get("usageTotals")
+    if isinstance(totals, dict):
+        state = totals.get("state")
+        if state == "refreshing":
+            since = totals.get("sinceS")
+            since_text = f" for {since} s" if isinstance(since, int) else ""
+            print("WAIT Tokenserver usage totals: the first history scan is "
+                  f"still running{since_text}; quota data is live and the "
+                  "panel is served placeholder zeros until it finishes",
+                  file=stdout)
+        elif state == "failing":
+            age = totals.get("ageS")
+            age_text = f" ({age} s old)" if isinstance(age, int) else ""
+            print("FIX Tokenserver usage totals: the recompute is failing, "
+                  f"so the served volume counters are frozen{age_text}; "
+                  "read the tokenserver log", file=stdout)
+            healthy = False
+    if payload.get("maxTrackerSaveOk") is False:
+        secs = payload.get("maxTrackerSaveFailingForS")
+        secs_text = f" for {secs} s" if isinstance(secs, int) else ""
+        print("FIX Max Tracker save: the state file cannot be written"
+              f"{secs_text}; observations stay in memory and retry, but "
+              "check free disk space and permissions", file=stdout)
+        healthy = False
+    return healthy
 
 
 def _doctor_panel_lan_contact(interactions: dict, stdout) -> None:


### PR DESCRIPTION
Closes #62.

## Problem

On a cold start the tokenserver refused `/api/tokens` until the first usage-history scan had finished. With a large `~/.claude/projects` tree that scan takes minutes, so the panel saw a failing host and showed the "no host" state even though the service was up.

## What changes

**Tokenserver**

- `/api/tokens` answers at once. While the first scan runs, `usageTotals` carries `{"state": "refreshing", "sinceS": …, "placeholder": true}`; once measured it carries `{"state": "ready", "ageS": …, "placeholder": false}`. A scan that keeps failing reports `"failing"` (with `sinceS` before the first success, `ageS` after) so a stuck volume recompute is visible instead of looking like warming-up forever.
- Placeholder counters are handed out only to clients that declare `X-VibePulse-Accepts: usage-totals`. Any other client (old firmware included) gets a 503 in the existing `{"error": …}` form during the scan, which the old firmware parser already rejects while keeping its last values. Zeros never reach a client that cannot tell they are placeholders.
- The first scan claims its slot under the cache lock and runs synchronously, so two threads cannot both start it.
- `GET /` exposes `usageTotals`, `maxTrackerSaveOk`, and `maxTrackerSaveFailingForS`. `publisher.py` skips the relay while the payload is a placeholder. `loopback.py`, `smoke.py`, `session_start.py` and `vibepulse_setup.py` send the header and classify refreshing/failing (WARMING UP vs RECOMPUTE FAILING).

**Firmware**

- `tokens_parse.c` reads `usageTotals.placeholder`; `usage_screen.c` keeps the previous volume and value fields while the flag is set (no zeros on the glass, no rate spike); `app.c` uses rate 0 for placeholder samples.
- `torget_http.c` sends `X-VibePulse-Accepts: usage-totals` on every request and logs client-init failures with a redacted target (OBS-12c).
- New fixture `sim-fixtures/tokens-warming-up.json` and `test/test_tokens.c` checks.

## Evidence

- `test/run.sh --skip-js` green locally (tokenserver suite, C tests, SDL landmarks).
- Not verified on the physical panel; firmware behaviour is covered by the host tests and simulator fixture only.

## Docs

CHANGELOG Unreleased, `docs/lessons.md` (lock-during-scan), `docs/observability.md` (GET / fields), `tools/tokenserver/README.md` startup section, `sim-fixtures/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4