### PR TITLE
fix(agent-status): derive the model label from the id instead of a hand map (OBS-30)

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "72b051a141be"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "d0ccaa5e8c87"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "9b0e0ca16561"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "9b0e0ca16561"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "36ef6a8ee30d"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "90329929fd28"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "2da0f22d72d9"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "26bc9e2d4b12"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "bb304d42f5d0"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "635036880d22"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "d0ccaa5e8c87"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "2da0f22d72d9"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Fixed
 
+- **Unmapped models reached the panel as raw ids (OBS-30).** The agent
+  rows typeset six model ids by hand (`OPUS 5`, `GPT-5.6 SOL`, ...) and let
+  the other hundred-odd in `prices.json` fall through as raw lowercase,
+  clipped at 24 bytes mid-string: `claude-haiku-4-5-20251001` rendered as
+  `claude-haiku-4-5-2025100` next to its typeset siblings. The label is now
+  derived from the id (family, version and variant uppercased, the dated
+  suffix dropped: `HAIKU 4.5`, `OPUS 4.8`, `SONNET 3.7`, `GPT-5.4 MINI`,
+  `O4 MINI`, `MYTHOS PREVIEW`), so a model the agent picks tomorrow is
+  typeset on arrival. The hand map stays for exceptions only, and a test
+  proves every priced model derives an uppercase label that fits the
+  panel's column.
+
 - **The panel printed the relay's secret URL every time a cloud fetch
   failed.** All three failure paths in `components/torget_net/torget_http.c`
   logged the address they had just failed on. When the fetch had failed over

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -21,6 +21,24 @@ point at the backlog item.
 
 ---
 
+## 2026-09-10 · A hand-written label map was a parser with six entries and a hundred inputs
+
+**What happened:** the agent rows on the panel typeset six model ids by
+hand (`MODEL_LABELS`) and let every other id in `prices.json` fall
+through as a raw lowercase string clipped at 24 bytes: `claude-fable-5-1`
+sat next to `OPUS 5`, and `claude-haiku-4-5-20251001` rendered as
+`claude-haiku-4-5-2025100` (OBS-30). **Root cause:** a lookup table is a
+parser whose grammar is "the cases someone remembered"; every new model
+was a silent miss with no test to fail. **The rule now:** derive the label
+from the id's own structure (family, version, variant; every snapshot
+date form dropped, including the compact `-0613` token before a variant)
+and keep the map for genuine exceptions only. **Guards:** a test walks
+every id in `prices.json` and every label fits the firmware column; the
+compact-snapshot forms are pinned after a Codex review found them.
+**Watch for:** an id shape neither grammar nor table knows — it lands
+uppercased, not clipped, but check it against Claude's own client before
+shipping a hand override.
+
 ## 2026-09-10 · The parser read a field where the docs put it, not where the writer puts it
 
 **What happened:** `/api/agent-status` served `effort: null` for every

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -446,7 +446,12 @@ load. Platform-dependent test assumptions are an established theme
 or forced verify schedule) instead of relying on wall-clock behavior.
 
 ### OBS-30 · Unmapped models reach the panel as raw ids
