### PR TITLE
docs: prepare VibePulse v1.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Designsystemet: **spec/ui-spec.md**. Hårdvarusanningen routas under
 `Hardware-aware work` nedan; läs den kanoniska femfilslistan där före
 hårdvaruarbete.
 
-## Status (2026-08-28, v1.0.0)
+## Status (2026-09-10, v1.1.0)
 
 Plattformen bröts ut ur underhållarens tidigare solcells-firmware (den
 historiken ligger i ett privat repo och är inget du behöver) och stöptes om
@@ -48,6 +48,15 @@ verklig sign-out/sign-in, sleep/resume och reboot. Release-taggen `v1.0.0`
 pekar på `ab3ce92`; de åtta filerna mellan hostrevisionen och taggen är endast
 dokumentation/test, inte runtime. Se den fullständiga sanerade rapporten och
 ärv aldrig denna PASS till en senare runtime-revision utan en ny körning.
+
+`v1.1.0` (2026-09-10) lade till SETTINGS-menyn på KEY3-hållet, ärlig
+uppvärmning (`usageTotals`-platshållare i stället för STALE efter omstart),
+coredump till flash, omstartsliggare i NVS, backoff i panelens pollers,
+karantän av korrupta tillståndsfiler och en engelsk tokenserver-katalog.
+Firmwaredelen är CI-byggd men **inte flashad**: `torget-home-01` kör
+fortfarande `v1.0.0-25-g054db68`, körschemat är `docs/flash-session-2026-09.md`,
+och coredump-partitionen kräver en engångs `partition-table-flash` över USB.
+Windows-PASS:et ovan förblir bundet till `bee5d8c` och ärvs inte av v1.1.0.
 
 Solelkollen och Vibbe/Buddy är egna produkter i egna repon och dras in som
 companion-inputs när de finns utcheckade — `TORGET_SOLELKOLLEN_DIR`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,248 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ## Unreleased
 
