### PR TITLE
docs: polish the v1.1.0 release notes

### DIFF
--- a/docs/releases/2026-09-10-settings-and-evidence.md
+++ b/docs/releases/2026-09-10-settings-and-evidence.md
@@ -1,150 +1,44 @@
-<!-- GitHub-ready v1.1.0 release body. Intentionally starts without an H1. -->
+VibePulse v1.1.0 adds on-screen settings, keeps live quotas available while usage history loads, and makes failures easier to diagnose.
 
-VibePulse v1.1.0 gives the panel a menu and a memory. A three-second hold on
-the one user button opens **SETTINGS** on the glass, so the update window and
-the Wi-Fi setup are chosen rather than guessed from whether the panel happens
-to have an address. A service restart no longer sends the glass STALE for
-minutes: the first answer is immediate and says which numbers are still
-placeholders. And when the panel does crash, it now leaves evidence — a
-coredump in flash and a reboot ledger in NVS — instead of a backtrace on a
-serial console nobody had attached.
+> **Verification status:** The new firmware is CI-built, **not yet flashed or physically verified**. `torget-home-01` still runs `v1.0.0-25-g054db68`. The Windows v1 host claim — core service, physical answer loop, and sign-in/sleep/reboot lifecycle — remains pinned to the v1.0.0 runtime `bee5d8c` and is **not inherited** by v1.1.0.
+
+## Settings from the panel
+
+Hold **KEY3** for three seconds to open **SETTINGS**:
+
+- **UPDATE** opens the ten-minute firmware update window.
+- **WIFI** starts setup so you can connect the panel using your phone.
+- **ABOUT** shows the firmware version and network address.
+
+UPDATE is disabled when the panel has no network address; WIFI stays available to help you connect. A short KEY3 press closes the menu. Opening a maintenance window still requires interaction on the device.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-menu.png" width="31%" alt="The SETTINGS menu on the panel: UPDATE, WIFI and ABOUT">
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-menu.png" width="40%" alt="Simulator: SETTINGS with UPDATE, WIFI and ABOUT available">
   &nbsp;
-  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-no-address.png" width="31%" alt="The same menu on a panel with no network: UPDATE greyed out, WIFI live">
-  &nbsp;
-  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-about.png" width="31%" alt="The ABOUT page showing the firmware version and the panel's address">
+  <img src="https://raw.githubusercontent.com/niclasvestlund-YT/vibepulse/v1.1.0/docs/img/vibepulse-settings-no-address.png" width="40%" alt="Simulator: SETTINGS without a network address; UPDATE is disabled and WIFI remains available">
 </p>
+<p align="center"><em>Simulator captures: connected (left), no network address (right).</em></p>
 
-## SETTINGS on the glass
+## Live quotas while history loads
 
-Hold **KEY3** for three seconds and a menu opens: **UPDATE** opens the
-ten-minute OTA maintenance window, **WIFI** opens the phone-first setup
-window, **ABOUT** shows the firmware version and the address. Without an
-address UPDATE is greyed out — a window with no address could never receive
-an upload — and the address is live, so losing Wi-Fi while the menu is up
-greys it out there and then. Any KEY3 release closes the menu, the same
-escape the two windows already had.
+Restarting the host service used to leave the panel waiting while a large usage history was scanned. The service now answers immediately and loads that history in the background.
 
-The consent model is unchanged: the menu is reachable only from the device,
-the token and the ten-minute window are untouched, and the menu and the
-**UPDATE READY** takeover are mutually exclusive so the menu can never open
-behind something you cannot see. The button arbitration that decides all of
-this moved into pure platform code shared byte-identically by the panel and
-the simulator, and it is pinned by a table of eight invariants plus one
-continuous journey test. The OTA runbooks and `tools/ota-flash.sh` now say
-the right gesture — they used to tell you to wait for a ring that never came.
+With the updated firmware, live quota rings can refresh during that scan. Volume counters remain placeholders until measured, so an unfinished scan cannot turn into misleading zeros. Existing firmware keeps its last good values and may still show **STALE** during startup; the improved display behaviour requires the firmware update.
 
-## An honest warm-up
+## Clearer diagnostics and recovery
 