-`server · S · open`
+`server · S · done (2026-09-10)` — `agent_status.derive_model_label`
+typesets any id (family, version, variant; dated suffix dropped) and
+`normalize_model` bounds the raw id wide enough to keep a dated id whole
+before deriving, then bounds the label to the 24-byte column.
+`MODEL_LABELS` is exceptions only. A test walks every id in `prices.json`.
+Original problem:
 `MODEL_LABELS` (`agent_status.py:56`) names six models; `prices.json`
 prices roughly a hundred and ten. `normalize_model` falls through to the
 raw lowercase id for the rest, so the panel mixes typeset labels

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "bb304d42f5d0"
+HOST_SOURCE_FINGERPRINT = "635036880d22"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "72b051a141be"
+HOST_SOURCE_FINGERPRINT = "d0ccaa5e8c87"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "9b0e0ca16561"
+HOST_SOURCE_FINGERPRINT = "36ef6a8ee30d"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "d0ccaa5e8c87"
+HOST_SOURCE_FINGERPRINT = "2da0f22d72d9"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "2da0f22d72d9"
+HOST_SOURCE_FINGERPRINT = "26bc9e2d4b12"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "d4ddf49d149d"
+HOST_SOURCE_FINGERPRINT = "9b0e0ca16561"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "8772b9339e93"
+HOST_SOURCE_FINGERPRINT = "90329929fd28"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -81,7 +81,7 @@ def derive_model_label(model_id: str) -> str:
     """Typeset a model id the way the hand-picked labels are typeset.
 
     ``claude-opus-4-8`` -> ``OPUS 4.8``; ``claude-haiku-4-5-20251001`` ->
-    ``HAIKU 4.5``; ``claude-3-7-sonnet-20250219`` -> ``SONNET 3.7``;
+    ``HAIKU 4.5``; ``claude-3-7-sonnet-20250219`` -> ``SONNET 3.7``; ``gpt-4-0125-preview`` -> ``GPT-4 PREVIEW``;
     ``claude-mythos-preview`` -> ``MYTHOS PREVIEW``; ``gpt-5.4-mini`` ->
     ``GPT-5.4 MINI``; ``gpt-4o`` -> ``GPT-4O``; ``o4-mini`` -> ``O4 MINI``;
     ``codex-mini-latest`` -> ``CODEX MINI LATEST``. Pure string work on a

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -87,9 +87,13 @@ def derive_model_label(model_id: str) -> str:
     ``codex-mini-latest`` -> ``CODEX MINI LATEST``. Pure string work on a
     bounded, control-free input; never raises.
     """
-    base = _DATED_SUFFIX.sub("", model_id.strip().lower())
+    base = model_id.strip().lower()
     if base.startswith("ft:"):
-        base = base[3:]
+        # A fine-tune id is `ft:<base>:<org>:<suffix>:<id>`: only the base
+        # model is a label, the rest is account metadata that must never
+        # reach the panel (Codex review of #106).
+        base = base[3:].split(":", 1)[0]
+    base = _DATED_SUFFIX.sub("", base)
     tokens = [token for token in base.split("-") if token]
     if not tokens:
         return model_id.upper()

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -53,11 +53,12 @@ ACTIVITIES = {
     "waiting_approval",
 }
 
