### PR TITLE
fix(state): quarantine corrupt state files and fsync the parent directory (OBS-11, OBS-21)

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "231811f7ad3d"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "2b08bb650c11"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "4b05b28b51f6"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "4b05b28b51f6"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "231811f7ad3d"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "bb304d42f5d0"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "d244555ebddb"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "540a51703feb"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "72b051a141be"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "d244555ebddb"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **A corrupt state file was wiped, silently, by the next save (OBS-11).**
+  All three stores (`max-tracker.json` with up to 400 days of history,
+  `quota-cache.json`, `usage-history.json`) answered unreadable bytes by
+  starting empty with no message, and the next save overwrote the evidence.
+  Each now moves the file aside as `<name>.corrupt-<UTC stamp>` beside the
+  original and logs one WARNING naming the file and the reason (never the
+  contents), then starts empty. The bytes are usually 99 % intact, so the
+  option to look or hand-repair is kept. Wrong-shape JSON counts too, and
+  a non-UTF-8 `max-tracker.json`, which used to raise out of the
+  constructor and stop the service from starting, is quarantined the same
+  way. One helper (`state_files.py`) holds the rule for all three.
+
+- **Two of three state writers stopped one fsync short of durable
+  (OBS-21).** `quota-cache.json` always did the full atomic dance: file
+  fsync, rename, parent-directory fsync. `max-tracker.json` and
+  `usage-history.json` stopped at the file fsync, so a power cut right
+  after the rename could bring back the previous file or none; the one
+  with 400 days in it was the least protected. Both now fsync the parent
+  through the same shared helper (a no-op on Windows, which has no
+  directory descriptors, exactly as the quota cache already handled it).
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   option to look or hand-repair is kept. Wrong-shape JSON counts too, and
   a non-UTF-8 `max-tracker.json`, which used to raise out of the
   constructor and stop the service from starting, is quarantined the same
-  way. One helper (`state_files.py`) holds the rule for all three.
+  way. One helper (`state_files.py`) holds the rule for all three, and the
+  quarantine rename gets the same directory fsync as a save, so the kept
+  copy is durable before the warning says it is.
 
 - **Two of three state writers stopped one fsync short of durable
   (OBS-21).** `quota-cache.json` always did the full atomic dance: file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,15 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   constructor and stop the service from starting, is quarantined the same
   way. One helper (`state_files.py`) holds the rule for all three, and the
   quarantine rename gets the same directory fsync as a save, so the kept
-  copy is durable before the warning says it is.
+  copy is durable before the warning says it is. Two more edges from the
+  review: a file that exists but cannot be read (permissions, I/O) makes
+  the store start empty *and refuse to save*, since a rename needs only
+  the directory's permission and would have overwritten it; and a
+  provider section that is a dict but not the `{v, days, weeks,
+  backfill}` shape `save()` writes is quarantined rather than skimmed.
+  The usage history keeps its new state in memory when the replace has
+  landed but the directory fsync failed (disk and memory agree), instead
+  of rolling back and dropping that sample on the next save.
 
 - **Two of three state writers stopped one fsync short of durable
   (OBS-21).** `quota-cache.json` always did the full atomic dance: file

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -41,7 +41,16 @@ corrupt too, since a valid file cannot look like that. Durability and
 quarantine live in one helper (`state_files.py`) so a fourth store
 inherits both instead of re-deciding them. **Guards:** per-store tests for
 invalid JSON, non-UTF-8 bytes and wrong shape (`{}` included, after a
-Codex review caught that gap), and for the parent fsync after the rename.
+Codex review caught that gap; a provider section that is a dict but not
+the `{v, days, weeks, backfill}` shape `save()` writes, after the next
+pass caught that one), and for the parent fsync after the rename. Two
+more rules from the same review: a file that exists but cannot be *read*
+(permissions, I/O) is not "empty" — the store starts empty but refuses to
+save, because a rename needs only the directory's permission and would
+have replaced the file on the first save; and when the replace has landed
+but the directory fsync fails, memory keeps the new state (disk and
+memory agree, only durability is unproven) instead of rolling back and
+letting the next save drop a sample that is on disk.
 **Watch for:** a new store that catches `OSError` broadly and returns
 empty, and a loader that accepts a partial shape "to be lenient".
 ## 2026-09-10 · The parser read a field where the docs put it, not where the writer puts it

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,32 @@ point at the backlog item.
 
 ---
 
+## 2026-09-10 · A store that starts over on a bad file destroys the evidence on its next save
+
+**What happened:** none of the three state files was ever corrupted in the
+field; this is an audit finding (OBS-11) made into a rule before it costs
+anyone 400 days of Max Tracker history. **Root cause:** each store handled
+"cannot read" the only way an unspecified case gets handled: return an
+empty state and carry on. The next `save()` then wrote the empty state over
+the corrupt bytes, which are usually 99 % intact. Recovery was impossible
+by design, and a non-UTF-8 `max-tracker.json` did not even reach that
+path: `read_text` raised out of the constructor and the service did not
+start. The parent-directory fsync (OBS-21) has the same shape: the quota
+cache had it, its two siblings did not, because each writer was written on
+its own day. **The rule now:** a state file that cannot be loaded is moved
+aside (`<name>.corrupt-<UTC stamp>`) with one WARNING naming file and
+reason, never contents, and only then does the store start empty; a
+parseable file that lacks the shape `save()` always writes counts as
+corrupt too, since a valid file cannot look like that. Durability and
+quarantine live in one helper (`state_files.py`) so a fourth store
+inherits both instead of re-deciding them. **Guards:** per-store tests for
+invalid JSON, non-UTF-8 bytes and wrong shape (`{}` included, after a
+Codex review caught that gap), and for the parent fsync after the rename.
+**Watch for:** a new store that catches `OSError` broadly and returns
+empty, and a loader that accepts a partial shape "to be lenient".
+
+---
+
 ## 2026-09-06 · The panel logged the credential it was told never to print
 
 **What happened:** all three failure paths in `torget_http.c` logged the

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -179,7 +179,11 @@ event happens to re-mark dirty.
 cycle retry.
 
 ### OBS-11 · Corrupt state files are silently wiped — quarantine them instead