-The tokenserver's first history scan used to run under the cache lock, so
-every `/api/tokens` request queued behind it; on a Mac with a large history
-the scan took 211 s, the panel's polls timed out one after another, and the
-glass went STALE two minutes into every restart of a healthy service
-(issue #62). The first request now answers at once. The scan runs in the
-background, and the response carries live quota percentages plus a new
-additive `usageTotals` block that says what the four volume counters are:
-`refreshing` (placeholders), `ready`, or `failing` (the recompute is crashing
-and the measurement is not coming).
+The new firmware adds a **coredump partition** for crash evidence and a **reboot ledger** in NVS to record restarts. Poller backoff reduces repeated requests to an unavailable service, and pinned logging settings keep diagnostics consistent across builds. These changes share the unflashed status above.
 
-Placeholders reach only a client that says it understands them
-(`X-VibePulse-Accepts: usage-totals`); everyone else gets the contract's
-error form, which already-flashed firmware rejects by design. New firmware
-sends the header, applies the live quota rings, and leaves the value page and
-the keep-awake burn rate alone until the counters are measured. Never
-invented zeros; counters never go backwards.
+The host also gets several practical improvements:
 
-## Evidence after a crash
-
-**Built in CI, not yet flashed or physically verified.** The panel on the
-shelf still runs `v1.0.0-25-g054db68`; the run sheet for bringing it up is
-`docs/flash-session-2026-09.md`, and that session is the physical gate for
-everything in this section.
-
-- A 128K `coredump` partition holds an ELF dump of every task's stack from
-  the last panic; the next boot logs `coredump i flash … idf.py coredump-info`
-  when one is there. The partition row is appended after `ota_1` in free
-  flash, and OTA never writes the table, so one USB
-  `idf.py -p <port> partition-table-flash` is needed before a dump can land.
-  The boot log says so until then.
-- A reboot ledger in NVS: `omstartsliggare: boot #N …; efter PANIK a,
-  vakthund b, BROWNOUT c`, right after the boot banner, counted since the
-  ledger was initialized or NVS last erased. "Did it reboot while I was
-  away?" is one serial line.
-- `sdkconfig.defaults` pins the log level (INFO, which compiles `ESP_LOGD`
-  and the `HTTP_CLIENT` request-line leak out structurally), panic
-  print-and-reboot, the warn-only task watchdog with its idle-task
-  subscriptions, and LVGL's own log at WARN. Because defaults never migrate a
-  stale generated `sdkconfig`, a configure-time guard refuses to build blind
-  and names the missing values and the fix.
-- Every device poller backs off from a dead service instead of hammering it:
-  first miss at the normal cadence, then doubling to a cap (agent status
-  1 → 30 s, tokens 30 → 300 s, Max Tracker 5 → 30 min, GitHub 30 → 300 s),
-  reset on the first success, transitions logged. A response the screen
-  cannot apply counts as a miss too.
-- Every permanent overlay logs what it costs in LVGL-pool and internal RAM
-  on every boot, so the AMOLED memory budget is measured rather than
-  remembered.
-
-## The host got harder to fool
-
-- A corrupt state file (`max-tracker.json` with up to 400 days of history,
-  `quota-cache.json`, `usage-history.json`) is moved aside as
-  `<name>.corrupt-<UTC stamp>` and logged, never silently wiped by the next
-  save; all three writers now fsync the parent directory.
-- `GET /` says why the Claude probe is idle — streak, interval, seconds left
-  of a 429 rest, age of the last cycle — assembled per cycle and published
-  under one lock, so it never reads half-built. On macOS a missing token
-  carries the keychain's own word (`keychain_denied_or_locked (exit N)`,
-  `keychain_no_entry`, `keychain_timeout`, …) and `docs/agent-setup.md` maps
-  each to its fix.
-- Agent rows typeset any model id on arrival (`HAIKU 4.5`, `GPT-5.4 MINI`,
-  `MYTHOS PREVIEW`) instead of clipping unknown ids mid-string, and `effort`
-  is read from where Claude Code actually writes it.
-- The panel no longer prints the relay's secret URL on a failed cloud fetch;
-  failure lines name a redacted target. A photo in `docs/img/` that carried
-  GPS coordinates was re-encoded without them.
-- `ruff` runs first in the host gate with bug-shaped rules only; the first
-  sweep found 43 things, including a backfill loop that swallowed every
-  exception.
-- `tools/snapshot.sh` bundles every ref before any history rewrite, tested
-  on macOS as well as Linux; `/repo-cleanup` proposes deletions with
-  evidence before touching anything; `doctor` names a saved Codex mode that
-  silently prevents approvals from reaching the panel.
-
-## The tokenserver speaks English
-
-Everything under `tools/tokenserver/` — modules, tests, the smoke test, the
-README, the launchd plist and the Windows installer — is translated (issue
-#12). Runtime keys, persisted file formats, API fields and exit codes are
-byte-identical. Log signatures moved with it; if you grep the service log,
-update these:
-
-| Before | After |
-|---|---|
-| `startar: rev` | `starting: rev` |
-| `förstaskanning …` | `first scan …` |
-| `serverar http://…` | `serving http://…` |
-| `500 på /api/…` | `500 on /api/…` |
-| `usage-omräkningen kraschade` / `frisk igen` | `usage recompute crashed` / `healthy again` |
-| `hittar varken … finns Claude Code …` | `found neither … is Claude Code or Codex on this machine?` |
-| smoke `[VARN]`, `röktest: …` | `[WARN]`, `smoke test: N ok, N warnings, N failures` |
-
-The smoke test and the runbook's comb step count both the old and the new
-start line, because the log outlives an upgrade.
-
-## What was not re-verified
-
-- The Windows v1 host claim (core service, physical answer loop, sign-in,
-  sleep and reboot lifecycle) is pinned to the v1.0.0 runtime `bee5d8c` and
-  is **not inherited** by this release's host code. The
-  [Windows validation procedure](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/windows-validation.md)
-  still describes how to earn it again.
-- The firmware changes above are CI-built only. Nothing in this release was
-  flashed to a panel.
+- Corrupt usage-history files are preserved for recovery instead of silently overwritten.
+- Claude credential errors and probe status give clearer explanations when data is unavailable.
+- Agent rows display readable model names and the recorded effort level.
+- Tokenserver logs, help, installer messages and documentation now read in English. Update any saved log searches; the [observability guide](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/observability.md) lists the current signatures.
 
 ## Upgrade
+
+In the checkout used by your host service:
 
 ```sh
 git fetch --tags origin
@@ -152,17 +46,10 @@ git switch --detach v1.1.0
 python3 tools/vibepulse_setup.py status
 ```
 
-Restart the host service so it runs this code (macOS:
-`launchctl kickstart -k gui/$(id -u)/se.torget.tokenserver`; Windows: stop
-and start the `VibePulse tokenserver` scheduled task as
-`docs/windows-setup.md` describes), then run
-`python3 tools/tokenserver/smoke.py`. Firmware goes through the existing
-consent-gated OTA path; the coredump partition additionally needs the one-time
-USB partition-table flash named above.
+Restart the service to load the new code: on macOS, run `launchctl kickstart -k gui/$(id -u)/se.torget.tokenserver`; on Windows, follow the [stop, wait, then start instructions](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/windows-setup.md#restarting-the-scheduled-task). Then run `python3 tools/tokenserver/smoke.py` to check the running service.
 
-This release remains source-only. **Do not attach `torget.bin`**: every local
-firmware build contains that installation's Wi-Fi credentials and may contain
-its private device key.
+Firmware installation remains a separate, explicitly authorized step. Follow the [flash-session run sheet](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/flash-session-2026-09.md). The coredump partition also needs a one-time USB `partition-table-flash`: OTA does not update the partition table.
 
-Full history:
-[v1.0.0...v1.1.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v1.0.0...v1.1.0).
+This release is **source-only**. **Do not attach `torget.bin`**: local firmware builds contain Wi-Fi credentials and may contain a private device key.
+
+[Full changelog](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/CHANGELOG.md) · [Compare v1.0.0...v1.1.0](https://github.com/niclasvestlund-YT/vibepulse/compare/v1.0.0...v1.1.0) · [Windows validation procedure](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/windows-validation.md)

--- a/docs/releases/2026-09-10-settings-and-evidence.md
+++ b/docs/releases/2026-09-10-settings-and-evidence.md
@@ -48,7 +48,7 @@ python3 tools/vibepulse_setup.py status
 
 Restart the service to load the new code: on macOS, run `launchctl kickstart -k gui/$(id -u)/se.torget.tokenserver`; on Windows, follow the [stop, wait, then start instructions](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/windows-setup.md#restarting-the-scheduled-task). Then run `python3 tools/tokenserver/smoke.py` to check the running service.
 
-Firmware installation remains a separate, explicitly authorized step. Follow the [flash-session run sheet](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/flash-session-2026-09.md). The coredump partition also needs a one-time USB `partition-table-flash`: OTA does not update the partition table.
+Firmware installation remains a separate, explicitly authorized step. Follow the [flash-session run sheet](https://github.com/niclasvestlund-YT/vibepulse/blob/v1.1.0/docs/flash-session-2026-09.md), but replace the run sheet's `main` checkout with `git switch --detach v1.1.0` so you build this release. The coredump partition also needs a one-time USB `partition-table-flash`: OTA does not update the partition table.
 
 This release is **source-only**. **Do not attach `torget.bin`**: local firmware builds contain Wi-Fi credentials and may contain a private device key.
 

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1796,24 +1796,32 @@ class PluginPackageTests(unittest.TestCase):
                        encoding="utf-8")
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
         changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-        self.assertFalse(release.lstrip().startswith("# "))
+        self.assertTrue(release.startswith("VibePulse v1.1.0"))
+        self.assertIsNone(re.search(r"^# ", release, re.MULTILINE))
         for required in (
-                "VibePulse v1.1.0", "SETTINGS on the glass",
-                "An honest warm-up", "Evidence after a crash",
-                "not yet flashed or physically verified",
-                "v1.0.0-25-g054db68", "partition-table-flash",
-                "What was not re-verified", "bee5d8c", "not inherited",
+                "Settings from the panel", "Live quotas while history loads",
+                "Clearer diagnostics and recovery", "coredump partition",
+                "reboot ledger", "Poller backoff", "pinned logging",
+                "CI-built", "not yet flashed or physically verified",
+                "torget-home-01", "v1.0.0-25-g054db68", "partition-table-flash",
+                "bee5d8c", "not inherited", "Simulator captures",
                 "source-only", "Do not attach `torget.bin`",
-                "v1.0.0...v1.1.0", "serving http://", "usage recompute crashed"):
+                "v1.0.0...v1.1.0", "docs/observability.md"):
             self.assertIn(required, release)
+        # The evidence boundary precedes every feature and screenshot.
+        opening = release.split("\n## ", 1)[0]
+        for boundary in ("CI-built", "not yet flashed or physically verified",
+                         "v1.0.0-25-g054db68", "bee5d8c", "not inherited"):
+            self.assertIn(boundary, opening)
         for image in (
                 "vibepulse-settings-menu.png",
-                "vibepulse-settings-no-address.png",
-                "vibepulse-settings-about.png"):
+                "vibepulse-settings-no-address.png"):
             self.assertIn(
                 "https://raw.githubusercontent.com/"
                 "niclasvestlund-YT/vibepulse/v1.1.0/docs/img/" + image,
                 release)
+        # The ABOUT fixture displays an older sample firmware version.
+        self.assertNotIn("vibepulse-settings-about.png", release)
         # The README's release section carries the same evidence boundary.
         self.assertIn("NOT YET FLASHED", readme)
         self.assertIn("Pinned to v1.0.0's runtime `bee5d8c`", readme)

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -1806,7 +1806,9 @@ class PluginPackageTests(unittest.TestCase):
                 "torget-home-01", "v1.0.0-25-g054db68", "partition-table-flash",
                 "bee5d8c", "not inherited", "Simulator captures",
                 "source-only", "Do not attach `torget.bin`",
-                "v1.0.0...v1.1.0", "docs/observability.md"):
+                "v1.0.0...v1.1.0", "docs/observability.md",
+                "replace the run sheet's `main` checkout with "
+                "`git switch --detach v1.1.0`"):
             self.assertIn(required, release)
         # The evidence boundary precedes every feature and screenshot.
         opening = release.split("\n## ", 1)[0]