-# Skärmetiketter för de modeller agenterna faktiskt rapporterar. Okända
-# id:n faller igenom som råa gemener (se normalize_model) — dvs. sol får
-# "GPT-5.6 SOL" medan dess syskon terra/luna skulle visas som "gpt-5.6-terra".
-# Prislistan känner alla tre; skärmen ska göra det också. (OBS-30 spårar att
-# fallet igenom fortfarande gäller resten av prices.json.)
+# Screen labels are DERIVED from the model id (family, version, variant --
+# uppercased, dated suffix dropped), so a model the agent picks tomorrow is
+# typeset on arrival instead of on the next hand edit (OBS-30: the panel
+# used to mix "OPUS 5" with a raw, mid-string-clipped
+# "claude-haiku-4-5-2025100"). MODEL_LABELS is for exceptions only: ids
+# whose derived label would be wrong or worse than a hand-picked one.
 MODEL_LABELS = {
     "claude-fable-5": "FABLE 5",
     "claude-opus-5": "OPUS 5",
@@ -66,6 +67,35 @@ MODEL_LABELS = {
     "gpt-5.6-sol": "GPT-5.6 SOL",
     "gpt-5.6-terra": "GPT-5.6 TERRA",
 }
+_DATED_SUFFIX = re.compile(r"-(?:20\d{6}|20\d\d-\d\d-\d\d)$")
+_VERSION_TOKEN = re.compile(r"^\d+(?:\.\d+)*$")
+
+
+def derive_model_label(model_id: str) -> str:
+    """Typeset a model id the way the hand-picked labels are typeset.
+
+    ``claude-opus-4-8`` -> ``OPUS 4.8``; ``claude-haiku-4-5-20251001`` ->
+    ``HAIKU 4.5``; ``claude-3-7-sonnet-20250219`` -> ``SONNET 3.7``;
+    ``claude-mythos-preview`` -> ``MYTHOS PREVIEW``; ``gpt-5.4-mini`` ->
+    ``GPT-5.4 MINI``; ``gpt-4o`` -> ``GPT-4O``; ``o4-mini`` -> ``O4 MINI``;
+    ``codex-mini-latest`` -> ``CODEX MINI LATEST``. Pure string work on a
+    bounded, control-free input; never raises.
+    """
+    base = _DATED_SUFFIX.sub("", model_id.strip().lower())
+    if base.startswith("ft:"):
+        base = base[3:]
+    tokens = [token for token in base.split("-") if token]
+    if not tokens:
+        return model_id.upper()
+    if tokens[0] == "claude" and len(tokens) > 1:
+        names = [t for t in tokens[1:] if not _VERSION_TOKEN.match(t)]
+        version = ".".join(t for t in tokens[1:] if _VERSION_TOKEN.match(t))
+        label = " ".join(t.upper() for t in names)
+        return f"{label} {version}".strip() if version else label
+    if tokens[0] == "gpt" and len(tokens) > 1:
+        head = f"GPT-{tokens[1].upper()}"
+        return " ".join([head, *(t.upper() for t in tokens[2:])])
+    return " ".join(t.upper() for t in tokens)
 
 
 def _bounded_display(value: Any, max_bytes: int) -> Optional[str]:
@@ -87,10 +117,18 @@ def _bounded_display(value: Any, max_bytes: int) -> Optional[str]:
 
 
 def normalize_model(value: Any) -> Optional[str]:
-    bounded = _bounded_display(value, 24)
-    if bounded is None:
+    # Bound the raw id first (a hostile transcript line stays bounded and
+    # control-free) but wide enough that a dated id survives whole --
+    # clipping at the panel width BEFORE deriving turned
+    # "claude-haiku-4-5-20251001" into "HAIKU 4.5.2025100". Then derive,
+    # then bound to the panel's 24-byte column.
+    raw = _bounded_display(value, 64)
+    if raw is None:
         return None
-    return MODEL_LABELS.get(bounded.lower(), bounded)
+    label = MODEL_LABELS.get(raw.lower())
+    if label is None:
+        label = derive_model_label(raw)
+    return _bounded_display(label, 24)
 
 
 def normalize_effort(value: Any) -> Optional[str]:

--- a/tools/tokenserver/agent_status.py
+++ b/tools/tokenserver/agent_status.py
@@ -67,7 +67,13 @@ MODEL_LABELS = {
     "gpt-5.6-sol": "GPT-5.6 SOL",
     "gpt-5.6-terra": "GPT-5.6 TERRA",
 }
-_DATED_SUFFIX = re.compile(r"-(?:20\d{6}|20\d\d-\d\d-\d\d)$")
+# Snapshot dates in an id, in every form the two catalogs use: a trailing
+# `-20250219` or `-2025-04-14`, and the compact `-0613` / `-0125` MMDD
+# token that may sit before a variant (`gpt-4-0125-preview`). A version
+# is never four bare digits, so the compact form is safe to drop wherever
+# it appears (Codex review of #106).
+_DATED_SUFFIX = re.compile(
+    r"-(?:20\d{6}|20\d\d-\d\d-\d\d|\d{4})(?=-|$)")
 _VERSION_TOKEN = re.compile(r"^\d+(?:\.\d+)*$")
 
 

--- a/tools/tokenserver/test_agent_status.py
+++ b/tools/tokenserver/test_agent_status.py
@@ -267,6 +267,63 @@ class ClassificationTests(unittest.TestCase):
         self.assertEqual(agent_status.normalize_model("gpt-5.6-luna"),
                          "GPT-5.6 LUNA")
 
+    def test_unmapped_model_ids_are_typeset_on_arrival(self):
+        """OBS-30: the panel mixed `OPUS 5` with a raw, mid-string-clipped
+        `claude-haiku-4-5-2025100` depending on which model the agent
+        picked. The label is derived from the id now; the map is for
+        exceptions only."""
+        cases = {
+            "claude-opus-4-8": "OPUS 4.8",
+            "claude-haiku-4-5-20251001": "HAIKU 4.5",
+            "claude-haiku-4-5": "HAIKU 4.5",
+            "claude-3-7-sonnet-20250219": "SONNET 3.7",
+            "claude-sonnet-4-20250514": "SONNET 4",
+            "claude-fable-5-1": "FABLE 5.1",
+            "claude-mythos-preview": "MYTHOS PREVIEW",
+            "claude-mythos-5": "MYTHOS 5",
+            "gpt-5.4-mini": "GPT-5.4 MINI",
+            "gpt-5.2-pro-2025-12-11": "GPT-5.2 PRO",
+            "gpt-5-codex": "GPT-5 CODEX",
+            "gpt-4o": "GPT-4O",
+            "gpt-4.1-nano-2025-04-14": "GPT-4.1 NANO",
+            "o4-mini": "O4 MINI",
+            "codex-mini-latest": "CODEX MINI LATEST",
+            "ft:gpt-4o-2024-08-06": "GPT-4O",
+            "Claude-Opus-4-8 ": "OPUS 4.8",
+        }
+        for model_id, expected in cases.items():
+            with self.subTest(model_id=model_id):
+                self.assertEqual(agent_status.normalize_model(model_id),
+                                 expected)
+        # The hand-picked exceptions still win over derivation.
+        self.assertEqual(agent_status.normalize_model("claude-fable-5"),
+                         "FABLE 5")
+
+    def test_every_priced_model_derives_a_label_that_fits_the_panel(self):
+        prices = json.loads((Path(__file__).resolve().parent /
+                             "prices.json").read_text(encoding="utf-8"))
+        ids = set()
+
+        def walk(node):
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    if key == "models" and isinstance(value, dict):
+                        ids.update(value)
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+        walk(prices)
+        self.assertGreater(len(ids), 100)
+        for model_id in sorted(ids):
+            with self.subTest(model_id=model_id):
+                label = agent_status.normalize_model(model_id)
+                self.assertIsNotNone(label)
+                self.assertLessEqual(len(label.encode("utf-8")), 24)
+                self.assertEqual(label, label.upper())
+                self.assertNotIn("CLAUDE", label)
+                self.assertFalse(label.startswith("-"))
+
     def test_screen_labels_fit_the_firmware_model_buffer(self):
         """TK_AGENT_MODEL_CAP är 25 (24 tecken + NUL). En etikett som
         spränger den klipps mitt i ordet på panelen."""

--- a/tools/tokenserver/test_agent_status.py
+++ b/tools/tokenserver/test_agent_status.py
@@ -337,6 +337,8 @@ class ClassificationTests(unittest.TestCase):
             "o4-mini": "O4 MINI",
             "codex-mini-latest": "CODEX MINI LATEST",
             "ft:gpt-4o-2024-08-06": "GPT-4O",
+            "ft:gpt-4o-2024-08-06:acme:support-bot:abc123": "GPT-4O",
+            "ft:gpt-4.1-mini-2025-04-14:acme::xyz": "GPT-4.1 MINI",
             # Compact MMDD snapshots, at the end and before a variant.
             "gpt-4-0613": "GPT-4",
             "gpt-3.5-turbo-0125": "GPT-3.5 TURBO",

--- a/tools/tokenserver/test_agent_status.py
+++ b/tools/tokenserver/test_agent_status.py
@@ -337,6 +337,12 @@ class ClassificationTests(unittest.TestCase):
             "o4-mini": "O4 MINI",
             "codex-mini-latest": "CODEX MINI LATEST",
             "ft:gpt-4o-2024-08-06": "GPT-4O",
+            # Compact MMDD snapshots, at the end and before a variant.
+            "gpt-4-0613": "GPT-4",
+            "gpt-3.5-turbo-0125": "GPT-3.5 TURBO",
+            "gpt-4-0125-preview": "GPT-4 PREVIEW",
+            "gpt-4-1106-preview": "GPT-4 PREVIEW",
+            "o1-2024-12-17": "O1",
             "Claude-Opus-4-8 ": "OPUS 4.8",
         }
         for model_id, expected in cases.items():


