### PR TITLE
docs: scope physical screenshot evidence before v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,8 +792,13 @@ Same code, same fonts, same pixels as the device — it builds the real
 platform and VibePulse against the real LVGL, and feeds it the recorded
 fixtures in `sim-fixtures/` through the same parsers the board runs. Every
 device screenshot in this README is an unmodified simulator frame (the
-banner just places three of them side by side), and the physical panel was
-reviewed against them ([review](docs/superpowers/reviews/2026-08-13-max-tracker-physical-static.md)).
+banner just places three of them side by side). The
+[2026-08-13 physical review](docs/superpowers/reviews/2026-08-13-max-tracker-physical-static.md)
+covered the quota pages, agent monitor states and Max Tracker pages in that
+build. It does not verify later screenshots or firmware: the v1.1.0 SETTINGS
+frames are simulator evidence only, and the firmware changes in this release
+remain CI-built and **not flashed** on `torget-home-01`, which still runs
+`v1.0.0-25-g054db68`.
 
 Keys: `[` / `]` change VibePulse page, `S` cycles agent status, `M` cycles
 Max Tracker fixtures, `T` re-feeds tokens, `G` simulates a new GitHub star,


### PR DESCRIPTION
The simulator section of README said the physical panel had been reviewed against every displayed screenshot, linking to the August 13 review. With the new SETTINGS frames, that implied physical evidence the v1.1.0 firmware does not have.

Scope that review to the quota pages, agent monitor states and Max Tracker pages in the recorded build. Explicitly identify the SETTINGS frames as simulator evidence and retain the CI-built, not-flashed boundary and `torget-home-01`'s installed `v1.0.0-25-g054db68` revision. The release body, changelog, Windows `bee5d8c` evidence boundary, and runtime code are unchanged.

Release review: all 45 pre-cut changelog entries are preserved under v1.1.0, Unreleased is empty, the three release images exist at 480×480 with absolute tag-pinned URLs, the compare link is v1.0.0...v1.1.0, and README's Latest release file links resolve. PR #113's merged-main CI run [34467928777](https://github.com/niclasvestlund-YT/vibepulse/actions/runs/34467928777) passed all nine jobs.

Validation: `ruff check .`, `python3 test/test_vibepulse_codex_plugin.py` (140 tests), `python3 test/test_docs_frame_drift.py` (15 tests), and `python3 test/test_ota_gesture_docs.py` (7 tests), using Python 3.12 and the pinned development dependencies. No device was flashed and no firmware binary is included. Publish v1.1.0 only after this PR is merged and CI passes for the resulting main commit.