-`server · S · open`
+`server · S · done (2026-09-10)` — `state_files.quarantine_corrupt` moves
+the file to `<name>.corrupt-<UTC stamp>` and logs one WARNING (file and
+reason, never contents) before the store starts empty; all three loaders
+use it, for invalid JSON, non-UTF-8 bytes and wrong top-level shape alike.
+Tested per store. Original problem:
 All three state stores respond to a corrupt file by starting empty with
 no message: `max_tracker.py:1095-1102` (up to **400 days** of history
 plus backfill watermarks), `quota_cache.py:112`, `usage_history.py:81`.
@@ -338,7 +342,12 @@ through that prompt; if they deny it, the only trace is
 one logged transition (OBS-04).
 
 ### OBS-21 · Two of three state writers skip the directory fsync
-`server · S · open`
+`server · S · done (2026-09-10)` — `state_files.fsync_parent` (the
+quota_cache pattern, Windows no-op included) now runs after the rename in
+`max_tracker._atomic_write` and `usage_history._persist`; quota_cache
+delegates to the same helper. A failing parent fsync raises, so the Max
+Tracker writer re-marks dirty and retries and `record_many` restores its
+memory. Original problem:
 `quota_cache` does the full atomic dance — file fsync, rename, *parent
 directory fsync*, with rollback (`quota_cache.py:148-154`) — precisely
 because a rename can otherwise evaporate on power loss.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -204,11 +204,14 @@ currently its only documentation.
 | `quota-cache.json` | last-known quota truths + reset times | until reset passes |
 | `max-tracker.json` | daily peaks, streaks, backfill watermarks | 400 days |
 
-All three are written atomically (temp + fsync + rename). All three
-**silently start over from empty if corrupt** — a bad `max-tracker.json`
-discards up to 400 days of history with no message and no backup
-(OBS-11). During a comb, validating these files is cheap insurance;
-`python3 -m json.tool < file > /dev/null` is enough to know they parse.
+All three are written atomically (temp + fsync + rename + parent-directory
+fsync, OBS-21). An unreadable one — invalid JSON, non-UTF-8 bytes, or the
+wrong top-level shape — is **quarantined, not overwritten** (OBS-11): the
+store moves it to `<name>.corrupt-<UTC stamp>` beside the original, logs
+one `tokenserver.state` WARNING with the file and reason, and starts
+empty. During a comb, a `*.corrupt-*` file in this directory is a finding:
+the bytes are usually mostly intact and worth a look before deleting.
+`python3 -m json.tool < file > /dev/null` is still the quick parse check.
 
 ### 5. The screen itself
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
+HOST_SOURCE_FINGERPRINT = "bb304d42f5d0"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "d244555ebddb"
+HOST_SOURCE_FINGERPRINT = "540a51703feb"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "231811f7ad3d"
+HOST_SOURCE_FINGERPRINT = "2b08bb650c11"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "72b051a141be"
+HOST_SOURCE_FINGERPRINT = "d244555ebddb"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+HOST_SOURCE_FINGERPRINT = "4b05b28b51f6"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "4b05b28b51f6"
+HOST_SOURCE_FINGERPRINT = "231811f7ad3d"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/tools/tokenserver/max_tracker.py
+++ b/tools/tokenserver/max_tracker.py
@@ -1115,11 +1115,19 @@ class MaxTrackerStore:
         if not isinstance(payload, dict):
             quarantine_corrupt(self.path, "top level is not an object")
             return
+        # save() always writes a dict section per provider, so a file
+        # missing one (`{}`, `{"claude": []}`) is not an older format but a
+        # damaged one: quarantine it rather than load nothing and let the
+        # next save overwrite it (the same shape smoke._tracker_state_shape
+        # already refuses).
+        if any(not isinstance(payload.get(provider), dict)
+               for provider in PROVIDERS):
+            quarantine_corrupt(
+                self.path, "missing a provider section (claude/codex)")
+            return
         with self._lock:
             for provider in PROVIDERS:
-                section = payload.get(provider)
-                if isinstance(section, dict):
-                    self._load_provider(provider, section)
+                self._load_provider(provider, payload[provider])
 
     def _load_provider(self, provider: str, section: dict) -> None:
         """Populate ``self._state`` from one provider's persisted section.

--- a/tools/tokenserver/max_tracker.py
+++ b/tools/tokenserver/max_tracker.py
@@ -50,6 +50,11 @@ import threading
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
+try:
+    from .state_files import fsync_parent, quarantine_corrupt
+except ImportError:  # run as a script / from the directory itself
+    from state_files import fsync_parent, quarantine_corrupt
+
 if __package__:
     from .codex_rollout import codex_rollout_rate_limits, observation_timestamp
 else:  # direktkörning: python3 tools/tokenserver/max_tracker.py
@@ -1090,15 +1095,25 @@ class MaxTrackerStore:
                     del weeks[week]
 
     def _load(self) -> None:
+        """Populate from disk. A missing file is the normal first run; an
+        unreadable one is quarantined (OBS-11) rather than overwritten by
+        the next save -- this file holds up to 400 days of history."""
         try:
             raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        except UnicodeError:
+            quarantine_corrupt(self.path, "not UTF-8")
+            return
         except OSError:
             return
         try:
             payload = json.loads(raw)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as error:
+            quarantine_corrupt(self.path, f"invalid JSON at byte {error.pos}")
             return
         if not isinstance(payload, dict):
+            quarantine_corrupt(self.path, "top level is not an object")
             return
         with self._lock:
             for provider in PROVIDERS:
@@ -1253,6 +1268,10 @@ class MaxTrackerStore:
                 os.fsync(stream.fileno())
             os.replace(temp_path, self.path)
             temp_path = None
+            # The rename is not durable until the directory entry is
+            # (OBS-21): a power cut between here and the next directory
+            # flush could bring back the previous file, or none.
+            fsync_parent(self.path)
         finally:
             if temp_path is not None:
                 try:

--- a/tools/tokenserver/max_tracker.py
+++ b/tools/tokenserver/max_tracker.py
@@ -43,6 +43,7 @@ avslutade backfill-filer aldrig läses om.
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import tempfile
@@ -54,6 +55,8 @@ try:
     from .state_files import fsync_parent, quarantine_corrupt
 except ImportError:  # run as a script / from the directory itself
     from state_files import fsync_parent, quarantine_corrupt
+
+log = logging.getLogger("tokenserver.state")
 
 if __package__:
     from .codex_rollout import codex_rollout_rate_limits, observation_timestamp
@@ -501,6 +504,11 @@ class MaxTrackerStore:
         # resolved (parsed or discarded), so losing this cache just means
         # re-reading that one line's bytes from disk again.
         self._pending = {provider: {} for provider in PROVIDERS}
+        # Set when the file exists but could not be read (permissions, I/O):
+        # the store then starts empty AND refuses to save, because a rename
+        # needs only the directory's permission and would replace up to 400
+        # days of history with the empty state (Codex review of #105).
+        self._load_error: str | None = None
         self._load()
 
     # -- live rollup ---------------------------------------------------
@@ -1105,7 +1113,12 @@ class MaxTrackerStore:
         except UnicodeError:
             quarantine_corrupt(self.path, "not UTF-8")
             return
-        except OSError:
+        except OSError as error:
+            self._load_error = type(error).__name__
+            log.warning("%s exists but could not be read (%s): starting "
+                        "empty and refusing to save over it until the "
+                        "service restarts with a readable file",
+                        self.path.name, self._load_error)
             return
         try:
             payload = json.loads(raw)
@@ -1120,14 +1133,29 @@ class MaxTrackerStore:
         # damaged one: quarantine it rather than load nothing and let the
         # next save overwrite it (the same shape smoke._tracker_state_shape
         # already refuses).
-        if any(not isinstance(payload.get(provider), dict)
+        if any(not self._valid_provider_section(payload.get(provider))
                for provider in PROVIDERS):
             quarantine_corrupt(
-                self.path, "missing a provider section (claude/codex)")
+                self.path, "a provider section (claude/codex) is missing or "
+                "not the {v, days, weeks, backfill} shape save() writes")
             return
         with self._lock:
             for provider in PROVIDERS:
                 self._load_provider(provider, payload[provider])
+
+    @classmethod
+    def _valid_provider_section(cls, section) -> bool:
+        """The exact shape ``_provider_payload`` writes, nothing looser.
+
+        ``{}`` or ``{"days": []}`` parse fine and used to load nothing,
+        after which the next save overwrote the file. The format has had
+        all four keys since its first commit, so a section without them
+        is damage, not an older version.
+        """
+        return (isinstance(section, dict) and
+                section.get("v") == cls._SCHEMA_VERSION and
+                all(isinstance(section.get(key), dict)
+                    for key in ("days", "weeks", "backfill")))
 
     def _load_provider(self, provider: str, section: dict) -> None:
         """Populate ``self._state`` from one provider's persisted section.