### PR DESCRIPTION
The published v1.1.0 notes buried the firmware verification boundary beneath lengthy engineering detail, and the ABOUT screenshot displayed an older sample firmware version. Rewrite the announcement around three user-facing highlights: settings, live quotas during startup, and clearer diagnostics.

Reduce the notes from roughly 1,375 words to 500, move the unflashed firmware and revision-bound Windows evidence to the opening, and show two explicitly labelled simulator captures. Link to the changelog and observability guide for implementation detail. Keep practical host restart instructions, the separate firmware authorization step, the USB partition-table requirement, and the source-only restriction.

Update the existing release-note regression check for the revised headings and image selection while retaining its evidence assertions. It now also requires the verification boundary before the feature sections and prevents the older-version ABOUT fixture from returning.

The firmware upgrade explicitly replaces the linked run sheet's `main` checkout with `git switch --detach v1.1.0`, so following the release instructions cannot silently select newer firmware. The existing release regression check pins this instruction; its targeted case and the OTA gesture suite pass after the correction.

Validation: `ruff check .`; `python3 test/test_vibepulse_codex_plugin.py` (140 tests); `python3 test/test_docs_frame_drift.py` (15 tests); `python3 test/test_ota_gesture_docs.py` (7 tests). Every linked file exists at `v1.1.0`.

This is an editorial update to an already published release. After merge and green CI, update the GitHub release body from this file. Keep the immutable `v1.1.0` tag at `4df3b4a7f8dd37c4d945fa31b1ae0a5ad8a8034f`. No runtime changes, firmware flashing, or binary attachments.