+## v1.1.0 — 2026-09-10
+
+Release notes:
+[v1.1.0 — SETTINGS on the glass, evidence after a crash](docs/releases/2026-09-10-settings-and-evidence.md).
+
+### Added
+
+- **A panic leaves evidence, and the panel counts its reboots (OBS-02,
+  OBS-03, OBS-28, OBS-35).** In source and CI-built, **not yet flashed or
+  physically verified**: a 128K `coredump` partition (appended after
+  `ota_1`; OTA never writes the table, so one USB
+  `idf.py partition-table-flash` is needed before a dump can land, and
+  the boot log says so until then) with ELF coredumps to flash on panic, a `coredump i flash … idf.py coredump-info` notice at the
+  next boot, and a reboot ledger in NVS (`omstartsliggare: boot #N sedan
+  liggaren initierades; efter PANIK a, vakthund b, BROWNOUT c`, counted
+  since the ledger was initialized or NVS last erased, never claimed as
+  "since first flash"; a read, write or commit failure logs which step and
+  no counts) right after the boot banner, so "did it reboot while I was
+  away?" is one serial line. `sdkconfig.defaults` now
+  pins the log level (INFO, maximum equals default, which compiles
+  `ESP_LOGD` and with it the `HTTP_CLIENT` request-line leak out
+  structurally), panic print-and-reboot, the task watchdog, and LVGL's own
+  log at WARN, each with its reason. Because defaults never migrate an
+  existing generated `sdkconfig` (the 2026-08-19 lesson), the root CMake
+  now refuses to configure when the effective config has lost the coredump
+  writer, the ELF format, the panic-then-reboot choice, the INFO default
+  or the log ceiling, the task watchdog (or has its panic option on: the
+  watchdog is warn-only, pinned off in the defaults) or the LVGL log with
+  its printf sink and WARN level (`cmake/torget_diagnostics_guard.cmake`,
+  naming the missing values and the `idf.py reconfigure` fix). The ledger
+  counters saturate at their ceiling instead of wrapping to zero. `test/test_firmware_diagnostics.py`
+  holds the pins and exercises the guard both ways; `docs/observability.md`
+  has the retrieval steps, and its signature table now points a panic at
+  the dump and the ledger instead of calling the banner the only witness;
+  a `Task watchdog got triggered` warning is transient serial evidence
+  only (warn-only, so no reboot, dump or ledger count), and a
+  chip-attributed watchdog reset counts in the ledger but has a dump only
+  when the separate `coredump i flash` notice follows the banner.
+
+- **The panel backs off from a dead service instead of hammering it
+  (OBS-13, OBS-12).** In source and CI-built, **not yet flashed**: every
+  device poller ran at a fixed cadence no matter what, so a stopped
+  tokenserver got a connect attempt every second from the agent-status
+  poller alone, all day. A small pure policy (`poll_backoff_policy.c`,
+  host-tested) now lets the first miss through at the normal cadence, then
+  doubles the wait per consecutive miss up to a cap (agent status 1 s to
+  30 s, tokens 30 s to 300 s, Max Tracker 5 to 30 min, the optional GitHub
+  feed 30 s to 300 s) and resets on the first success, logging only the
+  transitions. A miss is a response the screen could not apply, not merely
+  a dead host: a service answering 200 with a body the parser rejects
+  backs off the same way. The tokens poller's recovery notification still
+  cuts a long wait short. `docs/observability.md` maps the new log lines. Two diagnostic holes
+  closed on the way: the agent poller names the real fetch outcome
+  (`IO-fel` vs `överflöde`) instead of a collapsed `ESP_FAIL`, and the HTTP
+  helper's one silent failure path (no memory for a client) now logs, with
+  the target redacted like every other line there.
+
+- **A linter, at last (OBS-25).** `ruff` is pinned in `requirements-dev.txt`
+  (and `pyproject.toml` carries the same pin as `required-version`, so a
+  venv with another release is refused instead of linting differently from
+  CI), configured in `pyproject.toml` with bug-shaped rules only (pyflakes, bare
+  `except`, bugbear, `try/except/pass`, pylint errors, `global` declared for
+  a name never assigned) and runs first in `test/run.sh`, so CI's host gate
+  runs it too. The first sweep found 43 things across ~10 k lines. Every
+  remaining `try/except/pass` is now a named boundary (`# noqa: S110 -
+  <why>`) rather than an unexplained swallow, and the one that mattered is
+  fixed: the Max Tracker backfill loop caught every exception and dropped
+  it, so a bad session file could stop the heatmap's history from ever
+  filling in with nothing in the log; it now logs one line per ten minutes.
+  Sixteen closures over loop variables in tests are bound explicitly, three
+  `zip()` calls state `strict=True`, three dead imports and one dead
+  variable are gone, and `_probe_limits` no longer declares `global` for
+  three names it only reads. Catching `Exception` (74 sites, all
+  deliberate) and the `global` statement itself are not enabled; the config
+  says why.
+
+- **The Claude probe says why it is idle, and never half a status (OBS-18,
+  OBS-20).** `GET /` now carries the probe's backoff beside `claudeProbe`:
+  `claudeProbeStreak`, `claudeProbeIntervalS`, `claudeProbeCooldownLeftS`
+  and `claudeProbeAgeS` (the cadence is 240 s, doubling per miss to
+  960 s), so dashes on the screen can be told apart as "failing every
+  four minutes" versus "resting after a 429"; the smoke test prints them
+  next to a non-ok status. The status string is assembled per cycle and
+  published once, together with the streak and timestamp, under the lock
+  the HTTP threads read with, where it used to grow with `+=` on the probe
+  thread and could be served half-built; a 429's rest is published in that
+  same section as the status that explains it; `GET /` copies status,
+  backoff, rest, credential and header evidence in one locked read, and
+  header evidence (`ratelimitHeaders`, `unknownRateLimitBuckets`) is now
+  the current cycle's only — a cycle that never reached the fallback, was
+  held by another instance or crashed publishes it empty — never
+  hours-old names beside a fresh failure. On macOS the keychain read no
+  longer folds every failure into one shrug: `no_claude_oauth_token`
+  carries `keychain_denied_or_locked (exit N)` (Deny on the prompt, or a
+  locked keychain), `keychain_no_entry`, `keychain_timeout`,
+  `keychain_security_missing`, `keychain_malformed` or
+  `keychain_entry_without_token`, the same word sits in
+  `claudeCredential.reason`, `docs/agent-setup.md` maps each to its fix,
+  and `claude-keychain: X -> Y` logs the transitions.
+
+- **`tools/snapshot.sh`** — one verified bundle of every ref, plus the
+  pseudo-refs `--all` does not cover (`ORIG_HEAD`, `MERGE_HEAD`, `FETCH_HEAD`
+  and the rest, per worktree, including the extra parents a multi-line one
+  holds), to run before anything that rewrites history. It refuses on a shallow clone, which is
+  the trap that nearly cost 433 commits during the work above:
+  `git rev-parse --is-shallow-repository` answers `true` when the clone *is*
+  truncated, and a bundle taken from it restores a fraction of the history
+  without complaining. It also refuses a destination inside the repository,
+  verifies what it wrote by reading it back, and deletes the file if
+  verification fails. Now a work rule in `AGENTS.md`. Written for BSD
+  userland as well as GNU: the first draft parsed worktrees with awk's
+  `RS="\0"`, trimmed with `head -c -1` and called `mktemp` without a
+  template — three things that work on Linux and none of which work on
+  macOS, the very machine where the rule makes the tool mandatory.
+
+- **`/repo-cleanup`** — a two-phase cleanup command. Phase one only produces
+  an evidence table with a keep-list and an uncertainty list; phase two
+  executes the approved subset, one commit per category with `./test/run.sh`
+  between. It encodes the traps that make this repository different: the
+  docs are load-bearing and asserted by tests, C symbols reach the build
+  through CMake and Kconfig rather than callers, and the committed fonts are
+  generated on purpose.
+
+- **The OTA rules now reach Codex.** `AGENTS.md` and `CLAUDE.md` are the same
+  rules for two different agents, and the section saying the maintenance
+  window opens only from the device, that the sender gates exist because a
+  stale build once froze the panel, and that the launchd service must be
+  restarted, was in only one of them.
+
+- **`tools/snapshot.sh` has host tests, on macOS as well as Linux.** The
+  backup `AGENTS.md` makes mandatory before any history rewrite had no
+  coverage at all: no entry in `test/run.sh`, no test file, no shellcheck.
+  Three consecutive review rounds each found a real defect in that one file,
+  and every one was found by a reviewer building a repository shape by hand.
+  `test/test_snapshot_tool.py` now runs the tool against ten synthetic
+  repositories and asserts both the exit code and the published artifacts: an
+  ordinary repository publishes a `.bundle` plus its `.refs` sidecar at mode
+  0600 and clones back; a bare repository and a repository whose bundle
+  advertises no HEAD both exit 0; a shallow clone is refused with
+  `--unshallow` named; a destination inside a checkout is refused directly,
+  via `..`, via a linked worktree, and via a worktree whose path contains a
+  newline; a `prunable` registration neither refuses nor crashes; a run from a
+  linked worktree lands beside the **main** checkout; and a byte flipped in
+  the pack is caught — by the tool's own fetch into a temp bare repository,
+  because `git bundle verify` reads the header only and calls a corrupted
+  pack "okay".
+
+  The portability half is not decoration. Three of the five defects — `awk`
+  with NUL as `RS`, `head -c -1`, `mktemp` without a template — are invisible
+  on Linux, where GNU's tools do exactly what the script asks; they only bite
+  on the maintainer's own machine. A new `Snapshot tool` CI job therefore runs
+  the same file on `ubuntu-latest` **and** `macos-latest`, and the test carries
+  static guards for that class so a reintroduced GNU-ism goes red on ubuntu
+  the minute it is written. `shellcheck tools/snapshot.sh` runs alongside as a
+  complement, not a substitute: it flags neither `RS="\0"` nor a missing
+  `mktemp` template. Each of the five defects was reverted one at a time and
+  the test watched go red before this landed.
+
+- **The screenshots in `docs/img/` are checked against the simulator.**
+  `test/test_docs_frame_drift.py` compares every checked-in 480 × 480 frame
+  with what this build actually renders, and the answer is blunt: of
+  twenty-nine frames it can verify **four**. The Wi-Fi indicator was redrawn
+  in `d5be82d` — a thick white fan became a thin grey one — and most frames
+  still show the old glyph, so README, `docs/wifi.md` and the release bodies
+  have been showing a screen this firmware cannot produce. The four the
+  simulator reproduces exactly are pinned byte-for-byte and rejected if they
+  gain a colour profile or EXIF orientation, which would change what a
+  browser paints without changing a pixel. The other twenty-five are
+  quarantined by name *and* by a digest of the file — including eight whose
+  indicator box is simply blank, which proves nothing either way and had
+  been passing silently. Re-capturing them is a separate, deliberate
+  documentation change.
+
+- **`doctor` and Codex startup health now name a saved Codex mode that
+  silently prevents approvals from reaching the panel.** This is the failure
+  that looks exactly like a broken panel: the bridge is green, the panel
+  polls, and **APPROVE / DENY** never arrives — because `approval_policy =
+  "never"`, `approvals_reviewer = "auto_review"` or `sandbox_mode =
+  "danger-full-access"` means no permission event is ever created. The panel
+  cannot see a setting on the user's computer, so the host is the only place
+  that can say so, and the startup check now says it *before* reporting a
+  reachable service healthy. Reads the three mode names and nothing else in
+  the file, stops at the first table header so a value under `[profiles.x]`
+  is never read as a top-level one, and stays quiet when there is no
+  `config.toml` — most working installs have none, and a check that cries
+  wolf is skipped like any other. Rescued from
+  `niclas/wip/wifi-dma-calibration-20260904` before that branch is deleted.
+
+- **The KEY3 flow is tested as a journey, not only as a table.**
+  `test/test_key3_arbitration.c` pins eight invariants separately, which is
+  the right shape for them — but every cell in that table is set up by hand,
+  and a table where all cells pass says nothing about the *transitions*
+  between them. `test/test_key3_flow.c` walks one continuous trip through
+  the whole flow, feeding each tick's output back as the next tick's input
+  the way `main.c` does, and injects the events the button does not control
+  (the setup window opening itself, the notice arriving, windows expiring)
+  where they really occur. It also asserts no world state is a dead end.
+
+- **`docs/manual-test-key3.md`** — the short list of things only the panel
+  can settle, deliberately excluding everything already automated.
+
+- **Every permanent overlay now reports what it costs, on every boot.** The
+  three top-layer overlays — Wi-Fi setup, SETTINGS and the OTA ring — are
+  built once at start and kept for the whole run, and the AMOLED rule
+  forbids that without a measured memory budget. The measurement is now
+  automatic rather than remembered: each create is bracketed and logs
+  `overlaykostnad <name>: LVGL-pool +N B …, internt ±N B …`. Two numbers
+  because they answer different questions. LVGL's allocator pool is TLSF in
+  **PSRAM** (moved there as the 2026-08-16 freeze fix), so object trees come
+  out of its 256 KiB rather than internal RAM; the internal figure is the
+  control that shows whether a create takes internal memory anyway. A zero
+  delta retires the starvation worry for that layer with evidence instead of
+  argument, and a non-zero one puts the cost in the log.
+
+- A **SETTINGS** menu on a 3 s KEY3 hold. The hold used to derive which window
+  you wanted from whether the panel had an IP; it now opens a menu with
+  UPDATE, WIFI and ABOUT and lets you say. The consent model is unchanged —
+  the menu is reachable only from the device, so physical presence is still
+  required for UPDATE, and the token and the ten-minute window are untouched.
+  Without an address UPDATE is greyed out and cannot be picked, because an
+  update window with no address could never receive an upload; UPDATE is the
+  only row that goes dark, leaving WIFI as the one that can fix it, and the
+  address is live rather than a snapshot — lose Wi-Fi
+  while the menu is up and UPDATE greys out there and then, instead of
+  offering a window that could no longer receive anything. ABOUT shows the
+  firmware version and the address, with a dash for anything missing. There is
+  deliberately no "computer found" row: the only available signal is a boot
+  latch that never clears, so it would have read FOUND forever after one
+  fetch. Any KEY3 release closes the menu, the same escape the two windows
+  have. The menu and the UPDATE READY takeover are mutually exclusive: the
+  hold does nothing at all while that notice is up, and a notice that arrives
+  while the menu is open closes it. The notice is a UI state rather than an
+  open maintenance window, so without both edges the menu opened invisibly
+  behind it and reappeared on LATER. Answer the takeover with its own UPDATE
+  and LATER pills. Against everything else the menu keeps itself on top, which
+  it has to re-assert rather than inherit from creation order — the NO NETWORK
+  page redraws its countdown every second and lifts itself each time, and that
+  is precisely the state where the WIFI row is what you need. FEATURES and
+  PAIR from the design spec are not in this step: FEATURES needs the
+  internal-RAM budget re-measured on the unit, and PAIR belongs to a later
+  step.
+
 ### Changed
 
 - **The tokenserver directory speaks English (issue #12).** Every module,
@@ -19,6 +261,25 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   advice. Runtime keys, persisted file formats, API fields and exit codes
   are byte-identical; a handful of test fixtures keep non-ASCII text on
   purpose because they exist to prove UTF-8 handling.
+
+- KEY3's arbitration — which of the glass's owners gets the button on a given
+  tick — moved out of `main/main.c` into a pure `tg_button_arbitrate()` in
+  `platform/`, shared byte-identically by the panel and the simulator. It was
+  110 lines of decisions in the host layer that `sim/main.c` could not reach:
+  the simulator called `torget_settings_open()` directly during static QA, so
+  it was not the authority for the gesture, the escape, the intent handoff or
+  the asynchronous notice close, against `AGENTS.md` on both counts. Both hosts
+  now read inputs and apply outputs and decide nothing. No behaviour changed —
+  the point of the move is that the behaviour is now provable: the eight
+  invariants behind it, each with a real incident, are pinned as a table of
+  host tests rather than by reading source, including the notice close that
+  fires from `maintenance_ui_task()` with no button event to hang a test on.
+  The simulator drives the real gesture through `poll_keys()` (hold K for
+  three seconds), and the composite state where a notice arrives over an open
+  menu is captured at 480x480 for the first time. The consent model is
+  strengthened rather than restated: the arbitration reaches no service at all
+  and has no output that opens the maintenance window, so the only way there
+  remains a finger on the menu's UPDATE row.
 
 ### Fixed
 
@@ -66,6 +327,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   atomic write leaves both the previous file and memory intact. Firmware
   side built in CI, not flashed: an OTA to this build is what turns the
   post-restart STALE into a live panel; until then the old behaviour holds.
+
 - **Unmapped models reached the panel as raw ids (OBS-30).** The agent
   rows typeset six model ids by hand (`OPUS 5`, `GPT-5.6 SOL`, ...) and let
   the other hundred-odd in `prices.json` fall through as raw lowercase,
@@ -77,6 +339,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   typeset on arrival. The hand map stays for exceptions only, and a test
   proves every priced model derives an uppercase label that fits the
   panel's column.
+
 - **A corrupt state file was wiped, silently, by the next save (OBS-11).**
   All three stores (`max-tracker.json` with up to 400 days of history,
   `quota-cache.json`, `usage-history.json`) answered unreadable bytes by
@@ -107,6 +370,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   with 400 days in it was the least protected. Both now fsync the parent
   through the same shared helper (a no-op on Windows, which has no
   directory descriptors, exactly as the quota cache already handled it).
+
 - **`effort` was null for every Claude job.** `agent_status.py` read it
   from inside the API `message`, beside `model`. Claude Code writes it on
   the transcript *record*, beside `type` and `version`: measured on a live
@@ -118,6 +382,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   12-byte control-free bound; `tool_input` is still never a source. Found
   by the companion-features audit (`docs/companion-features-brainstorm.md`,
   "Fix first").
+
 - **Five SessionStart tests inherited the developer's own Codex settings.**
   `session_start.py` reads the saved `approval_policy`, `approvals_reviewer`
   and `sandbox_mode` from `$CODEX_HOME/config.toml`, else
@@ -129,6 +394,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   supplies its own; the explicit permission-mode tests still pass theirs
   and still prove the production check. A new test poisons the fallback
   home directory and asserts the isolation wins.
+
 - **The host gate could not go green anywhere but Europe.** Every Max
   Tracker test stamped its synthetic records at a fixed UTC hour such as
   `T10:00:00Z` and expected the store to file them under that same calendar
@@ -144,6 +410,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   day of the stamp it actually wrote. Verified green in seven zones from
   UTC-11 to UTC+14. No user-facing data was ever affected: the store was
   right, the expectations were not.
+
 - **The `secrets.h` check in the setup runbook failed every correct setup.**
   Step 1 of `docs/agent-setup.md` verified the host placeholder with an
   unanchored `grep -q 'DIN-MAC' secrets.h`. `secrets.h.example` says
@@ -211,137 +478,6 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   script regenerated nothing anywhere else. Its sibling already resolved the
   path from `__file__`.
 
-### Added
-
-- **A panic leaves evidence, and the panel counts its reboots (OBS-02,
-  OBS-03, OBS-28, OBS-35).** In source and CI-built, **not yet flashed or
-  physically verified**: a 128K `coredump` partition (appended after
-  `ota_1`; OTA never writes the table, so one USB
-  `idf.py partition-table-flash` is needed before a dump can land, and
-  the boot log says so until then) with ELF coredumps to flash on panic, a `coredump i flash … idf.py coredump-info` notice at the
-  next boot, and a reboot ledger in NVS (`omstartsliggare: boot #N sedan
-  liggaren initierades; efter PANIK a, vakthund b, BROWNOUT c`, counted
-  since the ledger was initialized or NVS last erased, never claimed as
-  "since first flash"; a read, write or commit failure logs which step and
-  no counts) right after the boot banner, so "did it reboot while I was
-  away?" is one serial line. `sdkconfig.defaults` now
-  pins the log level (INFO, maximum equals default, which compiles
-  `ESP_LOGD` and with it the `HTTP_CLIENT` request-line leak out
-  structurally), panic print-and-reboot, the task watchdog, and LVGL's own
-  log at WARN, each with its reason. Because defaults never migrate an
-  existing generated `sdkconfig` (the 2026-08-19 lesson), the root CMake
-  now refuses to configure when the effective config has lost the coredump
-  writer, the ELF format, the panic-then-reboot choice, the INFO default
-  or the log ceiling, the task watchdog (or has its panic option on: the
-  watchdog is warn-only, pinned off in the defaults) or the LVGL log with
-  its printf sink and WARN level (`cmake/torget_diagnostics_guard.cmake`,
-  naming the missing values and the `idf.py reconfigure` fix). The ledger
-  counters saturate at their ceiling instead of wrapping to zero. `test/test_firmware_diagnostics.py`
-  holds the pins and exercises the guard both ways; `docs/observability.md`
-  has the retrieval steps, and its signature table now points a panic at
-  the dump and the ledger instead of calling the banner the only witness;
-  a `Task watchdog got triggered` warning is transient serial evidence
-  only (warn-only, so no reboot, dump or ledger count), and a
-  chip-attributed watchdog reset counts in the ledger but has a dump only
-  when the separate `coredump i flash` notice follows the banner.
-- **The panel backs off from a dead service instead of hammering it
-  (OBS-13, OBS-12).** In source and CI-built, **not yet flashed**: every
-  device poller ran at a fixed cadence no matter what, so a stopped
-  tokenserver got a connect attempt every second from the agent-status
-  poller alone, all day. A small pure policy (`poll_backoff_policy.c`,
-  host-tested) now lets the first miss through at the normal cadence, then
-  doubles the wait per consecutive miss up to a cap (agent status 1 s to
-  30 s, tokens 30 s to 300 s, Max Tracker 5 to 30 min, the optional GitHub
-  feed 30 s to 300 s) and resets on the first success, logging only the
-  transitions. A miss is a response the screen could not apply, not merely
-  a dead host: a service answering 200 with a body the parser rejects
-  backs off the same way. The tokens poller's recovery notification still
-  cuts a long wait short. `docs/observability.md` maps the new log lines. Two diagnostic holes
-  closed on the way: the agent poller names the real fetch outcome
-  (`IO-fel` vs `överflöde`) instead of a collapsed `ESP_FAIL`, and the HTTP
-  helper's one silent failure path (no memory for a client) now logs, with
-  the target redacted like every other line there.
-- **A linter, at last (OBS-25).** `ruff` is pinned in `requirements-dev.txt`
-  (and `pyproject.toml` carries the same pin as `required-version`, so a
-  venv with another release is refused instead of linting differently from
-  CI), configured in `pyproject.toml` with bug-shaped rules only (pyflakes, bare
-  `except`, bugbear, `try/except/pass`, pylint errors, `global` declared for
-  a name never assigned) and runs first in `test/run.sh`, so CI's host gate
-  runs it too. The first sweep found 43 things across ~10 k lines. Every
-  remaining `try/except/pass` is now a named boundary (`# noqa: S110 -
-  <why>`) rather than an unexplained swallow, and the one that mattered is
-  fixed: the Max Tracker backfill loop caught every exception and dropped
-  it, so a bad session file could stop the heatmap's history from ever
-  filling in with nothing in the log; it now logs one line per ten minutes.
-  Sixteen closures over loop variables in tests are bound explicitly, three
-  `zip()` calls state `strict=True`, three dead imports and one dead
-  variable are gone, and `_probe_limits` no longer declares `global` for
-  three names it only reads. Catching `Exception` (74 sites, all
-  deliberate) and the `global` statement itself are not enabled; the config
-  says why.
-- **The Claude probe says why it is idle, and never half a status (OBS-18,
-  OBS-20).** `GET /` now carries the probe's backoff beside `claudeProbe`:
-  `claudeProbeStreak`, `claudeProbeIntervalS`, `claudeProbeCooldownLeftS`
-  and `claudeProbeAgeS` (the cadence is 240 s, doubling per miss to
-  960 s), so dashes on the screen can be told apart as "failing every
-  four minutes" versus "resting after a 429"; the smoke test prints them
-  next to a non-ok status. The status string is assembled per cycle and
-  published once, together with the streak and timestamp, under the lock
-  the HTTP threads read with, where it used to grow with `+=` on the probe
-  thread and could be served half-built; a 429's rest is published in that
-  same section as the status that explains it; `GET /` copies status,
-  backoff, rest, credential and header evidence in one locked read, and
-  header evidence (`ratelimitHeaders`, `unknownRateLimitBuckets`) is now
-  the current cycle's only — a cycle that never reached the fallback, was
-  held by another instance or crashed publishes it empty — never
-  hours-old names beside a fresh failure. On macOS the keychain read no
-  longer folds every failure into one shrug: `no_claude_oauth_token`
-  carries `keychain_denied_or_locked (exit N)` (Deny on the prompt, or a
-  locked keychain), `keychain_no_entry`, `keychain_timeout`,
-  `keychain_security_missing`, `keychain_malformed` or
-  `keychain_entry_without_token`, the same word sits in
-  `claudeCredential.reason`, `docs/agent-setup.md` maps each to its fix,
-  and `claude-keychain: X -> Y` logs the transitions.
-
-- **`tools/snapshot.sh`** — one verified bundle of every ref, plus the
-  pseudo-refs `--all` does not cover (`ORIG_HEAD`, `MERGE_HEAD`, `FETCH_HEAD`
-  and the rest, per worktree, including the extra parents a multi-line one
-  holds), to run before anything that rewrites history. It refuses on a shallow clone, which is
-  the trap that nearly cost 433 commits during the work above:
-  `git rev-parse --is-shallow-repository` answers `true` when the clone *is*
-  truncated, and a bundle taken from it restores a fraction of the history
-  without complaining. It also refuses a destination inside the repository,
-  verifies what it wrote by reading it back, and deletes the file if
-  verification fails. Now a work rule in `AGENTS.md`. Written for BSD
-  userland as well as GNU: the first draft parsed worktrees with awk's
-  `RS="\0"`, trimmed with `head -c -1` and called `mktemp` without a
-  template — three things that work on Linux and none of which work on
-  macOS, the very machine where the rule makes the tool mandatory.
-
-- **`/repo-cleanup`** — a two-phase cleanup command. Phase one only produces
-  an evidence table with a keep-list and an uncertainty list; phase two
-  executes the approved subset, one commit per category with `./test/run.sh`
-  between. It encodes the traps that make this repository different: the
-  docs are load-bearing and asserted by tests, C symbols reach the build
-  through CMake and Kconfig rather than callers, and the committed fonts are
-  generated on purpose.
-
-- **The OTA rules now reach Codex.** `AGENTS.md` and `CLAUDE.md` are the same
-  rules for two different agents, and the section saying the maintenance
-  window opens only from the device, that the sender gates exist because a
-  stale build once froze the panel, and that the launchd service must be
-  restarted, was in only one of them.
-
-### Removed
-
-- **Eighteen concept-mockup SVGs** under `docs/img/mockups/`. Tracked output
-  nothing referenced — the documents link the `.png` beside each one — and
-  the two generators reproduce all eighteen byte-identically, verified by
-  running them and getting a clean `git status`. Now gitignored, the way
-  `platform/fonts/src/` is.
-
-### Fixed
-
 - **The OTA runbook told you the wrong gesture, on the terminal, while you
   stood at the panel.** `tools/ota-flash.sh` said "håll KEY3 ~3 s tills
   UPDATES ON-ringen syns" — in its header *and* in the line it prints while
@@ -358,141 +494,6 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   across several `echo` lines, and guards the Wi-Fi setup window as well as
   the update window.
 
-### Added
-
-- **`tools/snapshot.sh` has host tests, on macOS as well as Linux.** The
-  backup `AGENTS.md` makes mandatory before any history rewrite had no
-  coverage at all: no entry in `test/run.sh`, no test file, no shellcheck.
-  Three consecutive review rounds each found a real defect in that one file,
-  and every one was found by a reviewer building a repository shape by hand.
-  `test/test_snapshot_tool.py` now runs the tool against ten synthetic
-  repositories and asserts both the exit code and the published artifacts: an
-  ordinary repository publishes a `.bundle` plus its `.refs` sidecar at mode
-  0600 and clones back; a bare repository and a repository whose bundle
-  advertises no HEAD both exit 0; a shallow clone is refused with
-  `--unshallow` named; a destination inside a checkout is refused directly,
-  via `..`, via a linked worktree, and via a worktree whose path contains a
-  newline; a `prunable` registration neither refuses nor crashes; a run from a
-  linked worktree lands beside the **main** checkout; and a byte flipped in
-  the pack is caught — by the tool's own fetch into a temp bare repository,
-  because `git bundle verify` reads the header only and calls a corrupted
-  pack "okay".
-
-  The portability half is not decoration. Three of the five defects — `awk`
-  with NUL as `RS`, `head -c -1`, `mktemp` without a template — are invisible
-  on Linux, where GNU's tools do exactly what the script asks; they only bite
-  on the maintainer's own machine. A new `Snapshot tool` CI job therefore runs
-  the same file on `ubuntu-latest` **and** `macos-latest`, and the test carries
-  static guards for that class so a reintroduced GNU-ism goes red on ubuntu
-  the minute it is written. `shellcheck tools/snapshot.sh` runs alongside as a
-  complement, not a substitute: it flags neither `RS="\0"` nor a missing
-  `mktemp` template. Each of the five defects was reverted one at a time and
-  the test watched go red before this landed.
-
-- **The screenshots in `docs/img/` are checked against the simulator.**
-  `test/test_docs_frame_drift.py` compares every checked-in 480 × 480 frame
-  with what this build actually renders, and the answer is blunt: of
-  twenty-nine frames it can verify **four**. The Wi-Fi indicator was redrawn
-  in `d5be82d` — a thick white fan became a thin grey one — and most frames
-  still show the old glyph, so README, `docs/wifi.md` and the release bodies
-  have been showing a screen this firmware cannot produce. The four the
-  simulator reproduces exactly are pinned byte-for-byte and rejected if they
-  gain a colour profile or EXIF orientation, which would change what a
-  browser paints without changing a pixel. The other twenty-five are
-  quarantined by name *and* by a digest of the file — including eight whose
-  indicator box is simply blank, which proves nothing either way and had
-  been passing silently. Re-capturing them is a separate, deliberate
-  documentation change.
-- **`doctor` and Codex startup health now name a saved Codex mode that
-  silently prevents approvals from reaching the panel.** This is the failure
-  that looks exactly like a broken panel: the bridge is green, the panel
-  polls, and **APPROVE / DENY** never arrives — because `approval_policy =
-  "never"`, `approvals_reviewer = "auto_review"` or `sandbox_mode =
-  "danger-full-access"` means no permission event is ever created. The panel
-  cannot see a setting on the user's computer, so the host is the only place
-  that can say so, and the startup check now says it *before* reporting a
-  reachable service healthy. Reads the three mode names and nothing else in
-  the file, stops at the first table header so a value under `[profiles.x]`
-  is never read as a top-level one, and stays quiet when there is no
-  `config.toml` — most working installs have none, and a check that cries
-  wolf is skipped like any other. Rescued from
-  `niclas/wip/wifi-dma-calibration-20260904` before that branch is deleted.
-
-- **The KEY3 flow is tested as a journey, not only as a table.**
-  `test/test_key3_arbitration.c` pins eight invariants separately, which is
-  the right shape for them — but every cell in that table is set up by hand,
-  and a table where all cells pass says nothing about the *transitions*
-  between them. `test/test_key3_flow.c` walks one continuous trip through
-  the whole flow, feeding each tick's output back as the next tick's input
-  the way `main.c` does, and injects the events the button does not control
-  (the setup window opening itself, the notice arriving, windows expiring)
-  where they really occur. It also asserts no world state is a dead end.
-- **`docs/manual-test-key3.md`** — the short list of things only the panel
-  can settle, deliberately excluding everything already automated.
-- **Every permanent overlay now reports what it costs, on every boot.** The
-  three top-layer overlays — Wi-Fi setup, SETTINGS and the OTA ring — are
-  built once at start and kept for the whole run, and the AMOLED rule
-  forbids that without a measured memory budget. The measurement is now
-  automatic rather than remembered: each create is bracketed and logs
-  `overlaykostnad <name>: LVGL-pool +N B …, internt ±N B …`. Two numbers
-  because they answer different questions. LVGL's allocator pool is TLSF in
-  **PSRAM** (moved there as the 2026-08-16 freeze fix), so object trees come
-  out of its 256 KiB rather than internal RAM; the internal figure is the
-  control that shows whether a create takes internal memory anyway. A zero
-  delta retires the starvation worry for that layer with evidence instead of
-  argument, and a non-zero one puts the cost in the log.
-
-- A **SETTINGS** menu on a 3 s KEY3 hold. The hold used to derive which window
-  you wanted from whether the panel had an IP; it now opens a menu with
-  UPDATE, WIFI and ABOUT and lets you say. The consent model is unchanged —
-  the menu is reachable only from the device, so physical presence is still
-  required for UPDATE, and the token and the ten-minute window are untouched.
-  Without an address UPDATE is greyed out and cannot be picked, because an
-  update window with no address could never receive an upload; UPDATE is the
-  only row that goes dark, leaving WIFI as the one that can fix it, and the
-  address is live rather than a snapshot — lose Wi-Fi
-  while the menu is up and UPDATE greys out there and then, instead of
-  offering a window that could no longer receive anything. ABOUT shows the
-  firmware version and the address, with a dash for anything missing. There is
-  deliberately no "computer found" row: the only available signal is a boot
-  latch that never clears, so it would have read FOUND forever after one
-  fetch. Any KEY3 release closes the menu, the same escape the two windows
-  have. The menu and the UPDATE READY takeover are mutually exclusive: the
-  hold does nothing at all while that notice is up, and a notice that arrives
-  while the menu is open closes it. The notice is a UI state rather than an
-  open maintenance window, so without both edges the menu opened invisibly
-  behind it and reappeared on LATER. Answer the takeover with its own UPDATE
-  and LATER pills. Against everything else the menu keeps itself on top, which
-  it has to re-assert rather than inherit from creation order — the NO NETWORK
-  page redraws its countdown every second and lifts itself each time, and that
-  is precisely the state where the WIFI row is what you need. FEATURES and
-  PAIR from the design spec are not in this step: FEATURES needs the
-  internal-RAM budget re-measured on the unit, and PAIR belongs to a later
-  step.
-
-### Changed
-
-- KEY3's arbitration — which of the glass's owners gets the button on a given
-  tick — moved out of `main/main.c` into a pure `tg_button_arbitrate()` in
-  `platform/`, shared byte-identically by the panel and the simulator. It was
-  110 lines of decisions in the host layer that `sim/main.c` could not reach:
-  the simulator called `torget_settings_open()` directly during static QA, so
-  it was not the authority for the gesture, the escape, the intent handoff or
-  the asynchronous notice close, against `AGENTS.md` on both counts. Both hosts
-  now read inputs and apply outputs and decide nothing. No behaviour changed —
-  the point of the move is that the behaviour is now provable: the eight
-  invariants behind it, each with a real incident, are pinned as a table of
-  host tests rather than by reading source, including the notice close that
-  fires from `maintenance_ui_task()` with no button event to hang a test on.
-  The simulator drives the real gesture through `poll_keys()` (hold K for
-  three seconds), and the composite state where a notice arrives over an open
-  menu is captured at 480x480 for the first time. The consent model is
-  strengthened rather than restated: the arbitration reaches no service at all
-  and has no output that opens the maintenance window, so the only way there
-  remains a finger on the menu's UPDATE row.
-
-### Fixed
-
 - The WiFi setup QR no longer survives the window it belongs to. Only the
   OPEN branch of `torget_wifi_ui_set()` ever managed the canvas, and only
   `HIDDEN` ever cleared it, so every hop from OPEN to another *visible* state
@@ -507,6 +508,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   `wifi-open-to-searching`, which the existing `wifi-searching` frame could
   not catch — that one is taken before any OPEN state, so the canvas has
   never been populated at that point.
+
 - `test_mcp_recovers_after_absolute_drip_deadline` no longer flakes on the
   Windows CI runner. It bounded wall clock taken around `run_mcp()`, which
   spawns a Python subprocess, so interpreter startup counted against a budget
@@ -516,6 +518,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   did. The bound is tighter than before, not looser: the two request/response
   cycles run in ~0.13 s and the assertion trips at 0.4 s, so a lengthened or
   removed drip deadline still turns it red.
+
 - The same file's `run_script()` no longer times a Codex plugin script out
   after 4 seconds on a loaded CI runner. The budget is a hang guard, not a
   speed assertion — nothing overrides it and no test asserts that it fires —
@@ -523,6 +526,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   windows-latest it did not: `test_unicode_decision_is_emitted_as_utf8` timed
   out and passed on a second run of the same commit. It is now a named
   `SCRIPT_HANG_TIMEOUT_SECONDS = 30`, still verified to catch a wedged script.
+
 - `test_production_process_timeout_kills_reaps_and_recovers` no longer bounds a
   Windows-only subprocess spawn it never budgeted for. A sweep of every timed
   assertion CI runs on windows-latest found it: `_terminate_process_tree()`
@@ -534,6 +538,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   still turns red at 5.1 s if the deadline is lengthened. The sweep found
   nothing else: the other three process tests are POSIX-only, and every timed
   bound in the tokenserver modules is in-process.
+
 - `/api/tokens` no longer reports a Codex-only computer's Claude counters as
   measured zeros. A new additive `claudeSourcePresent` flag says when the
   Claude directory is absent, so the zeros are not mistaken for a day with no
@@ -541,6 +546,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   percentages already came over as `null` and rendered as dashes; this closes
   the same invariant at the API and log boundaries. Flashed panels are
   unaffected: unknown keys are skipped, and an absent flag means present.
+
 - The usage service now starts on a computer that has Codex but not Claude
   Code. Its readiness check waited — before binding the HTTP port — until
   `~/.claude/projects` existed, so on a Codex-only machine the port never
@@ -548,6 +554,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   it could not poll. Codex usage is read from `~/.codex/sessions` and does not
   need that directory at all. Either provider is now enough to start, and the
   service waits only when neither is present.
+
 - The tokenserver now drains an unread request body before an early
   rejection, so a real Windows hook client sees the `403`/`415`/`404` it was
   sent instead of a connection abort. Rejections on the headers alone (a
@@ -564,11 +571,13 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   drained only up to the cap, so an early rejection of an over-cap body can
   still abort on Windows. Draining without a bound would hand any peer a
   denial-of-service lever, so the residue is accepted rather than chased.
+
 - A successfully parsed ESP32 quota response now clears the transport-level
   `STALE` state synchronously, rather than waiting for a later LVGL timer tick.
   The refresh is deliberately unconditional so display and app bookkeeping
   self-heal if they drift apart. Sanitized serial logs now include the Claude,
   Fable, Codex, and Max Tracker stale bits carried by each accepted payload.
+
 - The wall-powered ESP32 now disables Wi-Fi modem sleep and carries a bounded
   VibePulse transport watchdog. After at least one good quota response, a
   still-associated panel with a configured numbers relay now recycles Wi-Fi at
@@ -577,6 +586,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   disarmed until a real success, preventing restart loops during upstream
   outages. Reusable encrypted relay clients are reset on every failure exit
   instead of retaining a half-open transport.
+
 - The VibePulse Codex plugin advances to `0.1.7`. Its bounded SessionStart
   check now classifies the local server, plugin/server source drift, provider
   freshness, saved Claude credential risk, and direct panel contact as
@@ -593,6 +603,7 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   troubleshooting flow now distinguishes the original credential incident
   from a fresh-source/ping-alive panel HTTP stall and describes the staged
   firmware recovery without claiming it has passed before physical proof.
+
 - The local VibePulse MCP bridge now accepts the bounded `_meta` request field
   emitted by current Codex clients during tool discovery and invocation, so
   the physical `APPROVE` question remains available instead of failing MCP
@@ -602,14 +613,25 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   recognized private runtime configuration without printing it, and performs
   a real `bootout` + `bootstrap` so launchd cannot retain an old worktree. A
   failed bootstrap restores and reloads the previous service configuration.
+
 - The LaunchAgent installer now retries only the short, observed post-`bootout`
   bootstrap race before rolling back; permanent failures remain fail-closed.
+
 - The ESP-IDF dependency lock now records the exact resolver result used by the
   verified ESP32-S3 build, keeping flash candidates reproducible and clean.
+
 - Windows Task Scheduler installations can now persist the optional public
   GitHub source, named Claude/Codex plan labels, and explicit per-provider
   subscription costs. The background service no longer drops the GitHub Stars
   or API-versus-subscription inputs that work in a foreground launch.
+
+### Removed
+
+- **Eighteen concept-mockup SVGs** under `docs/img/mockups/`. Tracked output
+  nothing referenced — the documents link the `.png` beside each one — and
+  the two generators reproduce all eighteen byte-identically, verified by
+  running them and getting a clean `git status`. Now gitignored, the way
+  `platform/fonts/src/` is.
 
 ## v1.0.0 — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ Both answers already exist, buried in a terminal you're not looking at.
 VibePulse moves them onto a screen you can't miss: one glance from across
 the room, no window to switch to, no menu bar to squint at.
 
-> **Status:** v1.0.0. The core shelf-screen loop is real and physically
+> **Status:** v1.1.0. The core shelf-screen loop is real and physically
 > exercised on macOS and Windows: see quota, see an agent waiting, and answer
-> a supported prompt on the glass. Windows core, physical answer loop, and
-> persistent sign-in/sleep/reboot lifecycle are verified. The project is still
-> active, optional integrations remain opt-in, and every platform claim stays
-> tied to its recorded evidence.
+> a supported prompt on the glass. The Windows core, physical answer loop and
+> persistent sign-in/sleep/reboot lifecycle were verified at the v1.0.0 host
+> runtime and are not re-claimed for a later one. v1.1.0 adds SETTINGS on
+> the glass, an honest warm-up, and crash evidence in the firmware; the
+> firmware side is CI-built and waits for the next flash session. Optional
+> integrations remain opt-in, and every platform claim stays tied to its
+> recorded evidence.
 
 ## Start here
 
@@ -62,39 +65,37 @@ Codex. You do not need to read this whole page:
    on-glass feature switches are specified but not built yet (see the spec
    in `docs/superpowers/specs/`). Sound has no verified backend yet.
 
-## Latest release: v1.0.0
+## Latest release: v1.1.0
 
-The first major release makes Windows a first-class VibePulse host and records
-the real physical proof: clean source, full tests, Task Scheduler plus
-watchdog, bounded logs, real Claude/Codex sources, Private-LAN reachability,
-recent panel polling, and a human **NEEDS YOU → APPROVE → Ja** round trip.
-The same panel can discover and fail over between advertising Mac and Windows
-hosts. The real Windows host also passed sign-out/sign-in, sleep/resume, and a
-full reboot without losing the scheduled service or leaving the panel stale.
-Silence and computer fallback are still never approval.
+The first release after 1.0 gives the panel a menu and a memory. A
+three-second **KEY3** hold opens **SETTINGS** on the glass (UPDATE, WIFI,
+ABOUT), so the maintenance window is chosen rather than guessed. The service
+answers the panel at once after a restart while the first history scan runs,
+labelling the volume counters as placeholders instead of letting the glass go
+STALE. A panic now leaves an ELF coredump in flash and a reboot ledger in
+NVS, every device poller backs off from a dead service, and the logging
+configuration is pinned by a configure-time guard. The host quarantines a
+corrupt state file instead of wiping it, says why the Claude probe is idle,
+names the keychain failure, typesets any model id, and the whole tokenserver
+directory now reads in English. Never a number it did not measure, still.
 
-### Windows v1 verification
+### v1.1.0 verification
 
 | Gate | Result |
 |---|---|
-| Clean host, complete tokenserver suite | **PASS** — 788 tests, 11 named skips, 0 failures/errors |
-| Task Scheduler, immediate start, exact-PID watchdog, bounded logs | **PASS** |
-| Real Claude/Codex sources, Private-only firewall, LAN and discovery | **PASS** |
-| Recent panel polling and **NEEDS YOU → APPROVE → Ja** | **PASS** |
-| Sign-out/sign-in, sleep/resume, full reboot | **PASS** |
-| Post-transition freshness | **PASS** — bounded convergence, then 12/12 fresh samples after sign-in and reboot |
-| Release/lifecycle PR CI and merged-main CI | **PASS** — 14/14 and 7/7 jobs |
+| Host gate (`./test/run.sh`), tokenserver suite on ubuntu, macOS and Windows, both Workers, snapshot tool | **PASS** on every merged PR and on merged `main` |
+| ESP32-S3 firmware build | **PASS** in CI — a build, not a flash |
+| SETTINGS, warm-up placeholders, coredump, reboot ledger, poller backoff on the physical panel | **NOT YET FLASHED** — `torget-home-01` runs `v1.0.0-25-g054db68`; the run sheet is [`docs/flash-session-2026-09.md`](docs/flash-session-2026-09.md) |
+| Windows v1 host claim (core, physical answer loop, lifecycle) | **Pinned to v1.0.0's runtime `bee5d8c`** — not re-run for this release |
 
-The tested host runtime was exact revision `bee5d8c`; tag `v1.0.0` resolves to
-`ab3ce92`, with documentation/tests only between them. The lifecycle evidence
-was merged to `main` at `4d1c47d`. This is exact-revision evidence: a future
-runtime change must pass the gate again.
+The coredump partition is new in the table, and OTA never writes the table:
+one USB `idf.py -p <port> partition-table-flash` is needed before a dump can
+land, and the boot log says so until then.
 
-[Read the v1.0.0 notes](docs/releases/2026-08-28-windows-joins-the-shelf.md)
-· [Full Windows evidence](docs/superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md)
-· [Verified merged-main CI](https://github.com/niclasvestlund-YT/vibepulse/actions/runs/33214257872)
+[Read the v1.1.0 notes](docs/releases/2026-09-10-settings-and-evidence.md)
+· [Windows v1 evidence](docs/superpowers/reviews/2026-08-28-windows-v1-full-lifecycle.md)
 · [Full changelog](CHANGELOG.md)
-· [Compare v0.7.1...v1.0.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v0.7.1...v1.0.0)
+· [Compare v1.0.0...v1.1.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v1.0.0...v1.1.0)
 
 Contributing or validating another host? Read
 [CONTRIBUTING.md](CONTRIBUTING.md), the

--- a/docs/releases/2026-09-10-settings-and-evidence.md
+++ b/docs/releases/2026-09-10-settings-and-evidence.md
@@ -1,0 +1,168 @@
+<!-- GitHub-ready v1.1.0 release body. Intentionally starts without an H1. -->
+
+VibePulse v1.1.0 gives the panel a menu and a memory. A three-second hold on
+the one user button opens **SETTINGS** on the glass, so the update window and
+the Wi-Fi setup are chosen rather than guessed from whether the panel happens
+to have an address. A service restart no longer sends the glass STALE for
+minutes: the first answer is immediate and says which numbers are still
+placeholders. And when the panel does crash, it now leaves evidence — a
+coredump in flash and a reboot ledger in NVS — instead of a backtrace on a
+serial console nobody had attached.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-menu.png" width="31%" alt="The SETTINGS menu on the panel: UPDATE, WIFI and ABOUT">
+  &nbsp;
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-no-address.png" width="31%" alt="The same menu on a panel with no network: UPDATE greyed out, WIFI live">
+  &nbsp;
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-about.png" width="31%" alt="The ABOUT page showing the firmware version and the panel's address">
+</p>
+
+## SETTINGS on the glass
+
+Hold **KEY3** for three seconds and a menu opens: **UPDATE** opens the
+ten-minute OTA maintenance window, **WIFI** opens the phone-first setup
+window, **ABOUT** shows the firmware version and the address. Without an
+address UPDATE is greyed out — a window with no address could never receive
+an upload — and the address is live, so losing Wi-Fi while the menu is up
+greys it out there and then. Any KEY3 release closes the menu, the same
+escape the two windows already had.
+
+The consent model is unchanged: the menu is reachable only from the device,
+the token and the ten-minute window are untouched, and the menu and the
+**UPDATE READY** takeover are mutually exclusive so the menu can never open
+behind something you cannot see. The button arbitration that decides all of
+this moved into pure platform code shared byte-identically by the panel and
+the simulator, and it is pinned by a table of eight invariants plus one
+continuous journey test. The OTA runbooks and `tools/ota-flash.sh` now say
+the right gesture — they used to tell you to wait for a ring that never came.
+
+## An honest warm-up
+
+The tokenserver's first history scan used to run under the cache lock, so
+every `/api/tokens` request queued behind it; on a Mac with a large history
+the scan took 211 s, the panel's polls timed out one after another, and the
+glass went STALE two minutes into every restart of a healthy service
+(issue #62). The first request now answers at once. The scan runs in the
+background, and the response carries live quota percentages plus a new
+additive `usageTotals` block that says what the four volume counters are:
+`refreshing` (placeholders), `ready`, or `failing` (the recompute is crashing
+and the measurement is not coming).
+
+Placeholders reach only a client that says it understands them
+(`X-VibePulse-Accepts: usage-totals`); everyone else gets the contract's
+error form, which already-flashed firmware rejects by design. New firmware
+sends the header, applies the live quota rings, and leaves the value page and
+the keep-awake burn rate alone until the counters are measured. Never
+invented zeros; counters never go backwards.
+
+## Evidence after a crash
+
+**Built in CI, not yet flashed or physically verified.** The panel on the
+shelf still runs `v1.0.0-25-g054db68`; the run sheet for bringing it up is
+`docs/flash-session-2026-09.md`, and that session is the physical gate for
+everything in this section.
+
+- A 128K `coredump` partition holds an ELF dump of every task's stack from
+  the last panic; the next boot logs `coredump i flash … idf.py coredump-info`
+  when one is there. The partition row is appended after `ota_1` in free
+  flash, and OTA never writes the table, so one USB
+  `idf.py -p <port> partition-table-flash` is needed before a dump can land.
+  The boot log says so until then.
+- A reboot ledger in NVS: `omstartsliggare: boot #N …; efter PANIK a,
+  vakthund b, BROWNOUT c`, right after the boot banner, counted since the
+  ledger was initialized or NVS last erased. "Did it reboot while I was
+  away?" is one serial line.
+- `sdkconfig.defaults` pins the log level (INFO, which compiles `ESP_LOGD`
+  and the `HTTP_CLIENT` request-line leak out structurally), panic
+  print-and-reboot, the warn-only task watchdog with its idle-task
+  subscriptions, and LVGL's own log at WARN. Because defaults never migrate a
+  stale generated `sdkconfig`, a configure-time guard refuses to build blind
+  and names the missing values and the fix.
+- Every device poller backs off from a dead service instead of hammering it:
+  first miss at the normal cadence, then doubling to a cap (agent status
+  1 → 30 s, tokens 30 → 300 s, Max Tracker 5 → 30 min, GitHub 30 → 300 s),
+  reset on the first success, transitions logged. A response the screen
+  cannot apply counts as a miss too.
+- Every permanent overlay logs what it costs in LVGL-pool and internal RAM
+  on every boot, so the AMOLED memory budget is measured rather than
+  remembered.
+
+## The host got harder to fool
+
+- A corrupt state file (`max-tracker.json` with up to 400 days of history,
+  `quota-cache.json`, `usage-history.json`) is moved aside as
+  `<name>.corrupt-<UTC stamp>` and logged, never silently wiped by the next
+  save; all three writers now fsync the parent directory.
+- `GET /` says why the Claude probe is idle — streak, interval, seconds left
+  of a 429 rest, age of the last cycle — assembled per cycle and published
+  under one lock, so it never reads half-built. On macOS a missing token
+  carries the keychain's own word (`keychain_denied_or_locked (exit N)`,
+  `keychain_no_entry`, `keychain_timeout`, …) and `docs/agent-setup.md` maps
+  each to its fix.
+- Agent rows typeset any model id on arrival (`HAIKU 4.5`, `GPT-5.4 MINI`,
+  `MYTHOS PREVIEW`) instead of clipping unknown ids mid-string, and `effort`
+  is read from where Claude Code actually writes it.
+- The panel no longer prints the relay's secret URL on a failed cloud fetch;
+  failure lines name a redacted target. A photo in `docs/img/` that carried
+  GPS coordinates was re-encoded without them.
+- `ruff` runs first in the host gate with bug-shaped rules only; the first
+  sweep found 43 things, including a backfill loop that swallowed every
+  exception.
+- `tools/snapshot.sh` bundles every ref before any history rewrite, tested
+  on macOS as well as Linux; `/repo-cleanup` proposes deletions with
+  evidence before touching anything; `doctor` names a saved Codex mode that
+  silently prevents approvals from reaching the panel.
+
+## The tokenserver speaks English
+
+Everything under `tools/tokenserver/` — modules, tests, the smoke test, the
+README, the launchd plist and the Windows installer — is translated (issue
+#12). Runtime keys, persisted file formats, API fields and exit codes are
+byte-identical. Log signatures moved with it; if you grep the service log,
+update these:
+
+| Before | After |
+|---|---|
+| `startar: rev` | `starting: rev` |
+| `förstaskanning …` | `first scan …` |
+| `serverar http://…` | `serving http://…` |
+| `500 på /api/…` | `500 on /api/…` |
+| `usage-omräkningen kraschade` / `frisk igen` | `usage recompute crashed` / `healthy again` |
+| `hittar varken … finns Claude Code …` | `found neither … is Claude Code or Codex on this machine?` |
+| smoke `[VARN]`, `röktest: …` | `[WARN]`, `smoke test: N ok, N warnings, N failures` |
+
+The smoke test and the runbook's comb step count both the old and the new
+start line, because the log outlives an upgrade.
+
+## What was not re-verified
+
+- The Windows v1 host claim (core service, physical answer loop, sign-in,
+  sleep and reboot lifecycle) is pinned to the v1.0.0 runtime `bee5d8c` and
+  is **not inherited** by this release's host code. The
+  [Windows validation procedure](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/windows-validation.md)
+  still describes how to earn it again.
+- The firmware changes above are CI-built only. Nothing in this release was
+  flashed to a panel.
+
+## Upgrade
+
+```sh
+git fetch --tags origin
+git switch --detach v1.1.0
+python3 tools/vibepulse_setup.py status
+```
+
+Restart the host service so it runs this code (macOS:
+`launchctl kickstart -k gui/$(id -u)/se.torget.tokenserver`; Windows: stop
+and start the `VibePulse tokenserver` scheduled task as
+`docs/windows-setup.md` describes), then run
+`python3 tools/tokenserver/smoke.py`. Firmware goes through the existing
+consent-gated OTA path; the coredump partition additionally needs the one-time
+USB partition-table flash named above.
+
+This release remains source-only. **Do not attach `torget.bin`**: every local
+firmware build contains that installation's Wi-Fi credentials and may contain
+its private device key.
+
+Full history:
+[v1.0.0...v1.1.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v1.0.0...v1.1.0).

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1782,15 +1782,54 @@ class PluginPackageTests(unittest.TestCase):
         self.assertNotIn("eventual `v0.7.1` tag", release)
 
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("## Latest release: v1.0.0", readme)
-        self.assertIn("Compare v0.7.1...v1.0.0", readme)
-        self.assertIn("### Windows v1 verification", readme)
-        self.assertIn("788 tests, 11 named skips, 0 failures/errors", readme)
-        self.assertIn("14/14 and 7/7 jobs", readme)
+        self.assertIn("## Latest release: v1.1.0", readme)
+        self.assertIn("Compare v1.0.0...v1.1.0", readme)
+        self.assertIn("### v1.1.0 verification", readme)
         self.assertIn("windows-v1-full-lifecycle.md", readme)
         self.assertNotIn(
             "latest sanitized checkpoint is explicitly\n"
             "  **[PARTIAL]", readme)
+
+    def test_v110_release_is_honest_about_unflashed_firmware(self):
+        release = (ROOT / "docs/releases/"
+                   "2026-09-10-settings-and-evidence.md").read_text(
+                       encoding="utf-8")
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        self.assertFalse(release.lstrip().startswith("# "))
+        for required in (
+                "VibePulse v1.1.0", "SETTINGS on the glass",
+                "An honest warm-up", "Evidence after a crash",
+                "not yet flashed or physically verified",
+                "v1.0.0-25-g054db68", "partition-table-flash",
+                "What was not re-verified", "bee5d8c", "not inherited",
+                "source-only", "Do not attach `torget.bin`",
+                "v1.0.0...v1.1.0", "serving http://", "usage recompute crashed"):
+            self.assertIn(required, release)
+        for image in (
+                "vibepulse-settings-menu.png",
+                "vibepulse-settings-no-address.png",
+                "vibepulse-settings-about.png"):
+            self.assertIn(
+                "https://raw.githubusercontent.com/"
+                "niclasvestlund-YT/vibepulse/v1.1.0/docs/img/" + image,
+                release)
+        # The README's release section carries the same evidence boundary.
+        self.assertIn("NOT YET FLASHED", readme)
+        self.assertIn("Pinned to v1.0.0's runtime `bee5d8c`", readme)
+        self.assertIn("## v1.1.0 — 2026-09-10", changelog)
+        self.assertIn("2026-09-10-settings-and-evidence.md", changelog)
+        self.assertLess(changelog.index("## Unreleased"),
+                        changelog.index("## v1.1.0"))
+        self.assertLess(changelog.index("## v1.1.0"),
+                        changelog.index("## v1.0.0"))
+        # The cut left nothing behind: Unreleased is empty until the next change.
+        between = changelog[changelog.index("## Unreleased"):
+                            changelog.index("## v1.1.0")]
+        self.assertEqual(between.strip(), "## Unreleased")
+        for forbidden in ("oauth token:", "refresh token:",
+                          "account id:", "relay address:"):
+            self.assertNotIn(forbidden, release.lower())
 
     def test_v100_release_is_major_windows_honest_and_source_only(self):
         release = (ROOT / "docs/releases/"


### PR DESCRIPTION
## Outcome

The documentation cut for **v1.1.0 — SETTINGS on the glass, evidence after a crash**, done the way v1.0.0 was (#48): no code changes, so the tag can be placed on the squash of this PR.

- `CHANGELOG.md`: everything under `Unreleased` moved into `## v1.1.0 — 2026-09-10` with one heading per kind (Added, Changed, Fixed, Removed; the section had accumulated duplicate headings from months of merges). 45 entries before, 45 after, text untouched. A new empty `## Unreleased` sits on top, and the version header links the release notes.
- `docs/releases/2026-09-10-settings-and-evidence.md`: the GitHub-ready body. Plain intro paragraph, no H1, three 480×480 SETTINGS frames via absolute `raw.githubusercontent.com/…/v1.1.0/…` URLs, sections for SETTINGS, the honest warm-up (#62), the crash evidence (coredump, reboot ledger, poller backoff, pinned logging), host hardening, the English tokenserver with a before/after table of renamed log signatures, an explicit **What was not re-verified** section, upgrade steps, source-only / never attach `torget.bin`, compare link.
- `README.md`: the status blurb and the `Latest release` section now say v1.1.0, with a verification table that names the evidence honestly: CI green on every merged PR, firmware **built but not flashed** (`torget-home-01` still runs `v1.0.0-25-g054db68`, run sheet `docs/flash-session-2026-09.md`), and the Windows v1 host claim **pinned to `bee5d8c`**, not inherited.
- `AGENTS.md`: the status heading and a paragraph for v1.1.0 with the same boundary, in the section's Swedish.
- `test/test_vibepulse_codex_plugin.py`: the README pins move to v1.1.0, and `test_v110_release_is_honest_about_unflashed_firmware` pins the body's sections, image URLs, the evidence boundary in the README, the changelog order, and that `Unreleased` is empty after the cut.

## Root cause / rationale

Main is 86 commits and eight merged feature PRs past v1.0.0 with a full Unreleased section. The repo's release rule (AGENTS.md, CLAUDE.md) requires the changelog cut, the README's Latest release and the `docs/releases/` body in the same effort as the tag, and a release whose changelog still calls its features unreleased is not a finished release.

## Verification

- [x] Relevant focused tests pass: `test/test_vibepulse_codex_plugin.py` (140 tests), `test/test_docs_frame_drift.py`, `test/test_ota_gesture_docs.py`, `tools.tokenserver.test_smoke`; `ruff check .` clean.
- [x] New tests are registered in the host runner and relevant CI steps — the new test lives in a file the host gate already runs.
- [x] `./test/run.sh` — documentation-only change; CI's host gate runs it on this PR.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included; the release body says never to attach one.
- [x] Documentation and changelog match the behavior: the body and README claim only CI evidence for firmware and pin the Windows claim to the v1.0.0 runtime.

### Platform claims

- [x] This does not change a platform support claim. The Windows v1 claim is explicitly not re-claimed for the new host code.
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass.

### Hardware / UI

- [x] No hardware or UI behavior changed. The three frames in the body are the existing simulator captures already in `docs/img/`.
- [x] No physical flash.

## Not tested / remaining risk

- **The tag is yours to place.** After the squash merge: `git tag -a v1.1.0 -m "VibePulse v1.1.0" <merge sha> && git push origin v1.1.0`, then create the GitHub release from `docs/releases/2026-09-10-settings-and-evidence.md`. The image URLs only resolve once the tag exists.
- If you would rather flash first and release after, the body already states the boundary either way; only the README table row and the body's "not yet flashed" section would change after a physical pass.
- The repo's Social preview (Settings → Social preview) is the one shared-link image; refresh it if you consider SETTINGS a major feature. Not possible from here.
- `docs/windows-validation.md` still checks out `v1.0.0` as the exact validated candidate; left as is on purpose, since that is the runtime the evidence belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh7FPTJW5h8emjn4hzMdk4)_