@@ -1210,6 +1238,10 @@ class MaxTrackerStore:
         actual (potentially slow) disk write runs unlocked and never
         blocks a concurrent probe or HTTP snapshot.
         """
+        if self._load_error is not None:
+            raise OSError(
+                f"{self.path.name} was unreadable at startup "
+                f"({self._load_error}); refusing to overwrite it")
         with self._lock:
             self._prune_retention(today)
             payload = {provider: self._provider_payload(provider)

--- a/tools/tokenserver/quota_cache.py
+++ b/tools/tokenserver/quota_cache.py
@@ -12,6 +12,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
+try:
+    from .state_files import fsync_parent, quarantine_corrupt
+except ImportError:  # run as a script / from the directory itself
+    from state_files import fsync_parent, quarantine_corrupt
+
 
 _PROVIDERS = {"claude", "codex"}
 _SCOPES = {"general_session", "general_weekly", "model_weekly"}
@@ -108,11 +113,22 @@ class QuotaCache:
 
     def _load(self) -> Dict[Tuple[str, str, str], CachedQuota]:
         try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError):
+            raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {}
+        except UnicodeError:
+            quarantine_corrupt(self.path, "not UTF-8")
+            return {}
+        except OSError:
+            return {}
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as error:
+            quarantine_corrupt(self.path, f"invalid JSON at byte {error.pos}")
             return {}
         if (not isinstance(payload, dict) or set(payload) != {"v", "records"}
                 or payload["v"] != 1 or not isinstance(payload["records"], list)):
+            quarantine_corrupt(self.path, "not a {v: 1, records: [...]} file")
             return {}
         current_time = self._now()
         prune_expired = _finite_number(current_time)
@@ -146,17 +162,9 @@ class QuotaCache:
         }
 
     def _fsync_parent(self) -> None:
-        # Windows does not expose POSIX directory descriptors/fsync. The
-        # temporary file itself is still flushed before os.replace; asking
-        # Windows to open the parent as a file makes every cache write fail.
-        if os.name == "nt":
-            return
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-        descriptor = os.open(self.path.parent, flags)
-        try:
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
+        # One implementation for all three state files (OBS-21); the
+        # Windows no-op and its reason live in state_files.fsync_parent.
+        fsync_parent(self.path)
 
     def _persist(self, snapshot: Tuple[CachedQuota, ...]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/tokenserver/state_files.py
+++ b/tools/tokenserver/state_files.py
@@ -43,6 +43,17 @@ def quarantine_corrupt(path: Path, reason: str) -> Path | None:
                     "(%s): starting empty; the next save overwrites it",
                     path.name, reason, type(error).__name__)
         return None
+    # The rename is only durable once the directory entry is (OBS-21):
+    # without this, power loss before the next state save could drop the
+    # quarantined copy the warning below promises is kept.
+    try:
+        fsync_parent(target)
+    except OSError as error:
+        log.warning("%s is unreadable (%s): quarantined as %s and starting "
+                    "empty, but the directory fsync failed (%s) so the "
+                    "copy is not yet durable.",
+                    path.name, reason, target.name, type(error).__name__)
+        return target
     log.warning("%s is unreadable (%s): quarantined as %s and starting "
                 "empty. The bytes are kept for inspection or hand repair.",
                 path.name, reason, target.name)

--- a/tools/tokenserver/state_files.py
+++ b/tools/tokenserver/state_files.py
@@ -1,0 +1,66 @@
+"""Shared discipline for the service's small JSON state files.
+
+Three stores keep state on disk -- the Max Tracker (400 days of history),
+the quota cache and the usage history -- and each used to answer a corrupt
+file by starting empty, silently, and then overwriting the corrupt bytes on
+its next save (OBS-11). The bytes are usually 99 % intact; what was lost
+was the *option* to look. Two of the three also stopped their atomic write
+at the file fsync, one step short of the parent-directory fsync that makes
+a rename survive power loss (OBS-21). Both rules now live here, once.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger("tokenserver.state")
+
+
+def quarantine_corrupt(path: Path, reason: str) -> Path | None:
+    """Move an unreadable state file aside instead of overwriting it.
+
+    The file becomes ``<name>.corrupt-<UTC stamp>`` beside the original
+    (a numeric suffix if that name is taken), and one WARNING names the
+    file and the reason -- never its contents. Returns the new path, or
+    ``None`` when the move itself failed (the caller still starts empty;
+    the next save then overwrites, which is the pre-existing behaviour and
+    the only remaining option).
+    """
+    path = Path(path)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    target = path.with_name(f"{path.name}.corrupt-{stamp}")
+    counter = 1
+    while target.exists():
+        counter += 1
+        target = path.with_name(f"{path.name}.corrupt-{stamp}-{counter}")
+    try:
+        os.replace(path, target)
+    except OSError as error:
+        log.warning("%s is unreadable (%s) and could not be quarantined "
+                    "(%s): starting empty; the next save overwrites it",
+                    path.name, reason, type(error).__name__)
+        return None
+    log.warning("%s is unreadable (%s): quarantined as %s and starting "
+                "empty. The bytes are kept for inspection or hand repair.",
+                path.name, reason, target.name)
+    return target
+
+
+def fsync_parent(path: Path) -> None:
+    """Make a completed ``os.replace`` durable: fsync the directory entry.
+
+    Windows exposes no POSIX directory descriptors, and opening the parent
+    as a file there makes every write fail, so it is a no-op on ``nt`` --
+    the temporary file itself is still flushed before the replace.
+    """
+    if os.name == "nt":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(Path(path).parent, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/tools/tokenserver/test_max_tracker.py
+++ b/tools/tokenserver/test_max_tracker.py
@@ -1301,6 +1301,65 @@ class MaxTrackerStorePersistenceTests(unittest.TestCase):
                 reloaded.snapshot("2026-08-07", {}),
                 store.snapshot("2026-08-07", {}))
 