### PR DESCRIPTION
## Outcome

Every model an agent reports is typeset on the panel's agent rows, not only the six in the hand map. `claude-haiku-4-5-20251001` used to render as the raw, mid-string-clipped `claude-haiku-4-5-2025100` next to a typeset `OPUS 5`; it now renders as `HAIKU 4.5`. A model the agent picks tomorrow is typeset on arrival instead of on the next hand edit.

| id | label |
|---|---|
| `claude-opus-4-8` | `OPUS 4.8` |
| `claude-haiku-4-5-20251001` | `HAIKU 4.5` |
| `claude-3-7-sonnet-20250219` | `SONNET 3.7` |
| `claude-mythos-preview` | `MYTHOS PREVIEW` |
| `gpt-5.4-mini` | `GPT-5.4 MINI` |
| `gpt-5.2-pro-2025-12-11` | `GPT-5.2 PRO` |
| `o4-mini` | `O4 MINI` |
| `codex-mini-latest` | `CODEX MINI LATEST` |

Closes OBS-30 in `docs/observability-backlog.md`.

## Root cause / rationale

`MODEL_LABELS` named six ids; `prices.json` prices about a hundred and ten. `normalize_model` fell through to the raw lowercase id for the rest, and because it bounded the id at the panel's 24 bytes first, a dated id was clipped mid-string.