+    def test_a_corrupt_file_is_quarantined_not_overwritten(self):
+        # OBS-11: this file holds up to 400 days of history. A corrupt
+        # byte used to mean a silent empty start and, on the next save,
+        # the corrupt bytes -- 99 % intact, usually -- gone for good.
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "max-tracker.json"
+            path.parent.mkdir()
+            corrupt = b'{"claude": {"days": {"2026-08-07": {"vol": 4'
+            path.write_bytes(corrupt)
+
+            with self.assertLogs("tokenserver.state", level="WARNING") as captured:
+                store, _, _ = _new_store(directory, path=path)
+
+            self.assertEqual(store._state["claude"]["days"], {})
+            self.assertFalse(path.exists())
+            quarantined = list(path.parent.glob("max-tracker.json.corrupt-*"))
+            self.assertEqual(len(quarantined), 1)
+            self.assertEqual(quarantined[0].read_bytes(), corrupt)
+            text = "\n".join(captured.output)
+            self.assertIn("quarantined as max-tracker.json.corrupt-", text)
+            self.assertIn("invalid JSON", text)
+            self.assertNotIn("2026-08-07", text)  # never the contents
+
+            store.observe_volume("claude", "2026-08-08", 250)
+            store.save()
+            self.assertTrue(path.exists())
+            self.assertEqual(quarantined[0].read_bytes(), corrupt)
+
+    def test_a_non_utf8_file_is_quarantined_instead_of_crashing_startup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "max-tracker.json"
+            path.parent.mkdir()
+            path.write_bytes(b"\xff\xfe{}")
+            with self.assertLogs("tokenserver.state", level="WARNING") as captured:
+                store, _, _ = _new_store(directory, path=path)
+            self.assertEqual(store._state["claude"]["days"], {})
+            self.assertIn("not UTF-8", "\n".join(captured.output))
+            self.assertEqual(
+                len(list(path.parent.glob("max-tracker.json.corrupt-*"))), 1)
+
+    def test_save_fsyncs_the_parent_directory_after_the_rename(self):
+        # OBS-21: quota_cache did this from day one; the file with 400 days
+        # in it did not.
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "max-tracker.json"
+            store, _, _ = _new_store(directory, path=path)
+            store.observe_volume("claude", "2026-08-07", 400)
+            with mock.patch("tools.tokenserver.max_tracker.fsync_parent") as fsync:
+                store.save()
+            fsync.assert_called_once_with(path)
+
+            store.observe_volume("claude", "2026-08-08", 1)
+            with mock.patch("tools.tokenserver.max_tracker.fsync_parent",
+                            side_effect=OSError(5, "Input/output error")):
+                with self.assertRaises(OSError):
+                    store.save()
+            self.assertEqual(
+                [p.name for p in path.parent.iterdir()], ["max-tracker.json"])
+
     def test_reload_of_a_missing_file_starts_empty_without_error(self):
         with tempfile.TemporaryDirectory() as directory:
             store, _, _ = _new_store(directory)

--- a/tools/tokenserver/test_max_tracker.py
+++ b/tools/tokenserver/test_max_tracker.py
@@ -1376,8 +1376,61 @@ class MaxTrackerStorePersistenceTests(unittest.TestCase):
                     path.parent.glob("max-tracker.json.corrupt-*"))
                 self.assertEqual(len(quarantined), 1)
                 self.assertEqual(quarantined[0].read_bytes(), corrupt)
-                self.assertIn("missing a provider section",
+                self.assertIn("provider section (claude/codex) is missing",
                               "\n".join(captured.output))
+
+    def test_a_provider_section_with_the_wrong_shape_is_quarantined(self):
+        # Codex review of #105, second pass: both keys being dicts is not
+        # the shape save() writes; a section missing v/days/weeks/backfill
+        # loaded nothing and was overwritten on the next save.
+        valid = {"v": 1, "days": {}, "weeks": {}, "backfill": {}}
+        for corrupt in (
+                {"claude": {}, "codex": valid},
+                {"claude": valid, "codex": {"v": 1, "days": [],
+                                            "weeks": {}, "backfill": {}}},
+                {"claude": dict(valid, v=2), "codex": valid},
+                {"claude": {"v": 1, "days": {}, "weeks": {}}, "codex": valid},
+        ):
+            with self.subTest(corrupt=corrupt), \
+                    tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "nested" / "max-tracker.json"
+                path.parent.mkdir()
+                path.write_text(json.dumps(corrupt), encoding="utf-8")
+                with self.assertLogs("tokenserver.state",
+                                     level="WARNING") as captured:
+                    store, _, _ = _new_store(directory, path=path)
+                self.assertEqual(store._state["claude"]["days"], {})
+                self.assertFalse(path.exists())
+                self.assertEqual(
+                    len(list(path.parent.glob("max-tracker.json.corrupt-*"))),
+                    1)
+                self.assertIn("{v, days, weeks, backfill}",
+                              "\n".join(captured.output))
+
+    def test_an_unreadable_file_is_never_overwritten(self):
+        # Codex review of #105: PermissionError is not an empty file. The
+        # rename only needs the directory's permission, so a store that
+        # started empty would replace 400 days of history on its first save.
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "max-tracker.json"
+            path.parent.mkdir()
+            store, _, _ = _new_store(directory, path=path)
+            store.observe_volume("claude", "2026-08-07", 400)
+            store.save()
+            original = path.read_bytes()
+
+            with mock.patch.object(Path, "read_text",
+                                   side_effect=PermissionError("denied")), \
+                    self.assertLogs("tokenserver.state",
+                                    level="WARNING") as captured:
+                store, _, _ = _new_store(directory, path=path)
+            self.assertEqual(store._state["claude"]["days"], {})
+            self.assertIn("refusing to save", "\n".join(captured.output))
+            store.observe_volume("claude", "2026-08-08", 250)
+            with self.assertRaises(OSError) as raised:
+                store.save()
+            self.assertIn("refusing to overwrite", str(raised.exception))
+            self.assertEqual(path.read_bytes(), original)
 
     def test_a_non_utf8_file_is_quarantined_instead_of_crashing_startup(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/tokenserver/test_max_tracker.py
+++ b/tools/tokenserver/test_max_tracker.py
@@ -1357,6 +1357,28 @@ class MaxTrackerStorePersistenceTests(unittest.TestCase):
             self.assertTrue(path.exists())
             self.assertEqual(quarantined[0].read_bytes(), corrupt)
 
+    def test_a_parseable_file_without_both_provider_sections_is_quarantined(self):
+        # Codex review of #105: `{}` and `{"claude": [], "codex": {}}` parse
+        # fine, loaded nothing, and were overwritten by the next save.
+        for corrupt in (b"{}", b'{"claude": [], "codex": {}}',
+                        b'{"codex": {"days": {}}}'):
+            with self.subTest(corrupt=corrupt), \
+                    tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "nested" / "max-tracker.json"
+                path.parent.mkdir()
+                path.write_bytes(corrupt)
+                with self.assertLogs("tokenserver.state",
+                                     level="WARNING") as captured:
+                    store, _, _ = _new_store(directory, path=path)
+                self.assertEqual(store._state["claude"]["days"], {})
+                self.assertFalse(path.exists())
+                quarantined = list(
+                    path.parent.glob("max-tracker.json.corrupt-*"))
+                self.assertEqual(len(quarantined), 1)
+                self.assertEqual(quarantined[0].read_bytes(), corrupt)
+                self.assertIn("missing a provider section",
+                              "\n".join(captured.output))
+
     def test_a_non_utf8_file_is_quarantined_instead_of_crashing_startup(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "nested" / "max-tracker.json"

--- a/tools/tokenserver/test_quota_cache.py
+++ b/tools/tokenserver/test_quota_cache.py
@@ -151,6 +151,32 @@ class QuotaCacheTests(unittest.TestCase):
             self.assertEqual(cache.latest("codex", "general_weekly", now=300),
                              decreased)
 
+    def test_corrupt_file_is_quarantined_not_overwritten(self):
+        # OBS-11.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "quota.json"
+            path.write_text('{"v": 1, "records": [', encoding="utf-8")
+            with self.assertLogs("tokenserver.state", level="WARNING") as captured:
+                cache = QuotaCache(path)
+            self.assertIsNone(cache.latest("claude", "general_weekly"))
+            self.assertFalse(path.exists())
+            quarantined = list(path.parent.glob("quota.json.corrupt-*"))
+            self.assertEqual(len(quarantined), 1)
+            self.assertEqual(quarantined[0].read_text(encoding="utf-8"),
+                             '{"v": 1, "records": [')
+            self.assertIn("quarantined as quota.json.corrupt-",
+                          "\n".join(captured.output))
+
+    def test_wrong_shape_is_quarantined_too(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "quota.json"
+            path.write_text('{"v": 1, "records": [], "extra": 1}',
+                            encoding="utf-8")
+            with self.assertLogs("tokenserver.state", level="WARNING"):
+                QuotaCache(path)
+            self.assertEqual(
+                len(list(path.parent.glob("quota.json.corrupt-*"))), 1)
+
     def test_load_ignores_malformed_sibling_record(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "quota.json"

--- a/tools/tokenserver/test_usage_history.py
+++ b/tools/tokenserver/test_usage_history.py
@@ -64,7 +64,8 @@ class UsageHistoryPersistenceTests(unittest.TestCase):
             })
             self.assertEqual(list(path.parent.glob("*.tmp")), [])
 
-    def test_corrupt_file_starts_empty_without_touching_sibling(self):
+    def test_corrupt_file_is_quarantined_without_touching_sibling(self):
+        # OBS-11: start empty, but keep the bytes beside the file and say so.
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             path = root / "usage-history.json"
@@ -72,11 +73,43 @@ class UsageHistoryPersistenceTests(unittest.TestCase):
             path.write_text("{broken", encoding="utf-8")
             sibling.write_text("unchanged", encoding="utf-8")
 
-            history = UsageHistory(path)
+            with self.assertLogs("tokenserver.state", level="WARNING") as captured:
+                history = UsageHistory(path)
 
             self.assertEqual(history.records, ())
             self.assertEqual(sibling.read_text(encoding="utf-8"),
                              "unchanged")
+            self.assertFalse(path.exists())
+            quarantined = list(root.glob("usage-history.json.corrupt-*"))
+            self.assertEqual(len(quarantined), 1)
+            self.assertEqual(quarantined[0].read_text(encoding="utf-8"),
+                             "{broken")
+            self.assertIn("quarantined", "\n".join(captured.output))
+
+            self.assertTrue(history.record(
+                "claude", "week", 10, reset_at=DAY, at=0))
+            self.assertTrue(path.exists())
+
+    def test_wrong_shape_is_quarantined_too(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "usage-history.json"
+            path.write_text('{"v": 7, "samples": "no"}', encoding="utf-8")
+            with self.assertLogs("tokenserver.state", level="WARNING"):
+                history = UsageHistory(path)
+            self.assertEqual(history.records, ())
+            self.assertEqual(
+                len(list(path.parent.glob("usage-history.json.corrupt-*"))), 1)
+
+    def test_persist_fsyncs_the_parent_directory_after_the_rename(self):
+        # OBS-21.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "usage-history.json"
+            history = UsageHistory(path)
+            with mock.patch(
+                    "tools.tokenserver.usage_history.fsync_parent") as fsync:
+                self.assertTrue(history.record(
+                    "claude", "week", 10, reset_at=DAY, at=0))
+            fsync.assert_called_once_with(path)
 
     def test_rejects_unbounded_provider_or_window_names(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tools/tokenserver/test_usage_history.py
+++ b/tools/tokenserver/test_usage_history.py
@@ -90,6 +90,34 @@ class UsageHistoryPersistenceTests(unittest.TestCase):
                 "claude", "week", 10, reset_at=DAY, at=0))
             self.assertTrue(path.exists())
 
+    def test_quarantine_rename_is_fsynced_like_a_save(self):
+        # Codex review of #105: the rename that keeps the corrupt bytes is
+        # only durable once its directory entry is, same as a save.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "usage-history.json"
+            path.write_text("{broken", encoding="utf-8")
+            with mock.patch(
+                    "tools.tokenserver.state_files.fsync_parent") as fsync, \
+                    self.assertLogs("tokenserver.state", level="WARNING"):
+                UsageHistory(path)
+            quarantined = list(path.parent.glob("usage-history.json.corrupt-*"))
+            self.assertEqual(len(quarantined), 1)
+            fsync.assert_called_once_with(quarantined[0])
+
+    def test_quarantine_survives_a_failed_directory_fsync(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "usage-history.json"
+            path.write_text("{broken", encoding="utf-8")
+            with mock.patch("tools.tokenserver.state_files.fsync_parent",
+                            side_effect=OSError("EIO")), \
+                    self.assertLogs("tokenserver.state",
+                                    level="WARNING") as captured:
+                history = UsageHistory(path)
+            self.assertEqual(history.records, ())
+            self.assertEqual(
+                len(list(path.parent.glob("usage-history.json.corrupt-*"))), 1)
+            self.assertIn("not yet durable", "\n".join(captured.output))
+
     def test_wrong_shape_is_quarantined_too(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "usage-history.json"

--- a/tools/tokenserver/test_usage_history.py
+++ b/tools/tokenserver/test_usage_history.py
@@ -118,6 +118,50 @@ class UsageHistoryPersistenceTests(unittest.TestCase):
                 len(list(path.parent.glob("usage-history.json.corrupt-*"))), 1)
             self.assertIn("not yet durable", "\n".join(captured.output))
 
+    def test_post_replace_fsync_failure_keeps_memory_and_disk_together(self):
+        # Codex review of #105: the replace has landed when the directory
+        # fsync fails; rolling memory back made the next save drop the
+        # sample that was already on disk.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "usage-history.json"
+            history = UsageHistory(path)
+            with mock.patch("tools.tokenserver.usage_history.fsync_parent",
+                            side_effect=OSError("EIO")), \
+                    self.assertLogs("tokenserver.state",
+                                    level="WARNING") as captured:
+                self.assertTrue(history.record(
+                    "claude", "week", 10, reset_at=DAY, at=0))
+            self.assertEqual(len(history.records), 1)
+            on_disk = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(len(on_disk["samples"]), 1)
+            self.assertIn("directory fsync failed", "\n".join(captured.output))
+            # The next save carries both samples: nothing was dropped.
+            self.assertTrue(history.record(
+                "claude", "week", 12, reset_at=DAY, at=usage_history_module.SAMPLE_INTERVAL_S))
+            on_disk = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual([s["pct"] for s in on_disk["samples"]],
+                             [10.0, 12.0])
+
+    def test_an_unreadable_file_is_never_overwritten(self):
+        # Codex review of #105: a permission or I/O error is not "empty".
+        # The rename only needs the directory's permission, so a store
+        # that started empty would replace the file on its first save.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "usage-history.json"
+            UsageHistory(path).record("claude", "week", 10, reset_at=DAY, at=0)
+            original = path.read_bytes()
+            with mock.patch.object(Path, "read_text",
+                                   side_effect=PermissionError("denied")), \
+                    self.assertLogs("tokenserver.state",
+                                    level="WARNING") as captured:
+                history = UsageHistory(path)
+            self.assertEqual(history.records, ())
+            self.assertIn("refusing to save", "\n".join(captured.output))
+            self.assertFalse(history.record(
+                "claude", "week", 50, reset_at=DAY, at=usage_history_module.SAMPLE_INTERVAL_S))
+            self.assertEqual(path.read_bytes(), original)
+            self.assertEqual(history.records, ())
+
     def test_wrong_shape_is_quarantined_too(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "usage-history.json"

--- a/tools/tokenserver/usage_history.py
+++ b/tools/tokenserver/usage_history.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import tempfile
@@ -16,6 +17,12 @@ try:
     from .state_files import fsync_parent, quarantine_corrupt
 except ImportError:  # run as a script / from the directory itself
     from state_files import fsync_parent, quarantine_corrupt
+
+log = logging.getLogger("tokenserver.state")
+
+
+class _PostReplaceError(Exception):
+    """The new file is in place; only its directory entry's sync failed."""
 
 
 SAMPLE_INTERVAL_S = 15 * 60
@@ -69,6 +76,9 @@ class UsageHistory:
         # one instance; every state read/mutation plus its persist happens
         # under this lock so a batch stays atomic in memory and on disk.
         self._lock = threading.RLock()
+        # See MaxTrackerStore._load_error: an existing file that cannot be
+        # read is never overwritten by a store that started empty.
+        self._load_error: str | None = None
         self._records = self._load()
 
     @property
@@ -98,7 +108,12 @@ class UsageHistory:
         except UnicodeError:
             quarantine_corrupt(self.path, "not UTF-8")
             return []
-        except OSError:
+        except OSError as error:
+            self._load_error = type(error).__name__
+            log.warning("%s exists but could not be read (%s): starting "
+                        "empty and refusing to save over it until the "
+                        "service restarts with a readable file",
+                        self.path.name, self._load_error)
             return []
         try:
             payload = json.loads(raw)
@@ -116,6 +131,10 @@ class UsageHistory:
         return [record for record in records if record["at"] >= cutoff]
 
     def _persist(self) -> None:
+        if self._load_error is not None:
+            raise OSError(
+                f"{self.path.name} was unreadable at startup "
+                f"({self._load_error}); refusing to overwrite it")
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = None
         try:
@@ -131,7 +150,10 @@ class UsageHistory:
                 os.fsync(stream.fileno())
             os.replace(temporary, self.path)
             temporary = None
-            fsync_parent(self.path)  # OBS-21: the rename itself is not durable
+            try:
+                fsync_parent(self.path)  # OBS-21: the rename is not durable
+            except OSError as error:
+                raise _PostReplaceError() from error
         finally:
             if temporary is not None:
                 try:
@@ -184,6 +206,17 @@ class UsageHistory:
             self._records.sort(key=lambda record: record["at"])
             try:
                 self._persist()
+            except _PostReplaceError as error:
+                # The replace landed: disk and memory agree, only the
+                # directory entry's durability is unproven. Rolling memory
+                # back here would make the next successful save drop a
+                # sample that is on disk (Codex review of #105); keep it
+                # and say so.
+                log.warning("%s was saved but its directory fsync failed "
+                            "(%s): the file may not survive power loss "
+                            "until the next save",
+                            self.path.name, type(error.__cause__).__name__)
+                return added
             except OSError:
                 self._records = old_records
                 return 0

--- a/tools/tokenserver/usage_history.py
+++ b/tools/tokenserver/usage_history.py
@@ -12,6 +12,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+try:
+    from .state_files import fsync_parent, quarantine_corrupt
+except ImportError:  # run as a script / from the directory itself
+    from state_files import fsync_parent, quarantine_corrupt
+
 
 SAMPLE_INTERVAL_S = 15 * 60
 RETENTION_S = 8 * 24 * 60 * 60
@@ -87,11 +92,22 @@ class UsageHistory:
 
     def _load(self) -> list:
         try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError):
+            raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return []
+        except UnicodeError:
+            quarantine_corrupt(self.path, "not UTF-8")
+            return []
+        except OSError:
+            return []
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as error:
+            quarantine_corrupt(self.path, f"invalid JSON at byte {error.pos}")
             return []
         if (not isinstance(payload, dict) or payload.get("v") != 1 or
                 not isinstance(payload.get("samples"), list)):
+            quarantine_corrupt(self.path, "not a {v: 1, samples: [...]} file")
             return []
         records = [dict(record) for record in payload["samples"]
                    if self._valid_record(record)]
@@ -115,6 +131,7 @@ class UsageHistory:
                 os.fsync(stream.fileno())
             os.replace(temporary, self.path)
             temporary = None
+            fsync_parent(self.path)  # OBS-21: the rename itself is not durable
         finally:
             if temporary is not None:
                 try:


### PR DESCRIPTION
## Outcome

Two observability-backlog items on the server's state files, done together because they share one new helper (`tools/tokenserver/state_files.py`):

- **OBS-11.** An unreadable `max-tracker.json`, `quota-cache.json` or `usage-history.json` is no longer wiped by the next save. The store moves it to `<name>.corrupt-<UTC stamp>` beside the original, logs one `tokenserver.state` WARNING naming the file and the reason (never the contents), and starts empty. Invalid JSON, non-UTF-8 bytes and wrong top-level shape all count. A non-UTF-8 `max-tracker.json` used to raise `UnicodeDecodeError` out of the constructor and stop the service from starting; it is quarantined like the rest.
- **OBS-21.** `max-tracker.json` and `usage-history.json` now fsync the parent directory after the rename, as `quota-cache.json` always did. A failing parent fsync raises: the Max Tracker writer re-marks dirty and retries (OBS-10), and `record_many` restores its memory. Windows has no directory descriptors, so the helper is a no-op there, exactly as the quota cache already handled it; the quota cache now delegates to the same helper.

No API, payload or firmware change.

## Root cause / rationale

Both items are from the 2026-08-13 audit. The stores were written at different times with different care: the quota cache did the full atomic dance and the other two stopped one fsync short, and all three treated a corrupt file as "start over" because nothing else was ever specified. The file that mattered most (400 days of history) was the least protected. One helper for both rules means a fourth store inherits them.

## Verification

- [x] Focused tests, all new and green (`test_max_tracker`, `test_quota_cache`, `test_usage_history`, 147 tests in those three modules):
  - corrupt JSON is quarantined with byte-identical contents, the store starts empty, the warning names the file and reason and not the contents, the next save writes a fresh file and leaves the quarantined one untouched (all three stores);
  - wrong top-level shape is quarantined (usage history, quota cache);
  - a non-UTF-8 `max-tracker.json` no longer raises out of the constructor;
  - `save()` / `_persist()` call the parent fsync exactly once with the store's path, and a failing parent fsync surfaces as `OSError` without leaving a `.tmp` behind.
- [x] The existing `test_corrupt_file_starts_empty_without_touching_sibling` in the usage-history suite is extended to assert the quarantine rather than deleted; its sibling-untouched assertion still holds.
- [x] All modules already registered in `test/tokenserver-suite.txt`.
- [x] `./test/run.sh --skip-js` passes locally in full.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included. The warning prints the file name and the failing byte offset; never a byte of the file.
- [x] CHANGELOG (two `Fixed` entries), `docs/observability.md` state-files section rewritten, OBS-11 and OBS-21 marked done in the backlog, host source fingerprint re-pinned.

### Platform claims

- [x] This does not change a platform support claim.
- [x] Windows-affecting: the parent fsync is a no-op on `nt` (unchanged behaviour for the quota cache, new no-op for the other two); `os.replace` for the quarantine rename is the same primitive the atomic writes already use. The tokenserver suite runs on the Windows CI runner.

### Hardware / UI

- [x] No hardware or UI behavior changed.

## Not tested / remaining risk

- The quarantine rename on a read-only directory fails; the helper then logs that it could not quarantine and the store starts empty, which is the pre-existing behaviour. Covered by code, not by a test.
- The parent fsync's durability claim is the usual one for POSIX; it was not exercised with real power loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_