Now `derive_model_label` typesets any id: the dated suffix (`-20251001` or `-2025-12-11`) is dropped, `claude-` is dropped and the numeric tokens join into a version (`4-8` to `4.8`), `gpt-` keeps its version glued (`GPT-5.4`), everything else is uppercased words. `normalize_model` bounds the raw id wide enough (64 bytes, control-free) to keep a dated id whole, derives, then bounds the label to the 24-byte column. The hand map stays and wins, for exceptions only; its six entries agree with derivation today.

## Verification

- [x] Focused tests, green (`tools.tokenserver.test_agent_status`, 99 tests): a table of seventeen ids including mixed case and trailing whitespace; the hand map still wins; and a walk over every id in `prices.json` (more than a hundred) asserting each derives a non-empty, uppercase label within 24 bytes that never starts with a dash and never contains `CLAUDE`. The existing tests for the six mapped ids and the firmware buffer cap are unchanged and pass.
- [x] Whole tokenserver suite green (816 tests), SessionStart tests green.
- [x] Module already registered in `test/tokenserver-suite.txt`.
- [x] `./test/run.sh` not re-run in full for this one-module change; the same base passed it in full on the sibling branches tonight, and CI runs it here.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included.
- [x] CHANGELOG entry, OBS-30 marked done, host source fingerprint re-pinned.

### Platform claims

- [x] This does not change a platform support claim.

### Hardware / UI

- [x] No firmware changed. The `model` field on `/api/agent-status` keeps its 24-byte bound (`TK_AGENT_MODEL_CAP`); only its content for unmapped ids changes, from a raw id to a typeset one. Not verified on a physical panel.

## Not tested / remaining risk

- Very long variant names still clip at 24 bytes (`gpt-4o-mini-search-preview` becomes `GPT-4O MINI SEARCH PREVI`), now at a word boundary of a typeset label rather than inside a raw id. If a long name matters on the glass, the hand map is the place for its short form.
- Fine-tuned OpenAI ids (`ft:` prefix) drop the prefix rather than rendering it; none has been seen in a rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_