### PR TITLE
feat(tokenserver): Claude Code's statusLine as a quota source (single-account slice)

### DIFF
--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "435d13fe2445"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "cab1857bae12"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "123f8a3ac979"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "dc51d5957a32"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "3d96bb679447"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "82ca65619f70"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "dc51d5957a32"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "c2e8d9f1af40"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "cab1857bae12"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "123f8a3ac979"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "c2e8d9f1af40"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "3d96bb679447"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/.agents/plugins/plugins/vibepulse/scripts/session_start.py
+++ b/.agents/plugins/plugins/vibepulse/scripts/session_start.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 8737
 HEALTH_TIMEOUT_SECONDS = 0.45
 # Content fingerprint of the tokenserver Python sources shipped beside this
 # plugin release. A test forces this marker to move whenever host code moves.
-EXPECTED_HOST_SOURCE_FINGERPRINT = "21d7f23c2103"
+EXPECTED_HOST_SOURCE_FINGERPRINT = "435d13fe2445"
 CODEX_CONFIG_MAX_BYTES = 64 * 1024
 # Only the three top-level string settings that decide whether a permission
 # card can reach a user at all. Anchored and quote-matched so a value inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
 
 ### Added
 
+- **Claude Code's statusLine as a quota source (host side).**
+  `python3 tools/vibepulse_setup.py statusline install --yes-single-account`
+  points Claude Code's `statusLine` at a generated launcher; the bridge
+  (`tools/tokenserver/statusline_bridge.py`) keeps the session and weekly
+  rate-limit windows Claude Code already hands that command, then runs the
+  status line you had before with the same stdin. The tokenserver uses a
+  fresh sample ahead of the OAuth probe per window (later reset wins;
+  within a window the higher figure), slows the probe to 30 min while both
+  windows are covered, and never touches the model week. `statusline
+  status`, `doctor`, `smoke.py` and `GET /` (`claudeStatusline`) report
+  it. Single-account slice of the 2026-09-10 spec; account binding is not
+  implemented, and Windows install is refused for now.
+
 - SETTINGS → LABS stores independent choices for burn rate, Max Tracker,
   API-equivalent Value, the GitHub page and star popups. Choices apply after
   restart. Fresh sample configurations start with quotas/activity; upgrades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ on the [releases page](https://github.com/niclasvestlund-YT/vibepulse/releases).
   points Claude Code's `statusLine` at a generated launcher; the bridge
   (`tools/tokenserver/statusline_bridge.py`) keeps the session and weekly
   rate-limit windows Claude Code already hands that command, then runs the
-  status line you had before with the same stdin. The tokenserver uses a
-  fresh sample ahead of the OAuth probe per window (later reset wins;
-  within a window the higher figure), slows the probe to 30 min while both
-  windows are covered, and never touches the model week. `statusline
+  status line you had before with the same stdin. The tokenserver arbitrates
+  each window against the OAuth probe (later reset wins; within a window
+  the higher figure, a stored value being a floor until its reset), slows
+  the probe to 30 min while a fresh sample covers both windows, and never
+  touches the model week. `statusline
   status`, `doctor`, `smoke.py` and `GET /` (`claudeStatusline`) report
   it. Single-account slice of the 2026-09-10 spec; account binding is not
-  implemented, and Windows install is refused for now.
+  implemented, and install is macOS-only for now.
 
 - SETTINGS → LABS stores independent choices for burn rate, Max Tracker,
   API-equivalent Value, the GitHub page and star popups. Choices apply after

--- a/README.md
+++ b/README.md
@@ -415,9 +415,10 @@ Optionally, Claude Code itself can feed the quota: `python3
 tools/vibepulse_setup.py statusline install --yes-single-account` points
 Claude Code's `statusLine` at a small bridge that keeps the session and
 weekly windows Claude Code already hands that command, then runs the status
-line you had before. Fresh samples take precedence over the OAuth probe per
-window and the probe slows to every 30 minutes, so the shared rate-limit
-bucket is spent less. It asks you to confirm that Claude Code and the
+line you had before. Each window is arbitrated against the OAuth probe
+(the later reset wins, within one window the higher figure), and while a
+fresh sample covers both windows the probe slows to every 30 minutes, so
+the shared rate-limit bucket is spent less. It asks you to confirm that Claude Code and the
 tokenserver use the same Claude account; see
 [docs/agent-setup.md](docs/agent-setup.md).
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,16 @@ reported as current. Read that guard together with `claudeProbe` and the
 means the current source is live even if the saved fallback is expired. That
 is a future recovery risk, not a reason to restart the tokenserver.
 
+Optionally, Claude Code itself can feed the quota: `python3
+tools/vibepulse_setup.py statusline install --yes-single-account` points
+Claude Code's `statusLine` at a small bridge that keeps the session and
+weekly windows Claude Code already hands that command, then runs the status
+line you had before. Fresh samples take precedence over the OAuth probe per
+window and the probe slows to every 30 minutes, so the shared rate-limit
+bucket is spent less. It asks you to confirm that Claude Code and the
+tokenserver use the same Claude account; see
+[docs/agent-setup.md](docs/agent-setup.md).
+
 Codex plugin `0.1.7` turns the trusted `SessionStart` hook into a real bounded
 health check. It reads only the two loopback JSON endpoints, follows no
 redirects, times out in under a second, and injects one content-free class into

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -267,7 +267,7 @@ python3 tools/vibepulse_setup.py statusline status
 
 | Line | Meaning | What to do |
 |---|---|---|
-| `WAIT statusLine bridge: installed, no sample yet` | Nothing has spoken yet | Finish one Claude Code turn (existing sessions pick the new command up on their next trigger) |
+| `WAIT statusLine bridge: installed, no sample yet` | Nothing has spoken yet | Claude Code binds the statusLine command at session start, so a session that was already open never runs the bridge: restart Claude Code, then finish one turn. Until a payload carries `rate_limits`, the bridge leaves only `claude-statusline-quota.lock` in the state directory -- that file is the proof it ran |
 | `PASS statusLine bridge: fresh sample N s ago, Claude Code X.Y.Z` | Feeding | Nothing; `GET /` now shows `claudeStatusline.status: fresh` and, once both windows are covered, `bridged: true` with `claudeProbeIntervalS` at 1800 |
 | `VARN statusLine bridge: last sample N min ago` | No Claude Code session has spoken for over 15 minutes | Normal when idle; the probe is the source again until one does |
 | `FIX statusLine bridge: … no longer points at the launcher` | Something else rewrote `statusLine.command` | `statusline install --yes-single-account` again, or `statusline uninstall` to forget the bridge |

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -231,6 +231,55 @@ future recovery risk. Start a new Claude Code CLI turn to refresh that saved
 fallback. The service notices locally within 15 seconds; it does not need a
 restart, call an undocumented refresh endpoint, or mutate the refresh token.
 
+### Optional: let Claude Code's statusLine feed the quota (recommended)
+
+Claude Code hands its `statusLine` command a JSON document on every
+assistant message, and that document carries the account's session (5 h)
+and weekly rate-limit windows -- the same two numbers the probe above
+fetches from the rate-limited OAuth endpoint. The bridge keeps only those
+windows and the Claude Code version, and runs the status line the user had
+before with the same stdin, so nothing visible changes in Claude Code.
+Design: [the statusLine spec](superpowers/specs/2026-09-10-vibepulse-statusline-quota-source-design.md);
+this is its single-account slice.
+
+Before installing, confirm with the user that **Claude Code and the
+tokenserver use the same Claude account on this computer** -- the bridge
+cannot tell accounts apart, so a second account's status line would be
+shown as this one's quota. The command refuses without that consent:
+
+```sh
+python3 tools/vibepulse_setup.py statusline install --yes-single-account
+```
+
+Run it from the same interpreter the tokenserver uses (the venv, where one
+exists): the generated launcher bakes that interpreter's path in. It edits
+`~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`) with
+strict JSON, keeps every other key and every sibling of `statusLine`, and
+records the previous command in `claude-statusline-bridge.json` in the
+state directory so `statusline uninstall` restores it. macOS only for now;
+on Windows the command refuses (open question 4 in the spec).
+
+**Verify:**
+
+```sh
+python3 tools/vibepulse_setup.py statusline status
+```
+
+| Line | Meaning | What to do |
+|---|---|---|
+| `WAIT statusLine bridge: installed, no sample yet` | Nothing has spoken yet | Finish one Claude Code turn (existing sessions pick the new command up on their next trigger) |
+| `PASS statusLine bridge: fresh sample N s ago, Claude Code X.Y.Z` | Feeding | Nothing; `GET /` now shows `claudeStatusline.status: fresh` and, once both windows are covered, `bridged: true` with `claudeProbeIntervalS` at 1800 |
+| `VARN statusLine bridge: last sample N min ago` | No Claude Code session has spoken for over 15 minutes | Normal when idle; the probe is the source again until one does |
+| `FIX statusLine bridge: … no longer points at the launcher` | Something else rewrote `statusLine.command` | `statusline install --yes-single-account` again, or `statusline uninstall` to forget the bridge |
+| `FIX statusLine bridge: launcher missing` / `interpreter … is gone` | The state directory or the venv was removed | `statusline install --yes-single-account` again |
+
+`doctor` prints the same line, and `smoke.py` mirrors it from `GET /`.
+A stale sample never masquerades as live: the tokenserver uses a sample
+only while it is fresh, arbitrates each window against the probe (the
+later reset wins; within one window the higher figure wins, because usage
+only accumulates), and the model week is never touched. The panel wire
+contract is unchanged.
+
 Plugin `0.1.7` also performs a read-only startup classification from fixed
 loopback endpoints. `PROVIDER DATA STALE` means investigate Claude/Codex;
 `DEVICE PATH STALE` means provider data is already fresh and the next checks

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -257,7 +257,8 @@ exists): the generated launcher bakes that interpreter's path in. It edits
 strict JSON, keeps every other key and every sibling of `statusLine`, and
 records the previous command in `claude-statusline-bridge.json` in the
 state directory so `statusline uninstall` restores it. macOS only for now;
-on Windows the command refuses (open question 4 in the spec).
+on Windows and Linux the command refuses (open question 4 in the spec,
+and Linux is not a supported host).
 
 **Verify:**
 
@@ -269,15 +270,16 @@ python3 tools/vibepulse_setup.py statusline status
 |---|---|---|
 | `WAIT statusLine bridge: installed, no sample yet` | Nothing has spoken yet | Claude Code binds the statusLine command at session start, so a session that was already open never runs the bridge: restart Claude Code, then finish one turn. Until a payload carries `rate_limits`, the bridge leaves only `claude-statusline-quota.lock` in the state directory -- that file is the proof it ran |
 | `PASS statusLine bridge: fresh sample N s ago, Claude Code X.Y.Z` | Feeding | Nothing; `GET /` now shows `claudeStatusline.status: fresh` and, once both windows are covered, `bridged: true` with `claudeProbeIntervalS` at 1800 |
-| `VARN statusLine bridge: last sample N min ago` | No Claude Code session has spoken for over 15 minutes | Normal when idle; the probe is the source again until one does |
+| `VARN statusLine bridge: last sample N min ago` | No Claude Code session has spoken for over 15 minutes | Normal when idle; the stored windows still hold as a floor until they reset, and the probe runs at full cadence until one does |
 | `FIX statusLine bridge: … no longer points at the launcher` | Something else rewrote `statusLine.command` | `statusline install --yes-single-account` again, or `statusline uninstall` to forget the bridge |
 | `FIX statusLine bridge: launcher missing` / `interpreter … is gone` | The state directory or the venv was removed | `statusline install --yes-single-account` again |
 
 `doctor` prints the same line, and `smoke.py` mirrors it from `GET /`.
-A stale sample never masquerades as live: the tokenserver uses a sample
-only while it is fresh, arbitrates each window against the probe (the
-later reset wins; within one window the higher figure wins, because usage
-only accumulates), and the model week is never touched. The panel wire
+The tokenserver arbitrates each window against the probe (the later reset
+wins; within one window the higher figure wins, because usage only
+accumulates, so a stored window is a floor until it resets), judges
+freshness per window, slows the probe only while both windows are fresh,
+and never touches the model week. The panel wire
 contract is unchanged.
 
 Plugin `0.1.7` also performs a read-only startup classification from fixed

--- a/docs/observability-backlog.md
+++ b/docs/observability-backlog.md
@@ -711,6 +711,41 @@ rejection. Enough to aim the next question, cheap enough for an ESP32.
 
 ---
 
+### OBS-39 · A live probe can pull the cached week down within one window
+`tokenserver · S · open` — raised by Codex on #116 (2026-09-12); pre-existing.
+
+**Symptom:** the quota cache holds 60 % for a general-week reset and a
+later probe reports 40 % for the same, unexpired reset. `_resolve_weekly_quota`
+treats the probe as live and the async writer replaces the cached row, so
+the ring moves backward. Usage only accumulates within a window, so the
+lower figure is a lag on the API side, not a newer truth.
+**Evidence:** `_resolve_weekly_quota` (live → cache_record); `_merge_claude_statusline`
+already applies the same-window monotonic rule between the bridge sample
+and the cache, but only when a sample exists.
+**Fix:** make the cache an arbitration participant for the probe as well
+(same reset, higher figure wins; ties keep the probe), behind one real
+"same reset, lower figure" probe observation in the log first — the API
+may legitimately re-baseline a window, and that would be a different bug.
+
+---
+
+### OBS-40 · The session floor does not survive a tokenserver restart
+`tokenserver · S · open` — raised by Codex on #116 (2026-09-12); by design so far.
+
+**Symptom:** the probe observed 60 % for the 5 h window, the statusLine
+sample holds 40 % for the same reset, and the service restarts while the
+probe is down (429 rest, expired credential). `get_limits()` is empty, so
+the 40 % floor from the sample is served and recorded into Max Tracker
+(day peaks, so it cannot lower them) and the usage history (a lower point
+in the same window) until the probe recovers.
+**Evidence:** the README states on purpose that the session window is not
+cached; `quota_cache` already knows the `general_session` scope.
+**Fix:** persist the session observation in `general_session` and run the
+same three-way arbitration (probe, sample, cache) the week uses. Small,
+but a contract change for the session field: its own PR.
+
+---
+
 ## P3 — process & hygiene
 
 ### OBS-23 · The best diagnostics are undocumented; one documented one is wrong

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -300,7 +300,7 @@ lives in this section only (OBS-23).
 | `usage-history.json` | quota trend points, ≥15 min apart | 8 days |
 | `quota-cache.json` | last-known quota truths + reset times | until reset passes |
 | `max-tracker.json` | daily peaks, streaks, backfill watermarks | 400 days |
-| `claude-statusline-quota.json` | the statusLine bridge's session/week windows (+ lock file, install record `claude-statusline-bridge.json`, launcher `statusline-bridge.sh` with the previous status line baked in as a fallback) | until each window resets |
+| `claude-statusline-quota.json` | the statusLine bridge's session/week windows (+ lock file, install record `claude-statusline-bridge.json`, one launcher per Claude config directory, `statusline-bridge-<key>.sh`, with the previous status line baked in as a fallback) | until each window resets |
 
 All three are written atomically (temp + fsync + rename + parent-directory
 fsync, OBS-21). An unreadable one — invalid JSON, non-UTF-8 bytes, or the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -300,7 +300,7 @@ lives in this section only (OBS-23).
 | `usage-history.json` | quota trend points, ≥15 min apart | 8 days |
 | `quota-cache.json` | last-known quota truths + reset times | until reset passes |
 | `max-tracker.json` | daily peaks, streaks, backfill watermarks | 400 days |
-| `claude-statusline-quota.json` | the statusLine bridge's session/week windows (+ lock file, install record `claude-statusline-bridge.json`, launcher `statusline-bridge.sh`) | until each window resets |
+| `claude-statusline-quota.json` | the statusLine bridge's session/week windows (+ lock file, install record `claude-statusline-bridge.json`, launcher `statusline-bridge.sh` with the previous status line baked in as a fallback) | until each window resets |
 
 All three are written atomically (temp + fsync + rename + parent-directory
 fsync, OBS-21). An unreadable one — invalid JSON, non-UTF-8 bytes, or the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -134,6 +134,11 @@ repeating deserves attention. What a healthy boot looks like:
 
 - **`claude-probe: X -> Y`** — every probe status transition: a 401
   appearing, a 429 backoff starting, and the recovery back to ok.
+- **`claude-statusline: X -> Y`** — the statusLine bridge sample's status
+  (`not_installed`, `missing`, `unreadable`, `invalid`, `empty`, `stale`,
+  `fresh`), logged once per transition. `fresh -> stale` every evening and
+  `stale -> fresh` every morning is a healthy rhythm; `invalid` means the
+  bridge will quarantine the file on its next run.
 - **`claude-keychain: X -> Y`** — macOS only (OBS-20): every change in why
   the keychain read gave no token, logged once per transition like the
   probe line. `X` is the previous word, `ok` after a recovery, or `start`
@@ -210,6 +215,11 @@ Returns live server state, added after real debugging nights:
   `keychain_security_missing` / `keychain_malformed` the tool or the
   record itself. The string is assembled per probe cycle and published
   once, so it never reads half-built.
+- `claudeStatusline` — the statusLine bridge: `status` (as in the log
+  line above), `ageS` of the newest sample, `claudeCodeVersion`,
+  `bridged` (a fresh sample covers both windows, so the probe runs every
+  1800 s) and `account: "assumed-single"` — the install consent, not a
+  measurement.
 - `claudeProbeStreak` / `claudeProbeIntervalS` / `claudeProbeCooldownLeftS`
   / `claudeProbeAgeS` — the backoff behind `claudeProbe` (OBS-18):
   consecutive failed cycles, the current gap between cycles (240 s,
@@ -290,6 +300,7 @@ lives in this section only (OBS-23).
 | `usage-history.json` | quota trend points, ≥15 min apart | 8 days |
 | `quota-cache.json` | last-known quota truths + reset times | until reset passes |
 | `max-tracker.json` | daily peaks, streaks, backfill watermarks | 400 days |
+| `claude-statusline-quota.json` | the statusLine bridge's session/week windows (+ lock file, install record `claude-statusline-bridge.json`, launcher `statusline-bridge.sh`) | until each window resets |
 
 All three are written atomically (temp + fsync + rename + parent-directory
 fsync, OBS-21). An unreadable one — invalid JSON, non-UTF-8 bytes, or the

--- a/docs/superpowers/specs/2026-09-10-vibepulse-statusline-quota-source-design.md
+++ b/docs/superpowers/specs/2026-09-10-vibepulse-statusline-quota-source-design.md
@@ -11,8 +11,8 @@ requires `--yes-single-account` -- the operator asserts that Claude Code
 and the tokenserver share one Claude account. The account binding this
 document describes (`oauth/profile`, the identity watcher, generations,
 per-identity cache/tracker/history) is **not implemented**; a two-account
-host must not install the bridge. Windows install is refused (open
-question 4). The rest of this document is the design as reviewed.
+host must not install the bridge. Install is macOS-only: Windows is
+refused (open question 4) and Linux is not a supported host. The rest of this document is the design as reviewed.
 
 **Scope:** Tokenserver Claude quota sourcing, the setup command's
 `settings.json` edit, and the doctor/smoke/SessionStart classification of

--- a/docs/superpowers/specs/2026-09-10-vibepulse-statusline-quota-source-design.md
+++ b/docs/superpowers/specs/2026-09-10-vibepulse-statusline-quota-source-design.md
@@ -2,8 +2,17 @@
 
 **Date:** 2026-09-10
 
-**Status:** Draft, for maintainer review. Nothing in this document is
-implemented, and it authorizes no code, setup change or flash.
+**Status:** Partly implemented (2026-09-12). The single-account slice
+shipped: the bridge (`tools/tokenserver/statusline_bridge.py`), the
+`statusline install|uninstall|status` setup command, the tokenserver
+arbitration and bridged probe cadence, and the doctor/smoke lines. The
+sample is keyed under one account entry, `single`, and the install command
+requires `--yes-single-account` -- the operator asserts that Claude Code
+and the tokenserver share one Claude account. The account binding this
+document describes (`oauth/profile`, the identity watcher, generations,
+per-identity cache/tracker/history) is **not implemented**; a two-account
+host must not install the bridge. Windows install is refused (open
+question 4). The rest of this document is the design as reviewed.
 
 **Scope:** Tokenserver Claude quota sourcing, the setup command's
 `settings.json` edit, and the doctor/smoke/SessionStart classification of

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -30,7 +30,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "dc51d5957a32"
+HOST_SOURCE_FINGERPRINT = "c2e8d9f1af40"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -4463,7 +4463,8 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.state = root / "Application Support" / "VibePulse"
         self.config = root / "config.json"
         self.setup = load_setup()
-        self.launcher = self.state / self.setup.STATUSLINE_LAUNCHER_NAME
+        self.launcher = self.setup._statusline_launcher_path(
+            self.state, self.config_dir)
         self.command = shlex.quote(str(self.launcher))
 
     def run_setup(self, *argv, interactive=False, input_fn=None,
@@ -4833,6 +4834,64 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertEqual(code, 0, text)
         self.assertIn("VARN statusLine bridge: the launcher runs", text)
         self.assertIn("another checkout", text)
+
+    def test_each_config_directory_keeps_its_own_launcher(self):
+        # Codex on #116: two CLAUDE_CONFIG_DIRs sharing the state
+        # directory must not overwrite each other's baked-in fallback.
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "first-line"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        other_dir = Path(self.tmp.name) / "claude-other"
+        other_dir.mkdir()
+        (other_dir / "settings.json").write_text(json.dumps(
+            {"statusLine": {"type": "command", "command": "second-line"}}))
+        output = io.StringIO()
+        code = self.setup.main(
+            ["statusline", "install", "--yes-single-account"],
+            config_path=self.config, python=Path(sys.executable),
+            codex=None, stdout=output, stdin_isatty=False,
+            claude_config_dir=other_dir, statusline_state_dir=self.state,
+            statusline_platform="darwin")
+        self.assertEqual(code, 0, output.getvalue())
+        other_launcher = self.setup._statusline_launcher_path(
+            self.state, other_dir)
+        self.assertNotEqual(other_launcher, self.launcher)
+        self.assertIn("first-line", self.launcher.read_text())
+        self.assertIn("second-line", other_launcher.read_text())
+        # Uninstalling one directory leaves the other's launcher alone.
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertIn("keep their own launchers", text)
+        self.assertFalse(self.launcher.exists())
+        self.assertTrue(other_launcher.exists())
+        self.assertTrue((self.state / "claude-statusline-bridge.json").exists())
+
+    def test_reinstall_replaces_an_earlier_shared_launcher(self):
+        # Installs from before per-directory launchers recorded one shared
+        # statusline-bridge.sh; a reinstall moves to the keyed name and
+        # removes the orphan.
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        shared = self.state / "statusline-bridge.sh"
+        self.launcher.rename(shared)
+        record_path = self.state / "claude-statusline-bridge.json"
+        document = json.loads(record_path.read_text())
+        for entry in document["dirs"].values():
+            entry["launcher"] = str(shared)
+        record_path.write_text(json.dumps(document))
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": shlex.quote(str(shared))}})
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0, text)  # the record's launcher is judged
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         self.command)
+        self.assertEqual(self.record()["chained_command"], "my-status")
+        self.assertTrue(self.launcher.exists())
+        self.assertFalse(shared.exists())
 
     def test_settings_points_at_launcher_without_a_record_is_a_fix(self):
         self.run_setup("statusline", "install", "--yes-single-account")

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -30,7 +30,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "3d96bb679447"
+HOST_SOURCE_FINGERPRINT = "82ca65619f70"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -4909,6 +4909,13 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertEqual(self.record()["chained_command"], "my-status --x")
         self.assertIn("exec /bin/sh -c 'my-status --x'",
                       self.launcher.read_text())
+        # So does an uninstall without the record.
+        (self.state / "claude-statusline-bridge.json").unlink()
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertIn("restored 'my-status --x'", text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         "my-status --x")
 
 
 if __name__ == "__main__":

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -30,7 +30,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "435d13fe2445"
+HOST_SOURCE_FINGERPRINT = "cab1857bae12"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -30,7 +30,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "c2e8d9f1af40"
+HOST_SOURCE_FINGERPRINT = "3d96bb679447"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -4894,11 +4894,21 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertFalse(shared.exists())
 
     def test_settings_points_at_launcher_without_a_record_is_a_fix(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status --x"}})
         self.run_setup("statusline", "install", "--yes-single-account")
         (self.state / "claude-statusline-bridge.json").unlink()
         code, text = self.run_setup("statusline", "status")
         self.assertEqual(code, 1)
         self.assertIn("install record is gone", text)
+        # The reinstall status asks for recovers the previous line from
+        # the launcher's baked-in fallback instead of erasing it.
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        self.assertEqual(self.record()["chained_command"], "my-status --x")
+        self.assertIn("exec /bin/sh -c 'my-status --x'",
+                      self.launcher.read_text())
 
 
 if __name__ == "__main__":

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -30,7 +30,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "123f8a3ac979"
+HOST_SOURCE_FINGERPRINT = "dc51d5957a32"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -4466,14 +4466,16 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.launcher = self.state / self.setup.STATUSLINE_LAUNCHER_NAME
         self.command = shlex.quote(str(self.launcher))
 
-    def run_setup(self, *argv, interactive=False, input_fn=None):
+    def run_setup(self, *argv, interactive=False, input_fn=None,
+                  platform="darwin"):
         output = io.StringIO()
         code = self.setup.main(
             list(argv), config_path=self.config, python=Path(sys.executable),
             codex=None, stdout=output, stdin_isatty=interactive,
             input_fn=input_fn or (lambda prompt: ""),
             claude_config_dir=self.config_dir,
-            statusline_state_dir=self.state)
+            statusline_state_dir=self.state,
+            statusline_platform=platform)
         return code, output.getvalue()
 
     def read_settings(self):
@@ -4793,6 +4795,44 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertEqual(code, 0, text)
         self.assertEqual(self.read_settings()["statusLine"]["command"],
                          "my-status")
+
+    def test_install_is_macos_only(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        for platform, word in (("win32", "Windows"), ("linux", "linux")):
+            with self.subTest(platform):
+                code, text = self.run_setup(
+                    "statusline", "install", "--yes-single-account",
+                    platform=platform)
+                self.assertEqual(code, 1)
+                self.assertIn(word, text)
+                self.assertEqual(self.read_settings()["statusLine"]["command"],
+                                 "my-status")
+                self.assertFalse(self.state.exists())
+
+    def test_status_judges_the_recorded_bridge_path(self):
+        self.run_setup("statusline", "install", "--yes-single-account")
+        record_path = self.state / "claude-statusline-bridge.json"
+        document = json.loads(record_path.read_text())
+        # The checkout the launcher was installed from moved away.
+        for entry in document["dirs"].values():
+            entry["bridge"] = str(self.state / "gone" / "statusline_bridge.py")
+        record_path.write_text(json.dumps(document))
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 1)
+        self.assertIn("that script is gone", text)
+        self.assertIn(str(self.state / "gone"), text)
+        # Another, existing checkout: not a fix, but named.
+        other = self.state / "other" / "tools" / "tokenserver"
+        other.mkdir(parents=True)
+        (other / "statusline_bridge.py").write_text("# copy\n")
+        for entry in document["dirs"].values():
+            entry["bridge"] = str(other / "statusline_bridge.py")
+        record_path.write_text(json.dumps(document))
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0, text)
+        self.assertIn("VARN statusLine bridge: the launcher runs", text)
+        self.assertIn("another checkout", text)
 
     def test_settings_points_at_launcher_without_a_record_is_a_fix(self):
         self.run_setup("statusline", "install", "--yes-single-account")

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -14,6 +14,7 @@ import plistlib
 import re
 import signal
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -28,7 +29,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "21d7f23c2103"
+HOST_SOURCE_FINGERPRINT = "435d13fe2445"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -4441,6 +4442,298 @@ class RelaySetupTests(unittest.TestCase):
                     marketplace_remove, message))
         self.assertFalse(setup._known_absent(
             ["/codex", "mcp", "remove", "vibepulse"], accepted))
+
+
+@unittest.skipIf(sys.platform == "win32", "the launcher is a POSIX shell script")
+class StatusLineBridgeSetupTests(unittest.TestCase):
+    """`vibepulse_setup.py statusline install|uninstall|status` and the
+    doctor line: settings.json is edited strictly, the previous status
+    line is kept and restored, and every drift is named, never guessed."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        root = Path(self.tmp.name)
+        self.config_dir = root / "claude"
+        self.config_dir.mkdir()
+        self.settings = self.config_dir / "settings.json"
+        self.state = root / "state"
+        self.config = root / "config.json"
+        self.setup = load_setup()
+        self.launcher = self.state / self.setup.STATUSLINE_LAUNCHER_NAME
+
+    def run_setup(self, *argv, interactive=False, input_fn=None):
+        output = io.StringIO()
+        code = self.setup.main(
+            list(argv), config_path=self.config, python=Path(sys.executable),
+            codex=None, stdout=output, stdin_isatty=interactive,
+            input_fn=input_fn or (lambda prompt: ""),
+            claude_config_dir=self.config_dir,
+            statusline_state_dir=self.state)
+        return code, output.getvalue()
+
+    def read_settings(self):
+        return json.loads(self.settings.read_text(encoding="utf-8"))
+
+    def write_settings(self, document):
+        self.settings.write_text(json.dumps(document, indent=2) + "\n",
+                                 encoding="utf-8")
+
+    def record(self):
+        path = self.state / "claude-statusline-bridge.json"
+        document = json.loads(path.read_text(encoding="utf-8"))
+        bridge = self.setup.statusline_bridge
+        return document["dirs"][bridge.config_dir_key(self.config_dir)]
+
+    def test_install_requires_the_single_account_consent(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        code, text = self.run_setup("statusline", "install")
+        self.assertEqual(code, 1)
+        self.assertIn("FIX statusLine bridge: not installed", text)
+        self.assertIn("SAME Claude account", text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         "my-status")
+        self.assertFalse(self.state.exists())
+
+        code, text = self.run_setup(
+            "statusline", "install", interactive=True,
+            input_fn=lambda prompt: "no")
+        self.assertEqual(code, 1)
+        code, text = self.run_setup(
+            "statusline", "install", interactive=True,
+            input_fn=lambda prompt: "YES\n")
+        self.assertEqual(code, 0, text)
+
+    def test_install_keeps_the_previous_status_line_and_siblings(self):
+        self.write_settings({
+            "permissions": {"allow": ["Bash(ls:*)"]},
+            "statusLine": {"type": "command", "command": "my-status --x",
+                           "padding": 0},
+        })
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        self.assertIn("PASS statusLine bridge: installed", text)
+        self.assertIn("'my-status --x'", text)
+        saved = self.read_settings()
+        self.assertEqual(saved["permissions"], {"allow": ["Bash(ls:*)"]})
+        self.assertEqual(saved["statusLine"], {
+            "type": "command", "command": str(self.launcher), "padding": 0})
+        record = self.record()
+        self.assertEqual(record["chained_command"], "my-status --x")
+        self.assertEqual(record["python"], sys.executable)
+        launcher = self.launcher.read_text(encoding="utf-8")
+        self.assertIn(self.setup.STATUSLINE_LAUNCHER_MARKER, launcher)
+        self.assertIn("statusline_bridge.py", launcher)
+        self.assertIn("exec /bin/sh -c 'my-status --x'", launcher)
+        self.assertEqual(
+            stat.S_IMODE(self.launcher.stat().st_mode) & 0o077, 0)
+        self.assertTrue(os.access(self.launcher, os.X_OK))
+
+    def test_install_without_a_status_line_creates_the_block(self):
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        self.assertIn("no status line before", text)
+        self.assertEqual(self.read_settings(), {"statusLine": {
+            "type": "command", "command": str(self.launcher)}})
+        self.assertIsNone(self.record()["chained_command"])
+        self.assertIn("exit 0\n", self.launcher.read_text(encoding="utf-8"))
+
+    def test_launcher_round_trip_runs_the_bridge_then_the_old_line(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "cat; exit 4"}})
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        payload = json.dumps({
+            "version": "2.1.0",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 42, "resets_at":
+                              int(time.time()) + 3600},
+                "seven_day": {"used_percentage": 7, "resets_at":
+                              int(time.time()) + 86400}}}).encode()
+        completed = subprocess.run(
+            [str(self.launcher)], input=payload, capture_output=True,
+            timeout=30, env={**os.environ,
+                             "CLAUDE_CONFIG_DIR": str(self.config_dir),
+                             "HOME": self.tmp.name})
+        self.assertEqual(completed.returncode, 4, completed.stderr)
+        self.assertEqual(completed.stdout, payload)
+        # The launcher bakes in the state directory it was installed to.
+        sample = self.state / self.setup.statusline_bridge.SAMPLE_NAME
+        self.assertTrue(sample.is_file(), sample)
+        document = json.loads(sample.read_text())
+        self.assertEqual(document["accounts"]["single"]["five_hour"]["pct"],
+                         42.0)
+
+    def test_reinstall_is_idempotent_and_never_chains_itself(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        self.assertEqual(self.record()["chained_command"], "my-status")
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         str(self.launcher))
+        self.assertIn("exec /bin/sh -c my-status", self.launcher.read_text())
+
+    def test_install_refuses_untrusted_settings_and_commands(self):
+        self.settings.write_text('{"statusLine": {"type": "command", '
+                                 '"command": "a"}, "statusLine": 1}')
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 1)
+        self.assertIn("not strict JSON", text)
+        self.assertFalse(self.state.exists())
+
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "a\nrm -rf /"}})
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 1)
+        self.assertIn("not a single printable line", text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         "a\nrm -rf /")
+
+        self.write_settings({"statusLine": "junk"})
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 1)
+        self.assertIn("statusLine is not an object", text)
+
+        self.write_settings({"statusLine": {"type": "other",
+                                            "command": "a"}})
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 1)
+        self.assertIn("not a command", text)
+
+    def test_uninstall_restores_the_previous_line_and_cleans_up(self):
+        self.write_settings({"other": True,
+                             "statusLine": {"type": "command",
+                                            "command": "my-status",
+                                            "padding": 1}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        (self.state / "claude-statusline-quota.json").write_text("{}")
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertIn("restored 'my-status'", text)
+        self.assertEqual(self.read_settings(), {
+            "other": True,
+            "statusLine": {"type": "command", "command": "my-status",
+                           "padding": 1}})
+        self.assertFalse(self.launcher.exists())
+        self.assertFalse((self.state / "claude-statusline-bridge.json").exists())
+        self.assertFalse((self.state / "claude-statusline-quota.json").exists())
+
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0)
+        self.assertIn("OFF statusLine bridge: not installed", text)
+
+    def test_uninstall_removes_a_block_it_created(self):
+        self.write_settings({"other": True})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertIn("removed the statusLine entry", text)
+        self.assertEqual(self.read_settings(), {"other": True})
+
+    def test_uninstall_leaves_a_replaced_status_line_alone(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "their-new-line"}})
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertIn("left", text)
+        self.assertIn("'their-new-line'", text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         "their-new-line")
+        self.assertFalse(self.launcher.exists())
+
+    def test_status_and_doctor_name_each_state(self):
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0)
+        self.assertIn("OFF statusLine bridge: not installed", text)
+
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0, text)
+        self.assertIn("WAIT statusLine bridge: installed, no sample yet", text)
+
+        bridge = self.setup.statusline_bridge
+        now = int(time.time())
+        sample = self.state / bridge.SAMPLE_NAME
+        sample.write_text(json.dumps({"v": 1, "accounts": {"single": {
+            "five_hour": {"pct": 42.0, "resets_at": now + 3600,
+                          "at": now - 30, "seen": now - 30},
+            "claude_code_version": "2.1.0"}}}))
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0, text)
+        self.assertRegex(text, r"PASS statusLine bridge: fresh sample \d+ s "
+                               r"ago, Claude Code 2\.1\.0; account assumed "
+                               r"single")
+
+        sample.write_text(json.dumps({"v": 1, "accounts": {"single": {
+            "five_hour": {"pct": 42.0, "resets_at": now + 3600,
+                          "at": now - 4000, "seen": now - 4000}}}}))
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0, text)
+        self.assertIn("VARN statusLine bridge: last sample 66 min ago", text)
+
+        sample.write_text("{oops")
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 0, text)
+        self.assertIn("sample file is invalid", text)
+        self.assertEqual(sample.read_text(), "{oops")
+
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "their-new-line"}})
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 1)
+        self.assertIn("no longer points at the launcher", text)
+        self.assertIn("'their-new-line'", text)
+
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": str(self.launcher)}})
+        self.launcher.unlink()
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 1)
+        self.assertIn("launcher missing", text)
+
+        self.run_setup("statusline", "install", "--yes-single-account")
+        record_path = self.state / "claude-statusline-bridge.json"
+        document = json.loads(record_path.read_text())
+        for entry in document["dirs"].values():
+            entry["python"] = str(self.state / "gone-python")
+        record_path.write_text(json.dumps(document))
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 1)
+        self.assertIn("interpreter", text)
+        self.assertIn("is gone", text)
+
+        # The doctor prints the same line and counts the fix.
+        self.setup.save_config(self.config, self.setup.VibePulseConfig())
+        output = io.StringIO()
+        code = self.setup.main(
+            ["doctor"], config_path=self.config, python=Path(sys.executable),
+            codex=None, run=FakeRunner([python_probe_ok()]), stdout=output,
+            claude_config_dir=self.config_dir, statusline_state_dir=self.state)
+        self.assertEqual(code, 1)
+        self.assertIn("FIX statusLine bridge: interpreter", output.getvalue())
+
+    def test_settings_points_at_launcher_without_a_record_is_a_fix(self):
+        self.run_setup("statusline", "install", "--yes-single-account")
+        (self.state / "claude-statusline-bridge.json").unlink()
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 1)
+        self.assertIn("install record is gone", text)
 
 
 if __name__ == "__main__":

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 import plistlib
 import re
+import shlex
 import signal
 import socket
 import stat
@@ -4457,10 +4458,13 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.config_dir = root / "claude"
         self.config_dir.mkdir()
         self.settings = self.config_dir / "settings.json"
-        self.state = root / "state"
+        # A space, as in macOS's "Application Support": Claude Code hands
+        # the command to a shell, and an unquoted path split there.
+        self.state = root / "Application Support" / "VibePulse"
         self.config = root / "config.json"
         self.setup = load_setup()
         self.launcher = self.state / self.setup.STATUSLINE_LAUNCHER_NAME
+        self.command = shlex.quote(str(self.launcher))
 
     def run_setup(self, *argv, interactive=False, input_fn=None):
         output = io.StringIO()
@@ -4519,7 +4523,8 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         saved = self.read_settings()
         self.assertEqual(saved["permissions"], {"allow": ["Bash(ls:*)"]})
         self.assertEqual(saved["statusLine"], {
-            "type": "command", "command": str(self.launcher), "padding": 0})
+            "type": "command", "command": self.command, "padding": 0})
+        self.assertNotEqual(self.command, str(self.launcher))
         record = self.record()
         self.assertEqual(record["chained_command"], "my-status --x")
         self.assertEqual(record["python"], sys.executable)
@@ -4537,7 +4542,7 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertEqual(code, 0, text)
         self.assertIn("no status line before", text)
         self.assertEqual(self.read_settings(), {"statusLine": {
-            "type": "command", "command": str(self.launcher)}})
+            "type": "command", "command": self.command}})
         self.assertIsNone(self.record()["chained_command"])
         self.assertIn("exit 0\n", self.launcher.read_text(encoding="utf-8"))
 
@@ -4554,8 +4559,10 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
                               int(time.time()) + 3600},
                 "seven_day": {"used_percentage": 7, "resets_at":
                               int(time.time()) + 86400}}}).encode()
+        # Exactly as Claude Code runs it: the saved command through a shell.
         completed = subprocess.run(
-            [str(self.launcher)], input=payload, capture_output=True,
+            ["/bin/sh", "-c", self.read_settings()["statusLine"]["command"]],
+            input=payload, capture_output=True,
             timeout=30, env={**os.environ,
                              "CLAUDE_CONFIG_DIR": str(self.config_dir),
                              "HOME": self.tmp.name})
@@ -4577,7 +4584,7 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertEqual(code, 0, text)
         self.assertEqual(self.record()["chained_command"], "my-status")
         self.assertEqual(self.read_settings()["statusLine"]["command"],
-                         str(self.launcher))
+                         self.command)
         self.assertIn("exec /bin/sh -c my-status", self.launcher.read_text())
 
     def test_install_refuses_untrusted_settings_and_commands(self):
@@ -4701,7 +4708,7 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.assertIn("'their-new-line'", text)
 
         self.write_settings({"statusLine": {"type": "command",
-                                            "command": str(self.launcher)}})
+                                            "command": self.command}})
         self.launcher.unlink()
         code, text = self.run_setup("statusline", "status")
         self.assertEqual(code, 1)
@@ -4727,6 +4734,37 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
             claude_config_dir=self.config_dir, statusline_state_dir=self.state)
         self.assertEqual(code, 1)
         self.assertIn("FIX statusLine bridge: interpreter", output.getvalue())
+
+    def test_unquoted_launcher_path_is_named_and_repaired(self):
+        # The first release wrote the bare path; with the space in
+        # "Application Support" the shell ran nothing, forever WAIT.
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "my-status"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": str(self.launcher)}})
+        completed = subprocess.run(
+            ["/bin/sh", "-c", str(self.launcher)], input=b"{}",
+            capture_output=True, timeout=30)
+        self.assertEqual(completed.returncode, 127)
+        code, text = self.run_setup("statusline", "status")
+        self.assertEqual(code, 1)
+        self.assertIn("without shell quoting", text)
+        code, text = self.run_setup("statusline", "install",
+                                    "--yes-single-account")
+        self.assertEqual(code, 0, text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         self.command)
+        self.assertEqual(self.record()["chained_command"], "my-status")
+        code, text = self.run_setup("statusline", "status")
+        self.assertIn("WAIT statusLine bridge", text)
+        # Uninstall recognizes the bare form too and restores the old line.
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": str(self.launcher)}})
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertEqual(self.read_settings()["statusLine"]["command"],
+                         "my-status")
 
     def test_settings_points_at_launcher_without_a_record_is_a_fix(self):
         self.run_setup("statusline", "install", "--yes-single-account")

--- a/test/test_vibepulse_codex_plugin.py
+++ b/test/test_vibepulse_codex_plugin.py
@@ -30,7 +30,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".agents/plugins/plugins/vibepulse/scripts"
 MAX_HOOK_INPUT = 64 * 1024
-HOST_SOURCE_FINGERPRINT = "cab1857bae12"
+HOST_SOURCE_FINGERPRINT = "123f8a3ac979"
 
 PERMISSION = {
     "hook_event_name": "PermissionRequest",
@@ -4645,8 +4645,36 @@ class StatusLineBridgeSetupTests(unittest.TestCase):
         self.run_setup("statusline", "install", "--yes-single-account")
         code, text = self.run_setup("statusline", "uninstall")
         self.assertEqual(code, 0, text)
-        self.assertIn("removed the statusLine entry", text)
+        self.assertIn("removed the command", text)
+        self.assertIn("empty statusLine entry", text)
         self.assertEqual(self.read_settings(), {"other": True})
+
+    def test_uninstall_keeps_siblings_it_did_not_create(self):
+        # A statusLine block with no command, only padding, and a sibling
+        # added after the install: neither is the installer's to delete.
+        self.write_settings({"statusLine": {"padding": 2}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        saved = self.read_settings()
+        saved["statusLine"]["later"] = True
+        self.write_settings(saved)
+        code, text = self.run_setup("statusline", "uninstall")
+        self.assertEqual(code, 0, text)
+        self.assertEqual(self.read_settings(),
+                         {"statusLine": {"padding": 2, "later": True}})
+        self.assertNotIn("empty statusLine entry", text)
+
+    def test_launcher_bakes_in_the_previous_line_as_a_fallback(self):
+        self.write_settings({"statusLine": {"type": "command",
+                                            "command": "printf old; exit 3"}})
+        self.run_setup("statusline", "install", "--yes-single-account")
+        self.assertIn("--chained \"$CHAINED\"", self.launcher.read_text())
+        (self.state / "claude-statusline-bridge.json").write_text("{corrupt")
+        completed = subprocess.run(
+            ["/bin/sh", "-c", self.read_settings()["statusLine"]["command"]],
+            input=b"{}", capture_output=True, timeout=30,
+            env={**os.environ, "CLAUDE_CONFIG_DIR": str(self.config_dir)})
+        self.assertEqual(completed.returncode, 3, completed.stderr)
+        self.assertEqual(completed.stdout, b"old")
 
     def test_uninstall_leaves_a_replaced_status_line_alone(self):
         self.write_settings({"statusLine": {"type": "command",

--- a/test/tokenserver-suite.txt
+++ b/test/tokenserver-suite.txt
@@ -23,3 +23,4 @@ tools.tokenserver.test_interaction_relay_crypto
 tools.tokenserver.test_publisher
 tools.tokenserver.test_discovery
 tools.tokenserver.test_smoke
+tools.tokenserver.test_statusline_bridge

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -519,15 +519,15 @@ own failure take the status line down.
 
 Rules, shared with the doctor and smoke test:
 
-- The sample is used only while **fresh** (newest `seen` within 15 min,
-  `STATUSLINE_FRESH_S`). Stale means no session has spoken; the probe is
-  the source again and the cache keeps the last live figure.
 - Each window is arbitrated separately against the probe's reading, and
   the week also against the cache: the later reset is the newer window;
   within one window the higher figure is the later one, because usage only
-  accumulates. Ties keep the probe. The model week has no statusLine
-  counterpart and is never touched.
-- While a fresh sample covers both windows and the probe is healthy
+  accumulates. Ties keep the probe. A stored window is therefore a floor
+  until it resets, fresh or not: a lagging probe cannot pull the figure
+  down. The model week has no statusLine counterpart and is never touched.
+- Freshness (`seen` within 15 min, `STATUSLINE_FRESH_S`) is judged per
+  window and decides only the probe cadence: while a fresh sample covers
+  both windows, no older than the probe's own, and the probe is healthy
   (`usage_http_200 + ok`), the probe runs every 1800 s
   (`PROBE_WHEN_BRIDGED_S`) instead of 240 s. Every failure state keeps its
   own ladder.

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -503,6 +503,42 @@ The booleans `claudeWeekStale`, `claudeModelWeekStale` and `codexWeekStale`
 are optional additions to the v2 contract. If the percentage is missing
 the corresponding stale is always `false`.
 
+## Claude Code statusLine bridge
+
+`statusline_bridge.py` is a second, passive source for the Claude session
+and general week: Claude Code runs the `statusLine` command from
+`settings.json` on every assistant message and pipes it a JSON document
+whose `rate_limits.five_hour` / `seven_day` carry the same percentages and
+resets the OAuth probe fetches. `python3 tools/vibepulse_setup.py statusline
+install --yes-single-account` points that command at a generated launcher
+in the state directory; the bridge keeps only those two windows and the
+Claude Code version in `claude-statusline-quota.json`, then runs the status
+line the user had before with the same stdin and passes its output and
+exit status through. The bridge prints nothing itself and never lets its
+own failure take the status line down.
+
+Rules, shared with the doctor and smoke test:
+
+- The sample is used only while **fresh** (newest `seen` within 15 min,
+  `STATUSLINE_FRESH_S`). Stale means no session has spoken; the probe is
+  the source again and the cache keeps the last live figure.
+- Each window is arbitrated separately against the probe's reading, and
+  the week also against the cache: the later reset is the newer window;
+  within one window the higher figure is the later one, because usage only
+  accumulates. Ties keep the probe. The model week has no statusLine
+  counterpart and is never touched.
+- While a fresh sample covers both windows and the probe is healthy
+  (`usage_http_200 + ok`), the probe runs every 1800 s
+  (`PROBE_WHEN_BRIDGED_S`) instead of 240 s. Every failure state keeps its
+  own ladder.
+- `GET /` shows `claudeStatusline: {status, ageS, claudeCodeVersion,
+  bridged, account: "assumed-single"}`; the log line
+  `claude-statusline: X -> Y` records status transitions once.
+- Single account only: the install command makes the operator assert that
+  Claude Code and the tokenserver use the same Claude account on this
+  computer. The account-binding machinery the spec describes is not
+  implemented; `statusline uninstall` restores the previous command.
+
 ## Local usage history
 
 The service saves the history atomically in

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -524,10 +524,12 @@ Rules, shared with the doctor and smoke test:
   within one window the higher figure is the later one, because usage only
   accumulates. Ties keep the probe. A stored window is therefore a floor
   until it resets, fresh or not: a lagging probe cannot pull the figure
-  down. A window that wins while stale is served as that floor with
-  `claudeWeekStale: true` (the session simply shown), and is not recorded
-  into the cache, Max Tracker or the history as a new measurement -- the
-  fresh sample already did that. The model week has no statusLine
+  down. A week window that wins while stale is served as that floor with
+  `claudeWeekStale: true` and is not recorded into the cache, Max Tracker
+  or the history as a new measurement -- the fresh sample already did
+  that. The session has no stale flag on the wire, so a stale session
+  floor yields to a live probe reading and is otherwise withheld (dashes,
+  as before the bridge). The model week has no statusLine
   counterpart and is never touched.
 - Freshness (`seen` within 15 min, `STATUSLINE_FRESH_S`) is judged per
   window and decides only the probe cadence: while a fresh sample covers

--- a/tools/tokenserver/README.md
+++ b/tools/tokenserver/README.md
@@ -524,7 +524,11 @@ Rules, shared with the doctor and smoke test:
   within one window the higher figure is the later one, because usage only
   accumulates. Ties keep the probe. A stored window is therefore a floor
   until it resets, fresh or not: a lagging probe cannot pull the figure
-  down. The model week has no statusLine counterpart and is never touched.
+  down. A window that wins while stale is served as that floor with
+  `claudeWeekStale: true` (the session simply shown), and is not recorded
+  into the cache, Max Tracker or the history as a new measurement -- the
+  fresh sample already did that. The model week has no statusLine
+  counterpart and is never touched.
 - Freshness (`seen` within 15 min, `STATUSLINE_FRESH_S`) is judged per
   window and decides only the probe cadence: while a fresh sample covers
   both windows, no older than the probe's own, and the probe is healthy

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -274,8 +274,9 @@ def check_server(base_url, checkout_rev=None, checkout_src=None):
             minutes = age // 60 if isinstance(age, int) else "?"
             results.append((WARN, f"claude statusLine bridge: last sample "
                                   f"{minutes} min ago{tag} — no Claude Code "
-                                  "session has spoken since; the probe is the "
-                                  "source until one does"))
+                                  "session has spoken since; its windows "
+                                  "still hold as a floor, the probe runs at "
+                                  "full cadence"))
         elif state in ("missing", "empty"):
             results.append((WARN, "claude statusLine bridge: installed but "
                                   "no sample yet — finish one turn in a "

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -257,6 +257,33 @@ def check_server(base_url, checkout_rev=None, checkout_src=None):
         results.append((WARN, "claude credential missing from the "
                               "diagnostics — restart the tokenserver with "
                               "current code"))
+    # The statusLine bridge is optional: an older server has no field and
+    # an uninstalled bridge says nothing. Installed, it is judged.
+    statusline = root.get("claudeStatusline")
+    if isinstance(statusline, dict):
+        state = statusline.get("status")
+        age = statusline.get("ageS")
+        version = statusline.get("claudeCodeVersion")
+        tag = f" (Claude Code {version})" if isinstance(version, str) else ""
+        if state == "fresh":
+            bridged = statusline.get("bridged") is True
+            results.append((OK, f"claude statusLine bridge: sample {age} s "
+                                f"old{tag}; the probe is "
+                                f"{'a cross-check' if bridged else 'still primary'}"))
+        elif state == "stale":
+            minutes = age // 60 if isinstance(age, int) else "?"
+            results.append((WARN, f"claude statusLine bridge: last sample "
+                                  f"{minutes} min ago{tag} — no Claude Code "
+                                  "session has spoken since; the probe is the "
+                                  "source until one does"))
+        elif state in ("missing", "empty"):
+            results.append((WARN, "claude statusLine bridge: installed but "
+                                  "no sample yet — finish one Claude Code "
+                                  "turn"))
+        elif state in ("invalid", "unreadable"):
+            results.append((WARN, f"claude statusLine bridge: sample file is "
+                                  f"{state} — run `vibepulse_setup.py "
+                                  "statusline status`"))
     unknown = root.get("unknownRateLimitBuckets") or []
     if unknown:
         results.append((WARN, f"unknown rate-limit buckets: {unknown} — "

--- a/tools/tokenserver/smoke.py
+++ b/tools/tokenserver/smoke.py
@@ -278,8 +278,9 @@ def check_server(base_url, checkout_rev=None, checkout_src=None):
                                   "source until one does"))
         elif state in ("missing", "empty"):
             results.append((WARN, "claude statusLine bridge: installed but "
-                                  "no sample yet — finish one Claude Code "
-                                  "turn"))
+                                  "no sample yet — finish one turn in a "
+                                  "Claude Code session started after the "
+                                  "install"))
         elif state in ("invalid", "unreadable"):
             results.append((WARN, f"claude statusLine bridge: sample file is "
                                   f"{state} — run `vibepulse_setup.py "

--- a/tools/tokenserver/state_files.py
+++ b/tools/tokenserver/state_files.py
@@ -13,10 +13,28 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 log = logging.getLogger("tokenserver.state")
+
+
+def state_dir() -> Path:
+    """The service's state directory -- the lock, cache, history, tracker.
+
+    ``~/Library/Application Support`` is the macOS convention; the Windows
+    counterpart is ``%LOCALAPPDATA%``. Lives here rather than only in
+    ``tokenserver.py`` because the statusLine bridge, a short-lived process
+    Claude Code spawns on every status-line trigger, must find the same
+    directory without importing the whole service.
+    """
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        base = (Path(local_app_data) if local_app_data
+                else Path.home() / "AppData" / "Local")
+        return base / "VibePulse"
+    return Path.home() / "Library" / "Application Support" / "VibePulse"
 
 
 def quarantine_corrupt(path: Path, reason: str) -> Path | None:

--- a/tools/tokenserver/statusline_bridge.py
+++ b/tools/tokenserver/statusline_bridge.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Claude Code statusLine -> VibePulse bridge.
+
+Claude Code runs the command in ``settings.json``'s ``statusLine`` on every
+new assistant message (and a few other triggers) and pipes it a JSON
+document on stdin.  That document carries the account's session (5 h) and
+weekly rate-limit windows as ``rate_limits.five_hour`` / ``seven_day`` --
+the same two numbers the tokenserver otherwise has to fetch from an
+undocumented OAuth endpoint that rate-limits hard.
+
+This bridge is what ``vibepulse_setup.py statusline install`` points that
+command at.  It keeps exactly those two windows and the Claude Code
+``version`` string, validates every retained field strictly, and merges
+them per window into one file in the tokenserver's state directory,
+``claude-statusline-quota.json``.  Then it runs the status line the user
+had before (recorded at install time) with the same stdin, passing that
+command's stdout and exit status through unchanged.  The bridge itself
+prints nothing.
+
+Design: ``docs/superpowers/specs/2026-09-10-vibepulse-statusline-quota-
+source-design.md``.  This is the single-account slice of it: the sample is
+keyed under one account entry, ``single``, because the install command
+makes the operator assert that Claude Code and the tokenserver use the same
+Claude account on this computer.  The account-binding machinery the spec
+describes for two-account hosts is deliberately not implemented here.
+
+Invariants, in the spirit of ``docs/lessons.md``'s hostile-input entries:
+
+* A window absent from stdin is no observation: the stored window keeps
+  its value until its own ``resets_at`` passes.  Nothing is ever written
+  as zero and no window is ever invented.
+* A present-and-malformed window rejects the whole payload: nothing is
+  written, the stored entry stays exactly as it was, the chained command
+  still runs.
+* Within one reset window usage only accumulates, so a replay with the
+  same or a lower percentage never regresses the stored figure; it only
+  advances ``seen`` (the bridge is alive).  A newer ``resets_at`` is a new
+  window and replaces the old one.
+* The read-merge-replace runs under an interprocess lock; a bridge that
+  cannot take it within a short bound skips the write rather than putting
+  back a stale copy of a window another run just updated.
+* Whatever goes wrong, the chained command runs and the exit status is 0
+  when there is none -- Claude Code must never lose its status line to
+  this bridge.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # Windows
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # macOS/Linux
+    msvcrt = None
+
+if __package__:
+    from .state_files import fsync_parent, quarantine_corrupt, state_dir
+else:  # run directly: python3 tools/tokenserver/statusline_bridge.py
+    from state_files import fsync_parent, quarantine_corrupt, state_dir
+
+SAMPLE_NAME = "claude-statusline-quota.json"
+CONFIG_NAME = "claude-statusline-bridge.json"
+LOCK_NAME = "claude-statusline-quota.lock"
+SAMPLE_VERSION = 1
+CONFIG_VERSION = 1
+# v1 keys every sample under one account entry (see the module docstring).
+ACCOUNT_KEY = "single"
+WINDOWS = ("five_hour", "seven_day")
+# How far ahead a window may claim to reset.  Five hours plus slack for the
+# API's clock against the host's; eight days for the weekly window.  A
+# ``five_hour`` claiming a reset a week out would otherwise win the
+# later-reset arbitration and hold the session ring on a bogus window.
+RESET_SLACK_S = 15 * 60
+WINDOW_HORIZON_S = {
+    "five_hour": 5 * 3600 + RESET_SLACK_S,
+    "seven_day": 8 * 24 * 3600,
+}
+STDIN_MAX_BYTES = 256 * 1024
+SAMPLE_MAX_BYTES = 64 * 1024
+CONFIG_MAX_BYTES = 64 * 1024
+VERSION_MAX_CHARS = 64
+LOCK_WAIT_S = 0.5
+# A sample whose newest ``seen`` is older than this is "stale": Claude Code
+# has not spoken for a while (no session open, or the bridge is broken) and
+# the tokenserver's own probe is the better source again.  Shared with the
+# doctor and the tokenserver so all three agree on the word.
+FRESH_S = 15 * 60
+LOCK_RETRY_S = 0.05
+CHAINED_TIMEOUT_S = 10.0
+
+
+class RejectedPayload(ValueError):
+    """The stdin document must not touch the file (reason in ``args[0]``)."""
+
+
+def config_dir_key(config_dir: Path) -> str:
+    """The per-config-directory key setup and the bridge share."""
+    resolved = str(Path(config_dir).expanduser().resolve())
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:16]
+
+
+def claude_config_dir(env=None) -> Path:
+    """Where this Claude Code session keeps ``settings.json``."""
+    env = os.environ if env is None else env
+    override = env.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude"
+
+
+# --- validation -----------------------------------------------------------
+
+def _finite_number(value) -> bool:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:  # an int JSON parsed that no float can hold
+        return False
+
+
+def _validate_window(name: str, value, now: int) -> dict:
+    if not isinstance(value, dict):
+        raise RejectedPayload(f"{name}: not an object")
+    pct = value.get("used_percentage")
+    if not _finite_number(pct) or not 0 <= pct <= 100:
+        raise RejectedPayload(f"{name}: used_percentage out of range")
+    resets_at = value.get("resets_at")
+    if (not _finite_number(resets_at) or int(resets_at) != resets_at
+            or resets_at <= now
+            or resets_at > now + WINDOW_HORIZON_S[name]):
+        raise RejectedPayload(f"{name}: resets_at not a plausible epoch")
+    return {"pct": round(float(pct), 1), "resets_at": int(resets_at)}
+
+
+def parse_payload(raw: bytes, now: int) -> dict:
+    """Return ``{"windows": {...}, "version": str | None}`` or raise.
+
+    ``windows`` holds only the windows present on stdin, each validated.
+    A missing ``rate_limits`` block (the session-start invocation, the free
+    tier, an API-key session) is an empty ``windows`` -- no observation --
+    not a rejection.
+    """
+    if len(raw) > STDIN_MAX_BYTES:
+        raise RejectedPayload("stdin larger than the bound")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RejectedPayload(
+            f"stdin is not JSON ({type(error).__name__})") from None
+    if not isinstance(payload, dict):
+        raise RejectedPayload("stdin is not a JSON object")
+    windows = {}
+    limits = payload.get("rate_limits")
+    if limits is not None:
+        if not isinstance(limits, dict):
+            raise RejectedPayload("rate_limits is not an object")
+        for name in WINDOWS:
+            if name in limits:
+                windows[name] = _validate_window(name, limits[name], now)
+    version = payload.get("version")
+    if (not isinstance(version, str) or not version
+            or len(version) > VERSION_MAX_CHARS
+            or not version.isprintable()):
+        version = None
+    return {"windows": windows, "version": version}
+
+
+# --- the merge (pure) ---------------------------------------------------
+
+def _valid_stored_window(value, now: int, name: str) -> bool:
+    return (isinstance(value, dict)
+            and _finite_number(value.get("pct"))
+            and 0 <= value["pct"] <= 100
+            and _finite_number(value.get("resets_at"))
+            and value["resets_at"] > now
+            and value["resets_at"] <= now + WINDOW_HORIZON_S[name]
+            and _finite_number(value.get("at"))
+            and _finite_number(value.get("seen")))
+
+
+def merge_entry(stored, observed: dict, now: int) -> dict:
+    """Merge one payload's windows into one account entry.
+
+    ``stored`` is the entry as read from the file (anything; malformed
+    windows are treated as absent), ``observed`` is ``parse_payload``'s
+    result.  Returns the new entry; the caller decides whether it changed.
+    """
+    entry = {}
+    stored = stored if isinstance(stored, dict) else {}
+    for name in WINDOWS:
+        old = stored.get(name)
+        old = old if _valid_stored_window(old, now, name) else None
+        new = observed["windows"].get(name)
+        if new is None:
+            if old is not None:
+                entry[name] = dict(old)
+            continue
+        if (old is None or new["resets_at"] > old["resets_at"]
+                or (new["resets_at"] == old["resets_at"]
+                    and new["pct"] > old["pct"])):
+            entry[name] = {"pct": new["pct"], "resets_at": new["resets_at"],
+                           "at": now, "seen": now}
+        else:
+            # Same window, same or lower figure (a replay of Claude Code's
+            # cached values on a non-API trigger), or an older window than
+            # the one already stored: the value and its ``at`` stand, the
+            # bridge is nonetheless alive.
+            entry[name] = dict(old, seen=now)
+    version = observed.get("version")
+    if version is None:
+        version = stored.get("claude_code_version")
+    if isinstance(version, str) and version:
+        entry["claude_code_version"] = version[:VERSION_MAX_CHARS]
+    return entry
+
+
+# --- files --------------------------------------------------------------
+
+def sample_path(directory: Path | None = None) -> Path:
+    return (state_dir() if directory is None else Path(directory)) / SAMPLE_NAME
+
+
+def config_path(directory: Path | None = None) -> Path:
+    return (state_dir() if directory is None else Path(directory)) / CONFIG_NAME
+
+
+def _read_bounded_json(path: Path, limit: int):
+    """Return the parsed document, or raise: ``FileNotFoundError``,
+    ``OSError`` (unreadable) or ``ValueError`` (corrupt)."""
+    size = path.stat().st_size
+    if size > limit:
+        raise ValueError("larger than the bound")
+    raw = path.read_bytes()
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(type(error).__name__) from None
+
+
+def load_sample(path: Path):
+    """The stored document, or ``{}`` to start empty, or ``None`` when the
+    file exists but cannot be read (then nothing must be written back)."""
+    try:
+        document = _read_bounded_json(path, SAMPLE_MAX_BYTES)
+    except FileNotFoundError:
+        return {}
+    except ValueError as error:
+        quarantine_corrupt(path, str(error))
+        return {}
+    except OSError:
+        return None
+    if (not isinstance(document, dict)
+            or document.get("v") != SAMPLE_VERSION
+            or not isinstance(document.get("accounts"), dict)):
+        quarantine_corrupt(path, "not the v1 sample shape")
+        return {}
+    return document
+
+
+def peek_sample(path: Path) -> tuple[str, dict | None]:
+    """Read the sample without side effects, for the tokenserver and the
+    doctor: ``("missing", None)``, ``("unreadable", None)``,
+    ``("invalid", None)`` or ``("ok", document)``.  Never quarantines --
+    the bridge owns the file and does that on its next run."""
+    try:
+        document = _read_bounded_json(Path(path), SAMPLE_MAX_BYTES)
+    except FileNotFoundError:
+        return "missing", None
+    except ValueError:
+        return "invalid", None
+    except OSError:
+        return "unreadable", None
+    if (not isinstance(document, dict)
+            or document.get("v") != SAMPLE_VERSION
+            or not isinstance(document.get("accounts"), dict)):
+        return "invalid", None
+    return "ok", document
+
+
+def summarize_sample(document: dict | None, now: int) -> dict:
+    """The one account entry, validated and dated, for consumers.
+
+    Returns ``{"status": "empty" | "stale" | "fresh", "ageS": int | None,
+    "claudeCodeVersion": str | None, "windows": {name: {...}}}`` where
+    ``windows`` holds only the windows that are well-formed and have not
+    reset.  ``ageS`` is the age of the newest ``seen`` across them.
+    """
+    entry = None
+    if isinstance(document, dict) and isinstance(document.get("accounts"), dict):
+        entry = document["accounts"].get(ACCOUNT_KEY)
+    entry = entry if isinstance(entry, dict) else {}
+    windows = {name: dict(entry[name]) for name in WINDOWS
+               if _valid_stored_window(entry.get(name), now, name)}
+    version = entry.get("claude_code_version")
+    if not (isinstance(version, str) and version and version.isprintable()):
+        version = None
+    else:
+        version = version[:VERSION_MAX_CHARS]
+    if not windows:
+        return {"status": "empty", "ageS": None,
+                "claudeCodeVersion": version, "windows": {}}
+    seen = max(int(window["seen"]) for window in windows.values())
+    age = max(0, int(now) - seen)
+    return {"status": "fresh" if age <= FRESH_S else "stale", "ageS": age,
+            "claudeCodeVersion": version, "windows": windows}
+
+
+def chained_command(config_dir: Path, path: Path | None = None):
+    """The status line recorded for this config directory, or ``None``."""
+    try:
+        document = _read_bounded_json(
+            config_path() if path is None else path, CONFIG_MAX_BYTES)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(document, dict) or document.get("v") != CONFIG_VERSION:
+        return None
+    dirs = document.get("dirs")
+    if not isinstance(dirs, dict):
+        return None
+    record = dirs.get(config_dir_key(config_dir))
+    if not isinstance(record, dict):
+        return None
+    command = record.get("chained_command")
+    if isinstance(command, str) and command and "\n" not in command:
+        return command
+    return None
+
+
+def atomic_write_private(path: Path, payload: bytes) -> None:
+    """Write ``payload`` to ``path`` atomically, 0600, durable."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(name)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        temporary = None
+        fsync_parent(path)
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+
+
+class _Lock:
+    """Non-blocking interprocess lock with a bounded wait."""
+
+    def __init__(self, path: Path, wait_s: float = LOCK_WAIT_S,
+                 sleep=time.sleep, clock=time.monotonic):
+        self.path = Path(path)
+        self.wait_s = wait_s
+        self.sleep = sleep
+        self.clock = clock
+        self.handle = None
+
+    def _try(self) -> bool:
+        if fcntl is not None:
+            try:
+                fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return True
+            except OSError:
+                return False
+        if msvcrt is not None:
+            try:
+                msvcrt.locking(self.handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                return False
+        return True  # no locking primitive: behave as before locks existed
+
+    def __enter__(self) -> bool:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.handle = open(self.path, "a+")
+        except OSError:
+            return False
+        deadline = self.clock() + self.wait_s
+        while True:
+            if self._try():
+                return True
+            if self.clock() >= deadline:
+                self.handle.close()
+                self.handle = None
+                return False
+            self.sleep(LOCK_RETRY_S)
+
+    def __exit__(self, *exc) -> None:
+        if self.handle is None:
+            return
+        try:
+            if fcntl is not None:
+                fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+            elif msvcrt is not None:
+                msvcrt.locking(self.handle.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+        self.handle.close()
+        self.handle = None
+
+
+def record_sample(raw: bytes, *, now: int | None = None,
+                  directory: Path | None = None,
+                  lock_wait_s: float = LOCK_WAIT_S) -> str:
+    """Merge one stdin document into the sample file.
+
+    Returns a short outcome word for tests and the doctor: ``written``,
+    ``unchanged``, ``rejected``, ``locked`` (another bridge held the lock
+    for the whole bound), ``unreadable`` (the file exists but could not be
+    read, so nothing was replaced).  Never raises.
+    """
+    now = int(time.time()) if now is None else int(now)
+    try:
+        observed = parse_payload(raw, now)
+    except RejectedPayload:
+        return "rejected"
+    target = sample_path(directory)
+    lock = _Lock(target.with_name(LOCK_NAME), wait_s=lock_wait_s)
+    with lock as held:
+        if not held:
+            return "locked"
+        document = load_sample(target)
+        if document is None:
+            return "unreadable"
+        accounts = document.get("accounts") or {}
+        before = accounts.get(ACCOUNT_KEY)
+        after = merge_entry(before, observed, now)
+        if not any(name in after for name in WINDOWS):
+            after = None
+        if after == before:
+            return "unchanged"
+        accounts = dict(accounts)
+        if after is None:
+            accounts.pop(ACCOUNT_KEY, None)
+        else:
+            accounts[ACCOUNT_KEY] = after
+        payload = json.dumps({"v": SAMPLE_VERSION, "accounts": accounts},
+                             separators=(",", ":"), sort_keys=True)
+        try:
+            atomic_write_private(target, payload.encode("utf-8"))
+        except OSError:
+            return "unreadable"
+    return "written"
+
+
+def run_chained(command: str | None, stdin_bytes: bytes,
+                stdout=None, run=subprocess.run) -> int:
+    """Run the user's own status line with the same stdin; its stdout and
+    exit status pass through.  No command means an empty status line."""
+    if not command:
+        return 0
+    if sys.platform == "win32":
+        argv = ["cmd.exe", "/d", "/c", command]
+    else:
+        argv = ["/bin/sh", "-c", command]
+    try:
+        completed = run(argv, input=stdin_bytes, stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL, timeout=CHAINED_TIMEOUT_S,
+                        check=False)
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    out = stdout if stdout is not None else sys.stdout.buffer
+    try:
+        out.write(completed.stdout or b"")
+        out.flush()
+    except OSError:
+        pass
+    return int(completed.returncode or 0)
+
+
+def _directory_from_argv(argv) -> Path | None:
+    """``--state-dir PATH`` -- the launcher bakes in the directory it was
+    installed to, so the bridge and the record it reads never disagree."""
+    argv = list(argv or [])
+    if len(argv) == 2 and argv[0] == "--state-dir" and argv[1]:
+        return Path(argv[1])
+    return None
+
+
+def main(argv=None, *, stdin=None, stdout=None, env=None,
+         now=None, directory=None) -> int:
+    if directory is None:
+        directory = _directory_from_argv(argv)
+    stdin = sys.stdin.buffer if stdin is None else stdin
+    try:
+        raw = stdin.read(STDIN_MAX_BYTES + 1)
+    except OSError:
+        raw = b""
+    try:
+        record_sample(raw, now=now, directory=directory)
+    except Exception:  # noqa: S110 - a bridge bug must not take the status line down
+        pass
+    config_dir = claude_config_dir(env)
+    command = chained_command(
+        config_dir, None if directory is None else config_path(directory))
+    return run_chained(command, raw, stdout=stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/tokenserver/statusline_bridge.py
+++ b/tools/tokenserver/statusline_bridge.py
@@ -184,15 +184,45 @@ def parse_payload(raw: bytes, now: int) -> dict:
 
 # --- the merge (pure) ---------------------------------------------------
 
-def _valid_stored_window(value, now: int, name: str) -> bool:
+def _well_formed_window(value) -> bool:
+    """The persisted shape of one window, regardless of whether it has
+    reset since: the file-level check, so a malformed record is a corrupt
+    file to quarantine, never a value to silently drop and overwrite."""
     return (isinstance(value, dict)
             and _finite_number(value.get("pct"))
             and 0 <= value["pct"] <= 100
             and _finite_number(value.get("resets_at"))
-            and value["resets_at"] > now
-            and value["resets_at"] <= now + WINDOW_HORIZON_S[name]
+            and int(value["resets_at"]) == value["resets_at"]
             and _finite_number(value.get("at"))
             and _finite_number(value.get("seen")))
+
+
+def _valid_stored_window(value, now: int, name: str) -> bool:
+    """Well-formed AND still running: a reset in the future, within the
+    window's horizon."""
+    return (_well_formed_window(value)
+            and value["resets_at"] > now
+            and value["resets_at"] <= now + WINDOW_HORIZON_S[name])
+
+
+def _well_formed_document(document) -> bool:
+    """The whole v1 sample shape, down to each window: the envelope, every
+    account entry an object, every present window well-formed, the version
+    a string when present."""
+    if (not isinstance(document, dict)
+            or document.get("v") != SAMPLE_VERSION
+            or not isinstance(document.get("accounts"), dict)):
+        return False
+    for entry in document["accounts"].values():
+        if not isinstance(entry, dict):
+            return False
+        for name in WINDOWS:
+            if name in entry and not _well_formed_window(entry[name]):
+                return False
+        version = entry.get("claude_code_version")
+        if version is not None and not isinstance(version, str):
+            return False
+    return True
 
 
 def merge_entry(stored, observed: dict, now: int) -> dict:
@@ -266,9 +296,7 @@ def load_sample(path: Path):
         return {}
     except OSError:
         return None
-    if (not isinstance(document, dict)
-            or document.get("v") != SAMPLE_VERSION
-            or not isinstance(document.get("accounts"), dict)):
+    if not _well_formed_document(document):
         quarantine_corrupt(path, "not the v1 sample shape")
         return {}
     return document
@@ -287,9 +315,7 @@ def peek_sample(path: Path) -> tuple[str, dict | None]:
         return "invalid", None
     except OSError:
         return "unreadable", None
-    if (not isinstance(document, dict)
-            or document.get("v") != SAMPLE_VERSION
-            or not isinstance(document.get("accounts"), dict)):
+    if not _well_formed_document(document):
         return "invalid", None
     return "ok", document
 
@@ -300,14 +326,24 @@ def summarize_sample(document: dict | None, now: int) -> dict:
     Returns ``{"status": "empty" | "stale" | "fresh", "ageS": int | None,
     "claudeCodeVersion": str | None, "windows": {name: {...}}}`` where
     ``windows`` holds only the windows that are well-formed and have not
-    reset.  ``ageS`` is the age of the newest ``seen`` across them.
+    reset, each carrying its own ``age_s`` (since its ``seen``) and
+    ``fresh`` flag -- freshness is per window, because a payload that
+    keeps reporting only one window leaves the other's ``seen`` behind.
+    ``ageS`` and ``status`` describe the newest window.
     """
     entry = None
     if isinstance(document, dict) and isinstance(document.get("accounts"), dict):
         entry = document["accounts"].get(ACCOUNT_KEY)
     entry = entry if isinstance(entry, dict) else {}
-    windows = {name: dict(entry[name]) for name in WINDOWS
-               if _valid_stored_window(entry.get(name), now, name)}
+    windows = {}
+    for name in WINDOWS:
+        window = entry.get(name)
+        if not _valid_stored_window(window, now, name):
+            continue
+        window = dict(window)
+        window["age_s"] = max(0, int(now) - int(window["seen"]))
+        window["fresh"] = window["age_s"] <= FRESH_S
+        windows[name] = window
     version = entry.get("claude_code_version")
     if not (isinstance(version, str) and version and version.isprintable()):
         version = None
@@ -316,8 +352,7 @@ def summarize_sample(document: dict | None, now: int) -> dict:
     if not windows:
         return {"status": "empty", "ageS": None,
                 "claudeCodeVersion": version, "windows": {}}
-    seen = max(int(window["seen"]) for window in windows.values())
-    age = max(0, int(now) - seen)
+    age = min(window["age_s"] for window in windows.values())
     return {"status": "fresh" if age <= FRESH_S else "stale", "ageS": age,
             "claudeCodeVersion": version, "windows": windows}
 

--- a/tools/tokenserver/statusline_bridge.py
+++ b/tools/tokenserver/statusline_bridge.py
@@ -88,6 +88,10 @@ WINDOW_HORIZON_S = {
     "seven_day": 8 * 24 * 3600,
 }
 STDIN_MAX_BYTES = 256 * 1024
+# The chained status line was promised the same stdin: everything is
+# forwarded, up to this hard bound, even when the sample parser refuses
+# more than STDIN_MAX_BYTES of it.
+STDIN_FORWARD_MAX_BYTES = 8 * 1024 * 1024
 SAMPLE_MAX_BYTES = 64 * 1024
 CONFIG_MAX_BYTES = 64 * 1024
 VERSION_MAX_CHARS = 64
@@ -488,24 +492,44 @@ def run_chained(command: str | None, stdin_bytes: bytes,
     return int(completed.returncode or 0)
 
 
-def _directory_from_argv(argv) -> Path | None:
-    """``--state-dir PATH`` -- the launcher bakes in the directory it was
-    installed to, so the bridge and the record it reads never disagree."""
+def parse_argv(argv) -> dict:
+    """``--state-dir PATH`` and ``--chained COMMAND``, both baked into the
+    launcher at install time: the directory so the bridge and the record
+    it reads never disagree, the previous status line so a record that
+    cannot be read (corrupt, mid-rewrite, permissions) still leaves the
+    user their own status line.  Anything else is ignored."""
     argv = list(argv or [])
-    if len(argv) == 2 and argv[0] == "--state-dir" and argv[1]:
-        return Path(argv[1])
-    return None
+    found = {"directory": None, "chained": None}
+    index = 0
+    while index + 1 < len(argv):
+        flag, value = argv[index], argv[index + 1]
+        if flag == "--state-dir" and value:
+            found["directory"] = Path(value)
+        elif flag == "--chained" and value and "\n" not in value:
+            found["chained"] = value
+        index += 2
+    return found
+
+
+def _directory_from_argv(argv) -> Path | None:
+    return parse_argv(argv)["directory"]
+
+
+def read_stdin(stdin) -> bytes:
+    """Everything Claude Code wrote, up to the forward bound."""
+    try:
+        return stdin.read(STDIN_FORWARD_MAX_BYTES) or b""
+    except OSError:
+        return b""
 
 
 def main(argv=None, *, stdin=None, stdout=None, env=None,
          now=None, directory=None) -> int:
+    options = parse_argv(argv)
     if directory is None:
-        directory = _directory_from_argv(argv)
+        directory = options["directory"]
     stdin = sys.stdin.buffer if stdin is None else stdin
-    try:
-        raw = stdin.read(STDIN_MAX_BYTES + 1)
-    except OSError:
-        raw = b""
+    raw = read_stdin(stdin)
     try:
         record_sample(raw, now=now, directory=directory)
     except Exception:  # noqa: S110 - a bridge bug must not take the status line down
@@ -513,6 +537,10 @@ def main(argv=None, *, stdin=None, stdout=None, env=None,
     config_dir = claude_config_dir(env)
     command = chained_command(
         config_dir, None if directory is None else config_path(directory))
+    if command is None:
+        # No readable record for this config directory: the launcher's
+        # baked-in copy of the previous status line stands in.
+        command = options["chained"]
     return run_chained(command, raw, stdout=stdout)
 
 

--- a/tools/tokenserver/statusline_bridge.py
+++ b/tools/tokenserver/statusline_bridge.py
@@ -247,12 +247,16 @@ def merge_entry(stored, observed: dict, now: int) -> dict:
                     and new["pct"] > old["pct"])):
             entry[name] = {"pct": new["pct"], "resets_at": new["resets_at"],
                            "at": now, "seen": now}
-        else:
+        elif new["resets_at"] == old["resets_at"]:
             # Same window, same or lower figure (a replay of Claude Code's
-            # cached values on a non-API trigger), or an older window than
-            # the one already stored: the value and its ``at`` stand, the
-            # bridge is nonetheless alive.
+            # cached values on a non-API trigger): the value and its
+            # ``at`` stand, but this window was observed, so it is fresh.
             entry[name] = dict(old, seen=now)
+        else:
+            # An older window than the one stored: another session still
+            # holding a cached, since-superseded window. It never observed
+            # the stored one, so it must not vouch for its freshness.
+            entry[name] = dict(old)
     version = observed.get("version")
     if version is None:
         version = stored.get("claude_code_version")

--- a/tools/tokenserver/test_provider_gate.py
+++ b/tools/tokenserver/test_provider_gate.py
@@ -22,6 +22,17 @@ from unittest import mock
 from tools.tokenserver import codex_usage, tokenserver
 
 
+def setUpModule():
+    # A statusLine bridge installed on the developer's own machine must
+    # not feed these snapshots: point the reader at a file that is absent.
+    tokenserver._claude_statusline_path_override = (
+        Path(tempfile.gettempdir()) / "vibepulse-no-statusline-sample.json")
+
+
+def tearDownModule():
+    tokenserver._claude_statusline_path_override = None
+
+
 class ProviderGateTest(unittest.TestCase):
     """``_any_provider_dir``: either provider is enough."""
 

--- a/tools/tokenserver/test_smoke.py
+++ b/tools/tokenserver/test_smoke.py
@@ -147,6 +147,34 @@ class ServerCheckTests(unittest.TestCase):
         self.assertTrue(any("rereads it automatically" in text
                             for text in warnings))
 
+    def test_statusline_bridge_is_judged_only_when_installed(self):
+        cases = {
+            "not_installed": None,
+            "fresh": smoke.OK,
+            "stale": smoke.WARN,
+            "missing": smoke.WARN,
+            "empty": smoke.WARN,
+            "invalid": smoke.WARN,
+        }
+        for state, level in cases.items():
+            with self.subTest(state=state):
+                root = dict(HEALTHY_ROOT, claudeStatusline={
+                    "status": state, "ageS": 1200, "bridged": False,
+                    "claudeCodeVersion": "2.1.0",
+                    "account": "assumed-single"})
+                with canned_server({"/": root}) as base:
+                    results = smoke.check_server(base, checkout_rev="abc1234")
+                lines = [(lvl, text) for lvl, text in results
+                         if "statusLine bridge" in text]
+                if level is None:
+                    self.assertEqual(lines, [])
+                else:
+                    self.assertEqual([lvl for lvl, _ in lines], [level])
+                    if state in ("fresh", "stale"):
+                        self.assertIn("2.1.0", lines[0][1])
+                    if state == "stale":
+                        self.assertIn("20 min ago", lines[0][1])
+
     def test_unknown_buckets_warn(self):
         root = dict(HEALTHY_ROOT, unknownRateLimitBuckets=["7d_haiku"])
         with canned_server({"/": root}) as base:

--- a/tools/tokenserver/test_statusline_bridge.py
+++ b/tools/tokenserver/test_statusline_bridge.py
@@ -149,13 +149,14 @@ class MergeEntryTests(unittest.TestCase):
         self.assertEqual(entry["five_hour"]["pct"], 1.0)
         self.assertEqual(entry["five_hour"]["resets_at"], NOW + 3600)
 
-    def test_older_reset_than_stored_is_a_replay(self):
+    def test_older_reset_than_stored_never_vouches_for_the_newer(self):
+        # Another session re-emitting a superseded window did not observe
+        # the stored one: value, ``at`` AND ``seen`` stay as they were.
         stored = {"five_hour": {"pct": 5.0, "resets_at": NOW + 3600,
                                 "at": NOW - 60, "seen": NOW - 60}}
         entry = bridge.merge_entry(stored, self.observed(
             five_hour={"pct": 99.0, "resets_at": NOW + 100}), NOW)
-        self.assertEqual(entry["five_hour"]["pct"], 5.0)
-        self.assertEqual(entry["five_hour"]["seen"], NOW)
+        self.assertEqual(entry["five_hour"], stored["five_hour"])
 
     def test_absent_window_keeps_stored_until_it_expires(self):
         stored = {"seven_day": {"pct": 12.5, "resets_at": NOW + 100,

--- a/tools/tokenserver/test_statusline_bridge.py
+++ b/tools/tokenserver/test_statusline_bridge.py
@@ -1,0 +1,506 @@
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.tokenserver import statusline_bridge as bridge
+
+
+NOW = 1_800_000_000
+FIVE = {"used_percentage": 42.0, "resets_at": NOW + 4 * 3600}
+WEEK = {"used_percentage": 12.5, "resets_at": NOW + 5 * 86400}
+
+
+def payload(**overrides):
+    document = {
+        "version": "2.1.0",
+        "session_id": "abc",
+        "transcript_path": "/Users/x/.claude/projects/y/z.jsonl",
+        "rate_limits": {"five_hour": dict(FIVE), "seven_day": dict(WEEK)},
+    }
+    document.update(overrides)
+    return json.dumps(document).encode("utf-8")
+
+
+class ParsePayloadTests(unittest.TestCase):
+    def test_keeps_only_the_two_windows_and_the_version(self):
+        parsed = bridge.parse_payload(payload(), NOW)
+        self.assertEqual(parsed["version"], "2.1.0")
+        self.assertEqual(parsed["windows"], {
+            "five_hour": {"pct": 42.0, "resets_at": NOW + 4 * 3600},
+            "seven_day": {"pct": 12.5, "resets_at": NOW + 5 * 86400},
+        })
+
+    def test_missing_rate_limits_is_no_observation(self):
+        parsed = bridge.parse_payload(payload(rate_limits=None), NOW)
+        self.assertEqual(parsed["windows"], {})
+        document = json.loads(payload())
+        del document["rate_limits"]
+        parsed = bridge.parse_payload(json.dumps(document).encode(), NOW)
+        self.assertEqual(parsed["windows"], {})
+
+    def test_one_window_absent_keeps_the_other(self):
+        parsed = bridge.parse_payload(
+            payload(rate_limits={"seven_day": dict(WEEK)}), NOW)
+        self.assertEqual(list(parsed["windows"]), ["seven_day"])
+
+    def test_malformed_window_rejects_the_whole_payload(self):
+        cases = {
+            "pct string": {"used_percentage": "42", "resets_at": FIVE["resets_at"]},
+            "pct bool": {"used_percentage": True, "resets_at": FIVE["resets_at"]},
+            "pct negative": {"used_percentage": -1, "resets_at": FIVE["resets_at"]},
+            "pct over 100": {"used_percentage": 100.5, "resets_at": FIVE["resets_at"]},
+            "pct nan": {"used_percentage": float("nan"), "resets_at": FIVE["resets_at"]},
+            "reset past": {"used_percentage": 1, "resets_at": NOW},
+            "reset too far": {"used_percentage": 1, "resets_at": NOW + 6 * 3600},
+            "reset fractional": {"used_percentage": 1, "resets_at": NOW + 10.5},
+            "reset huge": {"used_percentage": 1, "resets_at": 10 ** 400},
+            "reset missing": {"used_percentage": 1},
+            "not an object": [1, 2],
+        }
+        for label, window in cases.items():
+            with self.subTest(label):
+                raw = json.dumps({"rate_limits": {"five_hour": window,
+                                                  "seven_day": dict(WEEK)}},
+                                 allow_nan=True).encode()
+                with self.assertRaises(bridge.RejectedPayload):
+                    bridge.parse_payload(raw, NOW)
+
+    def test_weekly_horizon_is_eight_days(self):
+        ok = {"used_percentage": 1, "resets_at": NOW + 7 * 86400 + 3600}
+        bad = {"used_percentage": 1, "resets_at": NOW + 9 * 86400}
+        bridge.parse_payload(
+            json.dumps({"rate_limits": {"seven_day": ok}}).encode(), NOW)
+        with self.assertRaises(bridge.RejectedPayload):
+            bridge.parse_payload(
+                json.dumps({"rate_limits": {"seven_day": bad}}).encode(), NOW)
+
+    def test_non_json_and_non_object_are_rejected(self):
+        for raw in (b"", b"not json", b"[1]", b"\xff\xfe", b"42", b"null"):
+            with self.subTest(raw):
+                with self.assertRaises(bridge.RejectedPayload):
+                    bridge.parse_payload(raw, NOW)
+        with self.assertRaises(bridge.RejectedPayload):
+            bridge.parse_payload(json.dumps({"rate_limits": 7}).encode(), NOW)
+
+    def test_oversized_stdin_is_rejected(self):
+        raw = b'{"pad":"' + b"x" * bridge.STDIN_MAX_BYTES + b'"}'
+        with self.assertRaises(bridge.RejectedPayload):
+            bridge.parse_payload(raw, NOW)
+
+    def test_version_is_bounded_and_printable(self):
+        for bad in ("", "x" * 65, "1.0\n", 7, None):
+            with self.subTest(bad):
+                parsed = bridge.parse_payload(payload(version=bad), NOW)
+                self.assertIsNone(parsed["version"])
+
+
+class MergeEntryTests(unittest.TestCase):
+    def observed(self, **windows):
+        return {"windows": windows, "version": "2.1.0"}
+
+    def test_first_observation_stamps_at_and_seen(self):
+        entry = bridge.merge_entry(None, self.observed(
+            five_hour={"pct": 42.0, "resets_at": NOW + 100}), NOW)
+        self.assertEqual(entry, {
+            "five_hour": {"pct": 42.0, "resets_at": NOW + 100,
+                          "at": NOW, "seen": NOW},
+            "claude_code_version": "2.1.0",
+        })
+
+    def test_replay_keeps_value_and_advances_seen(self):
+        stored = {"five_hour": {"pct": 42.0, "resets_at": NOW + 100,
+                                "at": NOW - 60, "seen": NOW - 60}}
+        for pct in (42.0, 30.0):
+            with self.subTest(pct):
+                entry = bridge.merge_entry(stored, self.observed(
+                    five_hour={"pct": pct, "resets_at": NOW + 100}), NOW)
+                self.assertEqual(entry["five_hour"], {
+                    "pct": 42.0, "resets_at": NOW + 100,
+                    "at": NOW - 60, "seen": NOW})
+
+    def test_higher_pct_in_the_same_window_replaces(self):
+        stored = {"five_hour": {"pct": 42.0, "resets_at": NOW + 100,
+                                "at": NOW - 60, "seen": NOW - 60}}
+        entry = bridge.merge_entry(stored, self.observed(
+            five_hour={"pct": 43.0, "resets_at": NOW + 100}), NOW)
+        self.assertEqual(entry["five_hour"],
+                         {"pct": 43.0, "resets_at": NOW + 100,
+                          "at": NOW, "seen": NOW})
+
+    def test_newer_reset_replaces_even_with_lower_pct(self):
+        stored = {"five_hour": {"pct": 90.0, "resets_at": NOW + 100,
+                                "at": NOW - 60, "seen": NOW - 60}}
+        entry = bridge.merge_entry(stored, self.observed(
+            five_hour={"pct": 1.0, "resets_at": NOW + 3600}), NOW)
+        self.assertEqual(entry["five_hour"]["pct"], 1.0)
+        self.assertEqual(entry["five_hour"]["resets_at"], NOW + 3600)
+
+    def test_older_reset_than_stored_is_a_replay(self):
+        stored = {"five_hour": {"pct": 5.0, "resets_at": NOW + 3600,
+                                "at": NOW - 60, "seen": NOW - 60}}
+        entry = bridge.merge_entry(stored, self.observed(
+            five_hour={"pct": 99.0, "resets_at": NOW + 100}), NOW)
+        self.assertEqual(entry["five_hour"]["pct"], 5.0)
+        self.assertEqual(entry["five_hour"]["seen"], NOW)
+
+    def test_absent_window_keeps_stored_until_it_expires(self):
+        stored = {"seven_day": {"pct": 12.5, "resets_at": NOW + 100,
+                                "at": NOW - 60, "seen": NOW - 60},
+                  "claude_code_version": "2.0.0"}
+        entry = bridge.merge_entry(stored, self.observed(), NOW)
+        self.assertEqual(entry["seven_day"], stored["seven_day"])
+        entry = bridge.merge_entry(stored, self.observed(), NOW + 100)
+        self.assertNotIn("seven_day", entry)
+
+    def test_malformed_stored_window_is_treated_as_absent(self):
+        for stored in ({"five_hour": "junk"},
+                       {"five_hour": {"pct": 500, "resets_at": NOW + 1,
+                                      "at": 1, "seen": 1}},
+                       {"five_hour": {"pct": 5, "resets_at": NOW + 10 ** 9,
+                                      "at": 1, "seen": 1}},
+                       {"five_hour": {"pct": 5, "resets_at": NOW + 1}},
+                       "not a dict", 7):
+            with self.subTest(stored):
+                entry = bridge.merge_entry(stored, self.observed(
+                    five_hour={"pct": 1.0, "resets_at": NOW + 50}), NOW)
+                self.assertEqual(entry["five_hour"]["pct"], 1.0)
+
+    def test_version_carries_over_when_the_payload_has_none(self):
+        stored = {"claude_code_version": "2.0.0"}
+        entry = bridge.merge_entry(
+            stored, {"windows": {}, "version": None}, NOW)
+        self.assertEqual(entry["claude_code_version"], "2.0.0")
+        entry = bridge.merge_entry(
+            {"claude_code_version": 7}, {"windows": {}, "version": None}, NOW)
+        self.assertNotIn("claude_code_version", entry)
+
+
+class RecordSampleTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name) / "state"
+
+    def read(self):
+        return json.loads((self.dir / bridge.SAMPLE_NAME).read_text())
+
+    def test_first_write_creates_a_private_v1_file(self):
+        self.assertEqual(bridge.record_sample(payload(), now=NOW,
+                                              directory=self.dir), "written")
+        document = self.read()
+        self.assertEqual(document["v"], 1)
+        entry = document["accounts"]["single"]
+        self.assertEqual(entry["five_hour"]["pct"], 42.0)
+        self.assertEqual(entry["seven_day"]["resets_at"], WEEK["resets_at"])
+        self.assertEqual(entry["claude_code_version"], "2.1.0")
+        if os.name == "posix":
+            mode = stat.S_IMODE((self.dir / bridge.SAMPLE_NAME).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+        self.assertEqual(
+            [p.name for p in self.dir.iterdir() if p.name.startswith(".")], [])
+
+    def test_replay_at_the_same_second_is_unchanged(self):
+        bridge.record_sample(payload(), now=NOW, directory=self.dir)
+        self.assertEqual(bridge.record_sample(payload(), now=NOW,
+                                              directory=self.dir), "unchanged")
+
+    def test_replay_later_advances_seen_only(self):
+        bridge.record_sample(payload(), now=NOW, directory=self.dir)
+        self.assertEqual(bridge.record_sample(payload(), now=NOW + 30,
+                                              directory=self.dir), "written")
+        entry = self.read()["accounts"]["single"]
+        self.assertEqual(entry["five_hour"]["at"], NOW)
+        self.assertEqual(entry["five_hour"]["seen"], NOW + 30)
+
+    def test_rejected_payload_leaves_the_file_untouched(self):
+        bridge.record_sample(payload(), now=NOW, directory=self.dir)
+        before = (self.dir / bridge.SAMPLE_NAME).read_bytes()
+        bad = payload(rate_limits={
+            "five_hour": {"used_percentage": 99, "resets_at": FIVE["resets_at"]},
+            "seven_day": {"used_percentage": "junk", "resets_at": 1}})
+        self.assertEqual(bridge.record_sample(bad, now=NOW + 1,
+                                              directory=self.dir), "rejected")
+        self.assertEqual((self.dir / bridge.SAMPLE_NAME).read_bytes(), before)
+
+    def test_session_start_payload_without_limits_writes_nothing_new(self):
+        raw = payload(rate_limits=None)
+        self.assertEqual(bridge.record_sample(raw, now=NOW,
+                                              directory=self.dir), "unchanged")
+        self.assertFalse((self.dir / bridge.SAMPLE_NAME).exists())
+
+    def test_expired_windows_are_dropped_and_empty_entry_removed(self):
+        bridge.record_sample(payload(), now=NOW, directory=self.dir)
+        later = WEEK["resets_at"] + 1
+        raw = payload(rate_limits=None)
+        self.assertEqual(bridge.record_sample(raw, now=later,
+                                              directory=self.dir), "written")
+        self.assertEqual(self.read(), {"v": 1, "accounts": {}})
+
+    def test_corrupt_file_is_quarantined_not_overwritten(self):
+        self.dir.mkdir(parents=True)
+        target = self.dir / bridge.SAMPLE_NAME
+        target.write_text("{not json")
+        with self.assertLogs("tokenserver.state", level="WARNING"):
+            outcome = bridge.record_sample(payload(), now=NOW,
+                                           directory=self.dir)
+        self.assertEqual(outcome, "written")
+        quarantined = [p for p in self.dir.iterdir()
+                       if ".corrupt-" in p.name]
+        self.assertEqual(len(quarantined), 1)
+        self.assertEqual(quarantined[0].read_text(), "{not json")
+        self.assertEqual(self.read()["accounts"]["single"]["five_hour"]["pct"],
+                         42.0)
+
+    def test_wrong_shape_is_quarantined(self):
+        self.dir.mkdir(parents=True)
+        (self.dir / bridge.SAMPLE_NAME).write_text(json.dumps({"v": 2}))
+        with self.assertLogs("tokenserver.state", level="WARNING"):
+            bridge.record_sample(payload(), now=NOW, directory=self.dir)
+        self.assertEqual(self.read()["v"], 1)
+
+    def test_unreadable_file_skips_the_write(self):
+        self.dir.mkdir(parents=True)
+        target = self.dir / bridge.SAMPLE_NAME
+        target.write_text("{}")
+        with mock.patch.object(Path, "read_bytes",
+                               side_effect=PermissionError("nope")):
+            outcome = bridge.record_sample(payload(), now=NOW,
+                                           directory=self.dir)
+        self.assertEqual(outcome, "unreadable")
+        self.assertEqual(target.read_text(), "{}")
+
+    @unittest.skipIf(bridge.fcntl is None and bridge.msvcrt is None,
+                     "no interprocess lock primitive")
+    def test_held_lock_skips_the_write_within_the_bound(self):
+        self.dir.mkdir(parents=True)
+        lock = bridge._Lock(self.dir / bridge.LOCK_NAME, wait_s=0)
+        with lock as held:
+            self.assertTrue(held)
+            with mock.patch.object(bridge, "LOCK_RETRY_S", 0):
+                outcome = bridge.record_sample(payload(), now=NOW,
+                                               directory=self.dir,
+                                               lock_wait_s=0.05)
+        self.assertEqual(outcome, "locked")
+        self.assertFalse((self.dir / bridge.SAMPLE_NAME).exists())
+        self.assertEqual(bridge.record_sample(payload(), now=NOW,
+                                              directory=self.dir), "written")
+
+    def test_unwritable_directory_is_reported_not_raised(self):
+        with mock.patch.object(bridge, "atomic_write_private",
+                               side_effect=OSError("disk full")):
+            outcome = bridge.record_sample(payload(), now=NOW,
+                                           directory=self.dir)
+        self.assertEqual(outcome, "unreadable")
+
+
+class SummarizeSampleTests(unittest.TestCase):
+    def document(self, **entry):
+        return {"v": 1, "accounts": {"single": entry}}
+
+    def test_fresh_stale_and_empty(self):
+        five = {"pct": 42.0, "resets_at": NOW + 100, "at": NOW - 10,
+                "seen": NOW - 10}
+        week = {"pct": 12.5, "resets_at": NOW + 86400, "at": NOW - 3000,
+                "seen": NOW - 3000}
+        summary = bridge.summarize_sample(
+            self.document(five_hour=five, seven_day=week,
+                          claude_code_version="2.1.0"), NOW)
+        self.assertEqual(summary["status"], "fresh")
+        self.assertEqual(summary["ageS"], 10)
+        self.assertEqual(summary["claudeCodeVersion"], "2.1.0")
+        self.assertEqual(set(summary["windows"]), {"five_hour", "seven_day"})
+        later = NOW + bridge.FRESH_S + 1
+        summary = bridge.summarize_sample(
+            self.document(five_hour=five, seven_day=week), later)
+        self.assertEqual(summary["status"], "stale")
+        self.assertEqual(list(summary["windows"]), ["seven_day"])
+        summary = bridge.summarize_sample(
+            self.document(five_hour=five, seven_day=week), NOW + 86400)
+        self.assertEqual(summary, {"status": "empty", "ageS": None,
+                                   "claudeCodeVersion": None, "windows": {}})
+        self.assertEqual(bridge.summarize_sample(None, NOW)["status"], "empty")
+        self.assertEqual(bridge.summarize_sample({"v": 1, "accounts": "x"},
+                                                 NOW)["status"], "empty")
+
+    def test_bad_version_is_dropped(self):
+        five = {"pct": 1, "resets_at": NOW + 100, "at": NOW, "seen": NOW}
+        for version in (7, "", "a\nb", "x" * 200):
+            summary = bridge.summarize_sample(
+                self.document(five_hour=five, claude_code_version=version), NOW)
+            self.assertIn(summary["claudeCodeVersion"], (None, "x" * 64))
+
+    def test_peek_sample_never_quarantines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / bridge.SAMPLE_NAME
+            self.assertEqual(bridge.peek_sample(path), ("missing", None))
+            path.write_text("{oops")
+            self.assertEqual(bridge.peek_sample(path), ("invalid", None))
+            self.assertEqual(path.read_text(), "{oops")
+            path.write_text(json.dumps({"v": 2, "accounts": {}}))
+            self.assertEqual(bridge.peek_sample(path), ("invalid", None))
+            path.write_text(json.dumps({"v": 1, "accounts": {}}))
+            self.assertEqual(bridge.peek_sample(path),
+                             ("ok", {"v": 1, "accounts": {}}))
+            with mock.patch.object(Path, "read_bytes",
+                                   side_effect=PermissionError("nope")):
+                self.assertEqual(bridge.peek_sample(path),
+                                 ("unreadable", None))
+
+
+class ChainedCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.config_dir = self.dir / "claude"
+
+    def write_config(self, record):
+        path = self.dir / bridge.CONFIG_NAME
+        key = bridge.config_dir_key(self.config_dir)
+        path.write_text(json.dumps({"v": 1, "dirs": {key: record}}))
+        return path
+
+    def test_reads_the_command_recorded_for_this_config_dir(self):
+        path = self.write_config({"chained_command": "echo hi"})
+        self.assertEqual(bridge.chained_command(self.config_dir, path),
+                         "echo hi")
+        other = self.dir / "other"
+        self.assertIsNone(bridge.chained_command(other, path))
+
+    def test_missing_or_malformed_config_means_no_command(self):
+        self.assertIsNone(bridge.chained_command(
+            self.config_dir, self.dir / "absent.json"))
+        for record in ({"chained_command": ""}, {"chained_command": 7},
+                       {"chained_command": "a\nb"}, {}, "junk"):
+            with self.subTest(record):
+                path = self.write_config(record)
+                self.assertIsNone(bridge.chained_command(self.config_dir, path))
+        path = self.dir / bridge.CONFIG_NAME
+        path.write_text("{oops")
+        self.assertIsNone(bridge.chained_command(self.config_dir, path))
+
+    def test_config_dir_key_is_stable_and_path_independent(self):
+        key = bridge.config_dir_key(self.config_dir)
+        self.assertEqual(len(key), 16)
+        self.assertEqual(key, bridge.config_dir_key(
+            self.dir / "x" / ".." / "claude"))
+
+    def test_claude_config_dir_honours_the_override(self):
+        self.assertEqual(bridge.claude_config_dir({"CLAUDE_CONFIG_DIR": "/x"}),
+                         Path("/x"))
+        self.assertEqual(bridge.claude_config_dir({}), Path.home() / ".claude")
+
+
+class RunChainedTests(unittest.TestCase):
+    def test_no_command_prints_nothing_and_exits_zero(self):
+        out = io.BytesIO()
+        run = mock.Mock()
+        self.assertEqual(bridge.run_chained(None, b"{}", stdout=out, run=run), 0)
+        self.assertEqual(out.getvalue(), b"")
+        run.assert_not_called()
+
+    def test_stdin_stdout_and_exit_status_pass_through(self):
+        out = io.BytesIO()
+        completed = subprocess.CompletedProcess(["sh"], 3, stdout=b"line\n")
+        run = mock.Mock(return_value=completed)
+        code = bridge.run_chained("my-status", b'{"a":1}', stdout=out, run=run)
+        self.assertEqual(code, 3)
+        self.assertEqual(out.getvalue(), b"line\n")
+        argv, kwargs = run.call_args
+        self.assertEqual(argv[0][-1], "my-status")
+        self.assertEqual(kwargs["input"], b'{"a":1}')
+        self.assertEqual(kwargs["timeout"], bridge.CHAINED_TIMEOUT_S)
+
+    def test_failed_or_timed_out_command_still_exits_zero(self):
+        for error in (OSError("no shell"),
+                      subprocess.TimeoutExpired("x", 10)):
+            with self.subTest(error):
+                out = io.BytesIO()
+                run = mock.Mock(side_effect=error)
+                self.assertEqual(
+                    bridge.run_chained("slow", b"", stdout=out, run=run), 0)
+                self.assertEqual(out.getvalue(), b"")
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX shell")
+    def test_real_shell_round_trip(self):
+        out = io.BytesIO()
+        code = bridge.run_chained("cat; exit 4", b"payload", stdout=out)
+        self.assertEqual(code, 4)
+        self.assertEqual(out.getvalue(), b"payload")
+
+
+class MainTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name) / "state"
+        self.config_dir = Path(self.tmp.name) / "claude"
+
+    def test_records_then_runs_the_chained_command(self):
+        self.dir.mkdir()
+        key = bridge.config_dir_key(self.config_dir)
+        (self.dir / bridge.CONFIG_NAME).write_text(json.dumps(
+            {"v": 1, "dirs": {key: {"chained_command": "cat"}}}))
+        out = io.BytesIO()
+        raw = payload()
+        code = bridge.main([], stdin=io.BytesIO(raw), stdout=out,
+                           env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                           now=NOW, directory=self.dir)
+        self.assertEqual(code, 0)
+        if sys.platform != "win32":
+            self.assertEqual(out.getvalue(), raw)
+        document = json.loads((self.dir / bridge.SAMPLE_NAME).read_text())
+        self.assertEqual(document["accounts"]["single"]["five_hour"]["pct"],
+                         42.0)
+
+    def test_state_dir_argument_selects_the_directory(self):
+        out = io.BytesIO()
+        code = bridge.main(["--state-dir", str(self.dir)],
+                           stdin=io.BytesIO(payload()), stdout=out,
+                           env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                           now=NOW)
+        self.assertEqual(code, 0)
+        self.assertTrue((self.dir / bridge.SAMPLE_NAME).is_file())
+        self.assertIsNone(bridge._directory_from_argv(["--state-dir"]))
+        self.assertIsNone(bridge._directory_from_argv(["--other", "x"]))
+        self.assertIsNone(bridge._directory_from_argv(None))
+
+    def test_bridge_prints_nothing_without_a_chained_command(self):
+        out = io.BytesIO()
+        code = bridge.main([], stdin=io.BytesIO(payload()), stdout=out,
+                           env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                           now=NOW, directory=self.dir)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), b"")
+
+    def test_a_bridge_bug_never_takes_the_status_line_down(self):
+        out = io.BytesIO()
+        with mock.patch.object(bridge, "record_sample",
+                               side_effect=RuntimeError("boom")):
+            code = bridge.main([], stdin=io.BytesIO(payload()), stdout=out,
+                               env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                               now=NOW, directory=self.dir)
+        self.assertEqual(code, 0)
+
+    def test_stdin_read_error_is_an_empty_payload(self):
+        class Broken(io.RawIOBase):
+            def read(self, n=-1):
+                raise OSError("closed")
+
+        out = io.BytesIO()
+        code = bridge.main([], stdin=Broken(), stdout=out,
+                           env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                           now=NOW, directory=self.dir)
+        self.assertEqual(code, 0)
+        self.assertFalse((self.dir / bridge.SAMPLE_NAME).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tokenserver/test_statusline_bridge.py
+++ b/tools/tokenserver/test_statusline_bridge.py
@@ -94,6 +94,13 @@ class ParsePayloadTests(unittest.TestCase):
         with self.assertRaises(bridge.RejectedPayload):
             bridge.parse_payload(raw, NOW)
 
+    def test_read_stdin_forwards_past_the_parse_cap(self):
+        raw = b"x" * (bridge.STDIN_MAX_BYTES + 10)
+        self.assertEqual(bridge.read_stdin(io.BytesIO(raw)), raw)
+        self.assertEqual(len(bridge.read_stdin(io.BytesIO(
+            b"y" * (bridge.STDIN_FORWARD_MAX_BYTES + 1)))),
+            bridge.STDIN_FORWARD_MAX_BYTES)
+
     def test_version_is_bounded_and_printable(self):
         for bad in ("", "x" * 65, "1.0\n", 7, None):
             with self.subTest(bad):
@@ -471,6 +478,58 @@ class MainTests(unittest.TestCase):
         self.assertIsNone(bridge._directory_from_argv(["--state-dir"]))
         self.assertIsNone(bridge._directory_from_argv(["--other", "x"]))
         self.assertIsNone(bridge._directory_from_argv(None))
+        options = bridge.parse_argv(["--chained", "my-status", "--state-dir",
+                                     "/s", "--junk", "1"])
+        self.assertEqual(options, {"directory": Path("/s"),
+                                   "chained": "my-status"})
+        self.assertIsNone(bridge.parse_argv(["--chained", ""])["chained"])
+        self.assertIsNone(bridge.parse_argv(["--chained", "a\nb"])["chained"])
+
+    def _capture_chained(self):
+        calls = []
+
+        def fake(command, stdin_bytes, stdout=None, run=None):
+            calls.append((command, stdin_bytes))
+            if stdout is not None and command:
+                stdout.write(b"old line")
+            return 0
+        return calls, mock.patch.object(bridge, "run_chained", fake)
+
+    def test_baked_chained_command_stands_in_for_an_unreadable_record(self):
+        self.dir.mkdir()
+        (self.dir / bridge.CONFIG_NAME).write_text("{corrupt")
+        out = io.BytesIO()
+        calls, patch = self._capture_chained()
+        with patch:
+            code = bridge.main(["--state-dir", str(self.dir),
+                                "--chained", "my-status"],
+                               stdin=io.BytesIO(payload()), stdout=out,
+                               env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                               now=NOW)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), b"old line")
+        self.assertEqual(calls[-1][0], "my-status")
+        # The record, when readable, still wins over the baked copy.
+        key = bridge.config_dir_key(self.config_dir)
+        (self.dir / bridge.CONFIG_NAME).write_text(json.dumps(
+            {"v": 1, "dirs": {key: {"chained_command": "from-record"}}}))
+        with patch:
+            bridge.main(["--state-dir", str(self.dir), "--chained", "baked"],
+                        stdin=io.BytesIO(payload()), stdout=io.BytesIO(),
+                        env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                        now=NOW)
+        self.assertEqual(calls[-1][0], "from-record")
+
+    def test_oversized_stdin_still_reaches_the_chained_command_whole(self):
+        raw = b'{"pad":"' + b"x" * bridge.STDIN_MAX_BYTES + b'"}'
+        calls, patch = self._capture_chained()
+        with patch:
+            bridge.main(["--state-dir", str(self.dir), "--chained", "c"],
+                        stdin=io.BytesIO(raw), stdout=io.BytesIO(),
+                        env={"CLAUDE_CONFIG_DIR": str(self.config_dir)},
+                        now=NOW)
+        self.assertEqual(calls[-1], ("c", raw))
+        self.assertFalse((self.dir / bridge.SAMPLE_NAME).exists())
 
     def test_bridge_prints_nothing_without_a_chained_command(self):
         out = io.BytesIO()

--- a/tools/tokenserver/test_statusline_bridge.py
+++ b/tools/tokenserver/test_statusline_bridge.py
@@ -272,6 +272,36 @@ class RecordSampleTests(unittest.TestCase):
             bridge.record_sample(payload(), now=NOW, directory=self.dir)
         self.assertEqual(self.read()["v"], 1)
 
+    def test_malformed_nested_record_is_quarantined_not_overwritten(self):
+        # A valid envelope around a broken window used to be "absent" and
+        # then overwritten by the next write; the bytes are evidence.
+        self.dir.mkdir(parents=True)
+        target = self.dir / bridge.SAMPLE_NAME
+        for entry in ({"five_hour": "junk"},
+                      {"five_hour": {"pct": 500, "resets_at": NOW + 1,
+                                     "at": 1, "seen": 1}},
+                      {"seven_day": {"pct": 1, "resets_at": NOW + 1.5,
+                                     "at": 1, "seen": 1}},
+                      {"claude_code_version": 7},
+                      "not an object"):
+            with self.subTest(entry):
+                for stale in self.dir.glob("*.corrupt-*"):
+                    stale.unlink()
+                corrupt = json.dumps({"v": 1, "accounts": {"single": entry}})
+                target.write_text(corrupt)
+                self.assertEqual(bridge.peek_sample(target), ("invalid", None))
+                with self.assertLogs("tokenserver.state", level="WARNING"):
+                    bridge.record_sample(payload(), now=NOW,
+                                         directory=self.dir)
+                quarantined = list(self.dir.glob("*.corrupt-*"))
+                self.assertEqual(len(quarantined), 1)
+                self.assertEqual(quarantined[0].read_text(), corrupt)
+        # An expired but well-formed window is not corruption.
+        target.write_text(json.dumps({"v": 1, "accounts": {"single": {
+            "five_hour": {"pct": 1, "resets_at": NOW - 1, "at": 1,
+                          "seen": 1}}}}))
+        self.assertEqual(bridge.peek_sample(target)[0], "ok")
+
     def test_unreadable_file_skips_the_write(self):
         self.dir.mkdir(parents=True)
         target = self.dir / bridge.SAMPLE_NAME
@@ -323,6 +353,11 @@ class SummarizeSampleTests(unittest.TestCase):
         self.assertEqual(summary["ageS"], 10)
         self.assertEqual(summary["claudeCodeVersion"], "2.1.0")
         self.assertEqual(set(summary["windows"]), {"five_hour", "seven_day"})
+        # Freshness is per window: the week was last seen 50 min ago.
+        self.assertTrue(summary["windows"]["five_hour"]["fresh"])
+        self.assertEqual(summary["windows"]["five_hour"]["age_s"], 10)
+        self.assertFalse(summary["windows"]["seven_day"]["fresh"])
+        self.assertEqual(summary["windows"]["seven_day"]["age_s"], 3000)
         later = NOW + bridge.FRESH_S + 1
         summary = bridge.summarize_sample(
             self.document(five_hour=five, seven_day=week), later)

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -313,6 +313,13 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
         self.assertEqual(merged["sessionPct"], 60.0)
         self.assertEqual(merged["weekPct"], 12.5)
         self.assertFalse(tokenserver._claude_statusline_bridged)
+        # Served as a floor, flagged as not a new measurement.
+        self.assertIs(merged["sessionLive"], False)
+        self.assertIs(merged["weekStaleFloor"], True)
+        self.write(five=(60.0, self.NOW + 3600), week=(12.5, self.NOW + 86400))
+        fresh = self.merge(probe)
+        self.assertIs(fresh["sessionLive"], True)
+        self.assertIs(fresh["weekStaleFloor"], False)
         # A newer probe window still wins over the stale floor.
         probe = {"sessionPct": 1.0, "sessionResetAt": self.NOW + 7200}
         self.assertEqual(self.merge(probe)["sessionPct"], 1.0)
@@ -410,6 +417,20 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
                                       "usage_http_200 + ok"):
                 self.assertEqual(tokenserver._probe_interval_s(), 240)
 
+    def test_fresh_plan_usage_lifts_the_stale_floor_flag(self):
+        usage = self.dir / "plan-usage-history.json"
+        usage.write_text(json.dumps({"version": 2, "samples": [{
+            "t": int(self.NOW * 1000), "org": "o",
+            "u": {"fh": 1, "sd": 13}}]}), encoding="utf-8")
+        cache = self.cache(pct=12.0, reset=self.NOW + 86400)
+        claude = {"weekPct": 12.0, "weekResetAt": self.NOW + 86400,
+                  "weekObservedAt": self.NOW - 7200,
+                  "weekIdentity": self.IDENTITY, "weekStaleFloor": True}
+        merged = tokenserver._merge_claude_plan_usage(
+            claude, cache, self.NOW, path=usage)
+        self.assertEqual(merged["weekPct"], 13.0)
+        self.assertNotIn("weekStaleFloor", merged)
+
     def test_plan_usage_replay_never_lowers_a_same_window_figure(self):
         usage = self.dir / "plan-usage-history.json"
         usage.write_text(json.dumps({"version": 2, "samples": [{
@@ -480,13 +501,23 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
                       history.record_calls)
 
     def test_snapshot_serves_a_stale_sample_as_a_floor(self):
+        # Codex P1 on #116: shown with the stale flag, never recorded into
+        # the cache, Max Tracker or the history as a new measurement.
         self.write(five=(42.0, self.NOW + 3600),
                    week=(12.5, self.NOW + 86400),
                    seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
-        snapshot, persisted = self._snapshot()
+        store = mock.Mock()
+        history = StubHistory()
+        snapshot, persisted = self._snapshot(store=store, history=history)
         self.assertEqual(snapshot["claudeSessionPct"], 42.0)
         self.assertEqual(snapshot["claudeWeekPct"], 12.5)
+        self.assertEqual(snapshot["claudeWeekResetMin"], 1440)
+        self.assertTrue(snapshot["claudeWeekStale"])
         self.assertFalse(tokenserver._claude_statusline_bridged)
+        store.observe_quota.assert_not_called()
+        self.assertEqual(persisted, [])
+        self.assertEqual([c for c in history.record_calls
+                          if c[0] == "claude"], [])
         # Expired windows are gone for good.
         self.write(five=(42.0, self.NOW - 1), week=(12.5, self.NOW - 1))
         snapshot, persisted = self._snapshot()

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -300,15 +300,40 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
         self.assertEqual(merged["weekSource"], "statusline")
         self.assertTrue(tokenserver._claude_statusline_bridged)
 
-    def test_stale_sample_is_a_no_op_and_not_bridged(self):
-        self.write(five=(42.0, self.NOW + 3600),
+    def test_stale_sample_is_a_floor_but_never_bridged(self):
+        # Codex P1 on #116: within a window usage only accumulates, so a
+        # stored 60 % beats a lagging probe's 40 % for the same reset even
+        # after Claude Code has gone quiet; only the probe cadence needs
+        # freshness.
+        self.write(five=(60.0, self.NOW + 3600),
                    week=(12.5, self.NOW + 86400),
                    seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
-        probe = {"sessionPct": 3.0, "sessionResetAt": self.NOW + 100}
-        self.assertIs(self.merge(probe), probe)
+        probe = {"sessionPct": 40.0, "sessionResetAt": self.NOW + 3600}
+        merged = self.merge(probe)
+        self.assertEqual(merged["sessionPct"], 60.0)
+        self.assertEqual(merged["weekPct"], 12.5)
         self.assertFalse(tokenserver._claude_statusline_bridged)
+        # A newer probe window still wins over the stale floor.
+        probe = {"sessionPct": 1.0, "sessionResetAt": self.NOW + 7200}
+        self.assertEqual(self.merge(probe)["sessionPct"], 1.0)
         self.path.unlink()
         self.assertIs(self.merge(probe), probe)
+
+    def test_freshness_is_judged_per_window(self):
+        # Codex P2 on #116: a payload that keeps reporting only one window
+        # leaves the other's ``seen`` behind; the old one must not ride the
+        # new one's freshness into the probe back-off.
+        five = {"pct": 42.0, "resets_at": self.NOW + 3600,
+                "at": self.NOW - 5, "seen": self.NOW - 5}
+        week = {"pct": 12.5, "resets_at": self.NOW + 86400,
+                "at": self.NOW - 7200, "seen": self.NOW - 7200}
+        self.path.write_text(json.dumps({"v": 1, "accounts": {"single": {
+            "five_hour": five, "seven_day": week}}}), encoding="utf-8")
+        merged = self.merge({})
+        self.assertEqual(merged["sessionPct"], 42.0)
+        self.assertEqual(merged["weekPct"], 12.5)  # still a floor
+        self.assertFalse(tokenserver._claude_statusline_bridged)
+        self.assertEqual(tokenserver._claude_statusline_status, "fresh")
 
     def test_later_reset_wins_and_same_reset_higher_figure_wins(self):
         probe = {"sessionPct": 50.0, "sessionResetAt": self.NOW + 3600,
@@ -454,15 +479,19 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
         self.assertIn(("claude", "week", 12.5, self.NOW + 86400, self.NOW),
                       history.record_calls)
 
-    def test_snapshot_ignores_a_stale_sample(self):
+    def test_snapshot_serves_a_stale_sample_as_a_floor(self):
         self.write(five=(42.0, self.NOW + 3600),
                    week=(12.5, self.NOW + 86400),
                    seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
-        store = mock.Mock()
-        snapshot, persisted = self._snapshot(store=store)
+        snapshot, persisted = self._snapshot()
+        self.assertEqual(snapshot["claudeSessionPct"], 42.0)
+        self.assertEqual(snapshot["claudeWeekPct"], 12.5)
+        self.assertFalse(tokenserver._claude_statusline_bridged)
+        # Expired windows are gone for good.
+        self.write(five=(42.0, self.NOW - 1), week=(12.5, self.NOW - 1))
+        snapshot, persisted = self._snapshot()
         self.assertIsNone(snapshot["claudeSessionPct"])
         self.assertIsNone(snapshot["claudeWeekPct"])
-        store.observe_quota.assert_not_called()
         self.assertEqual(persisted, [])
 
 

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -33,6 +33,18 @@ from tools.tokenserver.vibepulse_config import (
 )
 
 
+def setUpModule():
+    # A bridge installed on the developer's own machine must never leak
+    # into the snapshot assertions below: point the reader at a file that
+    # does not exist unless a test says otherwise.
+    tokenserver._claude_statusline_path_override = (
+        Path(tempfile.gettempdir()) / "vibepulse-no-statusline-sample.json")
+
+
+def tearDownModule():
+    tokenserver._claude_statusline_path_override = None
+
+
 class StubHistory:
     def __init__(self, forecasts=None):
         self.forecasts = forecasts or {}
@@ -171,6 +183,299 @@ class ClaudePlanUsageFallbackTests(unittest.TestCase):
         self.assertEqual(merged, {})
         self.assertEqual(tokenserver._claude_plan_usage_status,
                          "fresh_without_reset")
+
+
+class ClaudeStatuslineBridgeTests(unittest.TestCase):
+    """The statusLine sample as a quota source: read, arbitrated per
+    window against the probe and the cache, and only while fresh."""
+
+    NOW = 1_800_000_000
+    IDENTITY = None  # filled in setUp: the general-week identity
+
+    def setUp(self):
+        self.IDENTITY = tokenserver._quota_identity("claude", "general_weekly")
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.path = self.dir / "claude-statusline-quota.json"
+        saved = (tokenserver._claude_statusline_status,
+                 tokenserver._claude_statusline_logged,
+                 tokenserver._claude_statusline_view,
+                 tokenserver._claude_statusline_bridged,
+                 tokenserver._claude_statusline_cache)
+
+        def restore():
+            (tokenserver._claude_statusline_status,
+             tokenserver._claude_statusline_logged,
+             tokenserver._claude_statusline_view,
+             tokenserver._claude_statusline_bridged,
+             tokenserver._claude_statusline_cache) = saved
+        self.addCleanup(restore)
+        tokenserver._claude_statusline_cache = (None, None)
+        tokenserver._claude_statusline_logged = None
+        tokenserver._claude_statusline_bridged = False
+
+    def write(self, *, five=None, week=None, seen_ago=10, at_ago=None,
+              version="2.1.0"):
+        at_ago = seen_ago if at_ago is None else at_ago
+        entry = {"claude_code_version": version}
+        if five is not None:
+            pct, reset = five
+            entry["five_hour"] = {"pct": pct, "resets_at": reset,
+                                  "at": self.NOW - at_ago,
+                                  "seen": self.NOW - seen_ago}
+        if week is not None:
+            pct, reset = week
+            entry["seven_day"] = {"pct": pct, "resets_at": reset,
+                                  "at": self.NOW - at_ago,
+                                  "seen": self.NOW - seen_ago}
+        self.path.write_text(json.dumps(
+            {"v": 1, "accounts": {"single": entry}}), encoding="utf-8")
+
+    def cache(self, pct=None, reset=None):
+        cache = QuotaCache(self.dir / "quota.json", now=lambda: self.NOW)
+        if pct is not None:
+            cache.put(CachedQuota(
+                provider="claude", scope="general_weekly",
+                identity=self.IDENTITY, pct=pct, reset_at=reset,
+                observed_at=self.NOW - 600))
+        return cache
+
+    def merge(self, claude, cache=None):
+        return tokenserver._merge_claude_statusline(
+            claude, self.cache() if cache is None else cache, self.NOW,
+            path=self.path)
+
+    # -- reading ---------------------------------------------------------
+
+    def test_status_words_and_one_log_line_per_transition(self):
+        with self.assertLogs("tokenserver", level="INFO") as captured:
+            self.assertIsNone(tokenserver._read_claude_statusline(
+                self.path, now_ts=self.NOW))
+            self.assertEqual(tokenserver._claude_statusline_status,
+                             "not_installed")
+            (self.dir / "claude-statusline-bridge.json").write_text("{}")
+            tokenserver._read_claude_statusline(self.path, now_ts=self.NOW)
+            self.assertEqual(tokenserver._claude_statusline_status, "missing")
+            self.path.write_text("{oops")
+            tokenserver._read_claude_statusline(self.path, now_ts=self.NOW)
+            self.assertEqual(tokenserver._claude_statusline_status, "invalid")
+            self.assertEqual(self.path.read_text(), "{oops")  # not quarantined
+            self.write(five=(42.0, self.NOW + 3600), seen_ago=5)
+            summary = tokenserver._read_claude_statusline(
+                self.path, now_ts=self.NOW)
+            self.assertEqual(tokenserver._claude_statusline_status, "fresh")
+            self.assertEqual(summary["windows"]["five_hour"]["pct"], 42.0)
+            self.assertEqual(tokenserver._claude_statusline_view, {
+                "status": "fresh", "ageS": 5, "claudeCodeVersion": "2.1.0"})
+            # The same file, read again: same status, no new log line.
+            tokenserver._read_claude_statusline(self.path, now_ts=self.NOW)
+            self.write(five=(42.0, self.NOW + 3600),
+                       seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
+            tokenserver._read_claude_statusline(self.path, now_ts=self.NOW)
+            self.assertEqual(tokenserver._claude_statusline_status, "stale")
+            self.write(five=(42.0, self.NOW - 1))
+            self.assertIsNone(tokenserver._read_claude_statusline(
+                self.path, now_ts=self.NOW))
+            self.assertEqual(tokenserver._claude_statusline_status, "empty")
+        lines = [line for line in captured.output
+                 if "claude-statusline:" in line]
+        self.assertEqual([line.split("claude-statusline: ")[1]
+                          for line in lines], [
+            "start -> not_installed", "not_installed -> missing",
+            "missing -> invalid", "invalid -> fresh", "fresh -> stale",
+            "stale -> empty"])
+
+    def test_unchanged_file_is_not_reparsed(self):
+        self.write(five=(42.0, self.NOW + 3600))
+        tokenserver._read_claude_statusline(self.path, now_ts=self.NOW)
+        with mock.patch.object(tokenserver.statusline_bridge, "peek_sample",
+                               side_effect=AssertionError("reparsed")):
+            summary = tokenserver._read_claude_statusline(
+                self.path, now_ts=self.NOW + 1)
+        self.assertEqual(summary["windows"]["five_hour"]["pct"], 42.0)
+
+    # -- arbitration -----------------------------------------------------
+
+    def test_fresh_sample_stands_in_for_an_absent_probe(self):
+        self.write(five=(42.0, self.NOW + 3600),
+                   week=(12.5, self.NOW + 86400), at_ago=30)
+        merged = self.merge({})
+        self.assertEqual(merged["sessionPct"], 42.0)
+        self.assertEqual(merged["sessionResetAt"], self.NOW + 3600)
+        self.assertEqual(merged["sessionSource"], "statusline")
+        self.assertEqual(merged["weekPct"], 12.5)
+        self.assertEqual(merged["weekResetAt"], self.NOW + 86400)
+        self.assertEqual(merged["weekResetMin"], 1440)
+        self.assertEqual(merged["weekObservedAt"], self.NOW - 30)
+        self.assertEqual(merged["weekIdentity"], self.IDENTITY)
+        self.assertEqual(merged["weekSource"], "statusline")
+        self.assertTrue(tokenserver._claude_statusline_bridged)
+
+    def test_stale_sample_is_a_no_op_and_not_bridged(self):
+        self.write(five=(42.0, self.NOW + 3600),
+                   week=(12.5, self.NOW + 86400),
+                   seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
+        probe = {"sessionPct": 3.0, "sessionResetAt": self.NOW + 100}
+        self.assertIs(self.merge(probe), probe)
+        self.assertFalse(tokenserver._claude_statusline_bridged)
+        self.path.unlink()
+        self.assertIs(self.merge(probe), probe)
+
+    def test_later_reset_wins_and_same_reset_higher_figure_wins(self):
+        probe = {"sessionPct": 50.0, "sessionResetAt": self.NOW + 3600,
+                 "weekPct": 20.0, "weekResetAt": self.NOW + 86400,
+                 "weekObservedAt": self.NOW - 100,
+                 "weekIdentity": self.IDENTITY}
+        # Older session window, lower week figure: the probe stands.
+        self.write(five=(90.0, self.NOW + 1800),
+                   week=(19.0, self.NOW + 86400))
+        merged = self.merge(probe)
+        self.assertEqual(merged["sessionPct"], 50.0)
+        self.assertEqual(merged["weekPct"], 20.0)
+        self.assertNotIn("weekSource", merged)
+        self.assertFalse(tokenserver._claude_statusline_bridged)
+        # Same session reset, higher figure; newer week window.
+        self.write(five=(51.0, self.NOW + 3600),
+                   week=(1.0, self.NOW + 7 * 86400))
+        merged = self.merge(probe)
+        self.assertEqual(merged["sessionPct"], 51.0)
+        self.assertEqual(merged["weekPct"], 1.0)
+        self.assertEqual(merged["weekResetAt"], self.NOW + 7 * 86400)
+        self.assertTrue(tokenserver._claude_statusline_bridged)
+        # A tie keeps the probe's reading but still counts as covered.
+        self.write(five=(50.0, self.NOW + 3600),
+                   week=(20.0, self.NOW + 86400))
+        merged = self.merge(probe)
+        self.assertNotIn("sessionSource", merged)
+        self.assertNotIn("weekSource", merged)
+        self.assertTrue(tokenserver._claude_statusline_bridged)
+
+    def test_cache_that_knows_the_week_better_keeps_the_bridge_out(self):
+        self.write(week=(12.0, self.NOW + 86400))
+        merged = self.merge({}, self.cache(pct=13.0, reset=self.NOW + 86400))
+        self.assertNotIn("weekPct", merged)
+        merged = self.merge({}, self.cache(pct=1.0, reset=self.NOW + 2 * 86400))
+        self.assertNotIn("weekPct", merged)
+        merged = self.merge({}, self.cache(pct=11.0, reset=self.NOW + 86400))
+        self.assertEqual(merged["weekPct"], 12.0)
+        # The bridge's own earlier sample, persisted, must not make the
+        # next poll stale: an equal reading is still live.
+        merged = self.merge({}, self.cache(pct=12.0, reset=self.NOW + 86400))
+        self.assertEqual(merged["weekPct"], 12.0)
+        self.assertFalse(tokenserver._claude_statusline_bridged)
+
+    def test_model_week_is_never_touched(self):
+        self.write(five=(42.0, self.NOW + 3600), week=(12.5, self.NOW + 86400))
+        probe = {"modelPct": 70.0, "modelResetAt": self.NOW + 86400,
+                 "modelObservedAt": self.NOW, "modelIdentity": "m"}
+        merged = self.merge(probe)
+        for key in probe:
+            self.assertEqual(merged[key], probe[key])
+
+    def test_probe_slows_down_only_while_bridged_and_healthy(self):
+        with mock.patch.object(tokenserver, "_probe_failure_streak", 0):
+            with mock.patch.object(tokenserver, "_claude_statusline_bridged",
+                                   True), \
+                    mock.patch.object(tokenserver, "_probe_status",
+                                      "usage_http_200 + ok"):
+                self.assertEqual(tokenserver._probe_interval_s(),
+                                 tokenserver.PROBE_WHEN_BRIDGED_S)
+            with mock.patch.object(tokenserver, "_claude_statusline_bridged",
+                                   True), \
+                    mock.patch.object(tokenserver, "_probe_status",
+                                      "usage_request_failed: TimeoutError"):
+                self.assertEqual(tokenserver._probe_interval_s(), 240)
+            with mock.patch.object(tokenserver, "_claude_statusline_bridged",
+                                   True), \
+                    mock.patch.object(tokenserver, "_probe_status",
+                                      "token_expired_18:15"):
+                self.assertEqual(tokenserver._probe_interval_s(), 15.0)
+            with mock.patch.object(tokenserver, "_claude_statusline_bridged",
+                                   False), \
+                    mock.patch.object(tokenserver, "_probe_status",
+                                      "usage_http_200 + ok"):
+                self.assertEqual(tokenserver._probe_interval_s(), 240)
+
+    def test_plan_usage_replay_never_lowers_a_same_window_figure(self):
+        usage = self.dir / "plan-usage-history.json"
+        usage.write_text(json.dumps({"version": 2, "samples": [{
+            "t": int(self.NOW * 1000), "org": "o",
+            "u": {"fh": 1, "sd": 11}}]}), encoding="utf-8")
+        cache = self.cache(pct=11.0, reset=self.NOW + 86400)
+        claude = {"weekPct": 12.0, "weekResetAt": self.NOW + 86400,
+                  "weekObservedAt": self.NOW - 30,
+                  "weekIdentity": self.IDENTITY}
+        merged = tokenserver._merge_claude_plan_usage(
+            claude, cache, self.NOW, path=usage)
+        self.assertIs(merged, claude)
+        self.assertEqual(tokenserver._claude_plan_usage_status, "not_higher")
+
+    # -- the snapshot ----------------------------------------------------
+
+    def _snapshot(self, claude=None, store=None, history=None):
+        base = {"v": 1, "dayTokens": 0, "dayTokensPerHour": 0,
+                "daySessions": 0, "monthTokens": 0,
+                "at": "2026-08-07T10:00:00+02:00"}
+        persisted = []
+        with mock.patch.object(tokenserver, "_compute", return_value=base), \
+                mock.patch.object(tokenserver, "get_limits",
+                                  return_value=claude or {}), \
+                mock.patch.object(tokenserver, "_read_codex_limits",
+                                  return_value={}), \
+                mock.patch.object(tokenserver, "_claude_statusline_path_override",
+                                  self.path), \
+                mock.patch.object(tokenserver, "_read_claude_plan_usage",
+                                  return_value=None), \
+                mock.patch.object(
+                    tokenserver, "_persist_quota_records_async",
+                    side_effect=lambda cache, records: persisted.extend(
+                        r for r in records if r is not None)):
+            tokenserver._last_result = tokenserver._compute(Path("/unused"))
+            tokenserver._last_computed = time.monotonic()
+            snapshot = tokenserver.get_snapshot(
+                Path("/unused"), history=history or StubHistory(),
+                now_ts=self.NOW, quota_cache=self.cache(),
+                max_tracker_store=store)
+        return snapshot, persisted
+
+    def test_snapshot_serves_records_and_tracks_a_fresh_sample(self):
+        self.write(five=(42.0, self.NOW + 3600),
+                   week=(12.5, self.NOW + 86400), at_ago=30)
+        store = mock.Mock()
+        history = StubHistory()
+        snapshot, persisted = self._snapshot(store=store, history=history)
+        self.assertEqual(snapshot["claudeSessionPct"], 42.0)
+        self.assertEqual(snapshot["claudeSessionResetMin"], 60)
+        self.assertEqual(snapshot["claudeWeekPct"], 12.5)
+        self.assertEqual(snapshot["claudeWeekResetMin"], 1440)
+        self.assertFalse(snapshot["claudeWeekStale"])
+        self.assertEqual(snapshot["claudeWeekObservedAt"], self.NOW - 30)
+        self.assertIsNone(snapshot["claudeModelWeekPct"])
+        store.observe_quota.assert_any_call("claude", 300, 42.0, self.NOW)
+        store.observe_quota.assert_any_call(
+            "claude", 10080, 12.5, self.NOW - 30)
+        self.assertEqual([r for r in persisted if r.scope == "general_weekly"],
+                         [CachedQuota(
+                             provider="claude", scope="general_weekly",
+                             identity=self.IDENTITY, pct=12.5,
+                             reset_at=self.NOW + 86400,
+                             observed_at=self.NOW - 30, label=None)])
+        self.assertIn(("claude", "session", 42.0, self.NOW + 3600, self.NOW),
+                      history.record_calls)
+        self.assertIn(("claude", "week", 12.5, self.NOW + 86400, self.NOW),
+                      history.record_calls)
+
+    def test_snapshot_ignores_a_stale_sample(self):
+        self.write(five=(42.0, self.NOW + 3600),
+                   week=(12.5, self.NOW + 86400),
+                   seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
+        store = mock.Mock()
+        snapshot, persisted = self._snapshot(store=store)
+        self.assertIsNone(snapshot["claudeSessionPct"])
+        self.assertIsNone(snapshot["claudeWeekPct"])
+        store.observe_quota.assert_not_called()
+        self.assertEqual(persisted, [])
 
 
 class ClaudeLimitHeaderTests(unittest.TestCase):
@@ -2911,6 +3216,10 @@ class HandlerPrivacyTests(unittest.TestCase):
             "anthropic-ratelimit-unified-7d-utilization"])
         self.assertEqual(payload["unknownRateLimitBuckets"], ["7d_haiku"])
         self.assertEqual(payload["claudeLocalUsage"], "fresh_applied")
+        self.assertEqual(payload["claudeStatusline"]["account"],
+                         "assumed-single")
+        for key in ("status", "ageS", "claudeCodeVersion", "bridged"):
+            self.assertIn(key, payload["claudeStatusline"])
         self.assertEqual(payload["claudeCredential"], {
             "status": "expiring", "expiresInMin": 17})
         # OBS-18: the backoff state rides beside the status string.

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -201,17 +201,14 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
         saved = (tokenserver._claude_statusline_status,
                  tokenserver._claude_statusline_logged,
                  tokenserver._claude_statusline_view,
-                 tokenserver._claude_statusline_bridged,
-                 tokenserver._claude_statusline_cache)
+                 tokenserver._claude_statusline_bridged)
 
         def restore():
             (tokenserver._claude_statusline_status,
              tokenserver._claude_statusline_logged,
              tokenserver._claude_statusline_view,
-             tokenserver._claude_statusline_bridged,
-             tokenserver._claude_statusline_cache) = saved
+             tokenserver._claude_statusline_bridged) = saved
         self.addCleanup(restore)
-        tokenserver._claude_statusline_cache = (None, None)
         tokenserver._claude_statusline_logged = None
         tokenserver._claude_statusline_bridged = False
 
@@ -285,15 +282,6 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
             "start -> not_installed", "not_installed -> missing",
             "missing -> invalid", "invalid -> fresh", "fresh -> stale",
             "stale -> empty"])
-
-    def test_unchanged_file_is_not_reparsed(self):
-        self.write(five=(42.0, self.NOW + 3600))
-        tokenserver._read_claude_statusline(self.path, now_ts=self.NOW)
-        with mock.patch.object(tokenserver.statusline_bridge, "peek_sample",
-                               side_effect=AssertionError("reparsed")):
-            summary = tokenserver._read_claude_statusline(
-                self.path, now_ts=self.NOW + 1)
-        self.assertEqual(summary["windows"]["five_hour"]["pct"], 42.0)
 
     # -- arbitration -----------------------------------------------------
 

--- a/tools/tokenserver/test_tokenserver.py
+++ b/tools/tokenserver/test_tokenserver.py
@@ -310,12 +310,18 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
                    seen_ago=tokenserver.STATUSLINE_FRESH_S + 1)
         probe = {"sessionPct": 40.0, "sessionResetAt": self.NOW + 3600}
         merged = self.merge(probe)
-        self.assertEqual(merged["sessionPct"], 60.0)
+        # The week is a floor, flagged stale; the session has no stale
+        # flag on the wire, so a live probe reading of the window wins.
+        self.assertEqual(merged["sessionPct"], 40.0)
+        self.assertNotIn("sessionLive", merged)
         self.assertEqual(merged["weekPct"], 12.5)
-        self.assertFalse(tokenserver._claude_statusline_bridged)
-        # Served as a floor, flagged as not a new measurement.
-        self.assertIs(merged["sessionLive"], False)
         self.assertIs(merged["weekStaleFloor"], True)
+        self.assertFalse(tokenserver._claude_statusline_bridged)
+        # Without a probe reading the stale session floor is carried but
+        # marked not live (the snapshot withholds it).
+        merged = self.merge({})
+        self.assertEqual(merged["sessionPct"], 60.0)
+        self.assertIs(merged["sessionLive"], False)
         self.write(five=(60.0, self.NOW + 3600), week=(12.5, self.NOW + 86400))
         fresh = self.merge(probe)
         self.assertIs(fresh["sessionLive"], True)
@@ -430,6 +436,21 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
             claude, cache, self.NOW, path=usage)
         self.assertEqual(merged["weekPct"], 13.0)
         self.assertNotIn("weekStaleFloor", merged)
+        # An equal fresh reading is new evidence for the same figure.
+        usage.write_text(json.dumps({"version": 2, "samples": [{
+            "t": int(self.NOW * 1000), "org": "o",
+            "u": {"fh": 1, "sd": 12}}]}), encoding="utf-8")
+        merged = tokenserver._merge_claude_plan_usage(
+            claude, cache, self.NOW, path=usage)
+        self.assertEqual(merged["weekPct"], 12.0)
+        self.assertEqual(merged["weekObservedAt"], self.NOW)
+        self.assertNotIn("weekStaleFloor", merged)
+        self.assertEqual(tokenserver._claude_plan_usage_status,
+                         "fresh_applied")
+        # Without a stale floor an equal reading is still a replay.
+        live = dict(claude, weekStaleFloor=False)
+        self.assertIs(tokenserver._merge_claude_plan_usage(
+            live, cache, self.NOW, path=usage), live)
 
     def test_plan_usage_replay_never_lowers_a_same_window_figure(self):
         usage = self.dir / "plan-usage-history.json"
@@ -509,7 +530,8 @@ class ClaudeStatuslineBridgeTests(unittest.TestCase):
         store = mock.Mock()
         history = StubHistory()
         snapshot, persisted = self._snapshot(store=store, history=history)
-        self.assertEqual(snapshot["claudeSessionPct"], 42.0)
+        self.assertIsNone(snapshot["claudeSessionPct"])  # no stale flag
+        self.assertIsNone(snapshot["claudeSessionResetMin"])
         self.assertEqual(snapshot["claudeWeekPct"], 12.5)
         self.assertEqual(snapshot["claudeWeekResetMin"], 1440)
         self.assertTrue(snapshot["claudeWeekStale"])

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -333,20 +333,22 @@ def _window_wins(candidate_reset, candidate_pct, incumbent_reset,
 
 
 def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
-    """Let a fresh statusLine sample stand in for -- or ahead of -- the
-    OAuth probe's session and general week figures.
+    """Let the statusLine sample stand in for -- or ahead of -- the OAuth
+    probe's session and general week figures.
 
-    Only a FRESH sample (Claude Code spoke within STATUSLINE_FRESH_S) is
-    used: a stale one means no session is active and the probe is the
-    better source again, so the merge is then a no-op and the cache keeps
-    the last live figure.  Each window is arbitrated separately against
-    the probe's (and, for the week, the cache's) reading by
-    :func:`_window_wins`.  The model week has no statusLine counterpart
-    and is never touched.
+    Each window is arbitrated separately against the probe's (and, for the
+    week, the cache's) reading by :func:`_window_wins`, whether or not the
+    sample is fresh: within a window usage only accumulates, so a stored
+    60 % is a floor until that window resets, and a probe that says 40 %
+    for the same reset is lagging, not newer. Freshness (Claude Code spoke
+    within STATUSLINE_FRESH_S, judged per window) decides only whether the
+    probe may slow down: both windows fresh and no older than the probe's
+    own is ``bridged``. The model week has no statusLine counterpart and
+    is never touched.
     """
     global _claude_statusline_bridged
     summary = _read_claude_statusline(path=path, now_ts=now_ts)
-    if summary is None or summary["status"] != "fresh":
+    if summary is None:
         _claude_statusline_bridged = False
         return claude
     windows = summary["windows"]
@@ -359,7 +361,8 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
     probe_session = (_valid_epoch_after(probe_reset, now_ts)
                      and _valid_pct(probe_pct))
     if five is not None:
-        if not probe_session or five["resets_at"] >= probe_reset:
+        if five["fresh"] and (not probe_session
+                              or five["resets_at"] >= probe_reset):
             covered += 1
         if (not probe_session or _window_wins(
                 five["resets_at"], five["pct"], probe_reset, probe_pct)):
@@ -374,7 +377,8 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
                   and _valid_pct(probe_pct)
                   and isinstance(claude.get("weekIdentity"), str))
     if week is not None:
-        if not probe_week or week["resets_at"] >= probe_reset:
+        if week["fresh"] and (not probe_week
+                              or week["resets_at"] >= probe_reset):
             covered += 1
         cached = quota_cache.latest("claude", "general_weekly", now=now_ts)
         wins = (not probe_week or _window_wins(
@@ -393,8 +397,6 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
             merged["weekObservedAt"] = int(week["at"])
             merged["weekIdentity"] = _quota_identity("claude", "general_weekly")
             merged["weekSource"] = "statusline"
-    # Both windows covered by a fresh sample no older than the probe's own
-    # windows: the probe is a cross-check now and may slow down.
     _claude_statusline_bridged = covered == 2
     return merged
 

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -92,7 +92,7 @@ if __package__:
         load_config,
         save_config,
     )
-    from . import codex_usage, interactions, value_meter
+    from . import codex_usage, interactions, statusline_bridge, value_meter
 else:  # run directly: python3 tools/tokenserver/tokenserver.py
     from discovery import DiscoveryAdvertiser
     from agent_status import AgentStatusService
@@ -119,6 +119,7 @@ else:  # run directly: python3 tools/tokenserver/tokenserver.py
     )
     import codex_usage
     import interactions
+    import statusline_bridge
     import value_meter
 
 RECOMPUTE_EVERY_S = 30
@@ -132,6 +133,13 @@ LIMITS_EVERY_S = 240  # the rate-limit probe: 15 calls/h -- the account's
 AUTH_RECOVERY_EVERY_S = 15.0  # local token check; no upstream while waiting
 CLAUDE_CREDENTIAL_WARNING_S = 30 * 60
 CLAUDE_PLAN_USAGE_FRESH_S = 20 * 60
+# The Claude Code statusLine bridge (tools/tokenserver/statusline_bridge.py)
+# leaves the account's session and week windows in the state directory on
+# every assistant message. While both are fresh the OAuth probe is only a
+# cross-check and runs at this slower cadence instead of LIMITS_EVERY_S --
+# the account's rate-limit bucket is shared with Claude Code itself.
+STATUSLINE_FRESH_S = statusline_bridge.FRESH_S
+PROBE_WHEN_BRIDGED_S = 1800
 CLAUDE_PLAN_USAGE_MAX_BYTES = 2 * 1024 * 1024
 HTTP_MAX_WORKERS = 32
 JSON_BODY_TIMEOUT_S = 2.0
@@ -147,6 +155,20 @@ REQUEST_DRAIN_TIMEOUT_S = 0.05
 # branches on a Mac.
 _IS_WINDOWS = sys.platform == "win32"
 _claude_plan_usage_status = "not_checked"
+# The statusLine bridge sample: content-free status word for GET / and
+# the transition log (not_installed / missing / unreadable / invalid /
+# empty / stale / fresh), the last summary served, and a (mtime, size)
+# keyed parse cache so the 30 s polls do not reparse an unchanged file.
+_claude_statusline_status = "not_checked"
+_claude_statusline_logged = None
+_claude_statusline_view = {"status": "not_checked", "ageS": None,
+                           "claudeCodeVersion": None}
+_claude_statusline_bridged = False
+_claude_statusline_cache = (None, None)
+_claude_statusline_lock = threading.Lock()
+# Tests point this at a file that does not exist so a bridge installed on
+# the developer's own machine never leaks into snapshot assertions.
+_claude_statusline_path_override = None
 
 
 def _state_dir():
@@ -247,6 +269,148 @@ def _read_claude_plan_usage(path=None, now_ts=None):
         "week_pct": values[1],
         "observed_at": int(observed_at),
     }
+
+
+def _claude_statusline_path():
+    if _claude_statusline_path_override is not None:
+        return Path(_claude_statusline_path_override)
+    return _state_dir() / statusline_bridge.SAMPLE_NAME
+
+
+def _read_claude_statusline(path=None, now_ts=None):
+    """The bridge's validated windows, or ``None`` when there is nothing
+    usable.  Sets the status word and logs its transitions once."""
+    global _claude_statusline_status, _claude_statusline_logged, \
+        _claude_statusline_view, _claude_statusline_cache
+    sample_path = _claude_statusline_path() if path is None else Path(path)
+    current_ts = time.time() if now_ts is None else now_ts
+    with _claude_statusline_lock:
+        try:
+            info = sample_path.stat()
+            key = (info.st_mtime_ns, info.st_size)
+        except FileNotFoundError:
+            key = None
+            installed = statusline_bridge.config_path(
+                sample_path.parent).exists()
+            status, document = ("missing" if installed
+                                else "not_installed"), None
+        except OSError:
+            key, status, document = None, "unreadable", None
+        else:
+            if key == _claude_statusline_cache[0]:
+                status, document = "ok", _claude_statusline_cache[1]
+            else:
+                status, document = statusline_bridge.peek_sample(sample_path)
+        summary = None
+        if status == "ok":
+            _claude_statusline_cache = (key, document)
+            summary = statusline_bridge.summarize_sample(document, current_ts)
+            status = summary["status"]
+        else:
+            _claude_statusline_cache = (None, None)
+        view = {"status": status,
+                "ageS": summary["ageS"] if summary else None,
+                "claudeCodeVersion":
+                    summary["claudeCodeVersion"] if summary else None}
+        _claude_statusline_status = status
+        _claude_statusline_view = view
+        if status != _claude_statusline_logged:
+            log.info("claude-statusline: %s -> %s",
+                     _claude_statusline_logged or "start", status)
+            _claude_statusline_logged = status
+    if summary is None or not summary["windows"]:
+        return None
+    return summary
+
+
+def _valid_epoch_after(value, now_ts):
+    return (isinstance(value, (int, float)) and not isinstance(value, bool)
+            and math.isfinite(value) and value > now_ts)
+
+
+def _valid_pct(value):
+    return (isinstance(value, (int, float)) and not isinstance(value, bool)
+            and math.isfinite(value) and 0 <= value <= 100)
+
+
+def _window_wins(candidate_reset, candidate_pct, incumbent_reset,
+                 incumbent_pct):
+    """The spec's arbitration between two readings of one rate-limit
+    window: the later reset is the newer window; within one window usage
+    only accumulates, so the higher figure is the later one.  Ties keep
+    the incumbent."""
+    if incumbent_reset is None:
+        return True
+    if candidate_reset != incumbent_reset:
+        return candidate_reset > incumbent_reset
+    return candidate_pct > incumbent_pct
+
+
+def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
+    """Let a fresh statusLine sample stand in for -- or ahead of -- the
+    OAuth probe's session and general week figures.
+
+    Only a FRESH sample (Claude Code spoke within STATUSLINE_FRESH_S) is
+    used: a stale one means no session is active and the probe is the
+    better source again, so the merge is then a no-op and the cache keeps
+    the last live figure.  Each window is arbitrated separately against
+    the probe's (and, for the week, the cache's) reading by
+    :func:`_window_wins`.  The model week has no statusLine counterpart
+    and is never touched.
+    """
+    global _claude_statusline_bridged
+    summary = _read_claude_statusline(path=path, now_ts=now_ts)
+    if summary is None or summary["status"] != "fresh":
+        _claude_statusline_bridged = False
+        return claude
+    windows = summary["windows"]
+    merged = dict(claude)
+    covered = 0
+
+    five = windows.get("five_hour")
+    probe_reset = claude.get("sessionResetAt")
+    probe_pct = claude.get("sessionPct")
+    probe_session = (_valid_epoch_after(probe_reset, now_ts)
+                     and _valid_pct(probe_pct))
+    if five is not None:
+        if not probe_session or five["resets_at"] >= probe_reset:
+            covered += 1
+        if (not probe_session or _window_wins(
+                five["resets_at"], five["pct"], probe_reset, probe_pct)):
+            merged["sessionPct"] = five["pct"]
+            merged["sessionResetAt"] = five["resets_at"]
+            merged["sessionSource"] = "statusline"
+
+    week = windows.get("seven_day")
+    probe_reset = claude.get("weekResetAt")
+    probe_pct = claude.get("weekPct")
+    probe_week = (_valid_epoch_after(probe_reset, now_ts)
+                  and _valid_pct(probe_pct)
+                  and isinstance(claude.get("weekIdentity"), str))
+    if week is not None:
+        if not probe_week or week["resets_at"] >= probe_reset:
+            covered += 1
+        cached = quota_cache.latest("claude", "general_weekly", now=now_ts)
+        wins = (not probe_week or _window_wins(
+            week["resets_at"], week["pct"], probe_reset, probe_pct))
+        if wins and cached is not None and _window_wins(
+                cached.reset_at, cached.pct, week["resets_at"], week["pct"]):
+            # The cache knows a strictly better reading (a later window,
+            # or a higher figure in this one). An equal reading is the
+            # bridge's own earlier sample coming back: still live.
+            wins = False
+        if wins:
+            merged["weekPct"] = week["pct"]
+            merged["weekResetAt"] = week["resets_at"]
+            merged["weekResetMin"] = max(
+                0, int(round((week["resets_at"] - now_ts) / 60)))
+            merged["weekObservedAt"] = int(week["at"])
+            merged["weekIdentity"] = _quota_identity("claude", "general_weekly")
+            merged["weekSource"] = "statusline"
+    # Both windows covered by a fresh sample no older than the probe's own
+    # windows: the probe is a cross-check now and may slow down.
+    _claude_statusline_bridged = covered == 2
+    return merged
 
 
 def _log_dir():
@@ -487,6 +651,14 @@ def _merge_claude_plan_usage(claude, quota_cache, now_ts, path=None):
     cached = quota_cache.latest("claude", "general_weekly", now=now_ts)
     if cached is None or cached.reset_at <= now_ts:
         _claude_plan_usage_status = "fresh_without_reset"
+        return claude
+    existing_pct = claude.get("weekPct")
+    if (claude.get("weekResetAt") == cached.reset_at and
+            _valid_pct(existing_pct) and local["week_pct"] <= existing_pct):
+        # Same window, no higher figure: usage only accumulates within a
+        # window, so a later-but-lower local sample is a replay of an
+        # earlier reading (the statusLine bridge made this case real).
+        _claude_plan_usage_status = "not_higher"
         return claude
 
     merged = dict(claude)
@@ -1526,6 +1698,11 @@ def _probe_interval_s():
         # check only rereads the local keychain/credentials file and quickly
         # notices when the official Claude client has changed the token.
         return AUTH_RECOVERY_EVERY_S
+    if _claude_statusline_bridged and _probe_status == "usage_http_200 + ok":
+        # The statusLine bridge covers both windows with a fresh sample:
+        # the probe is a cross-check and spends fewer of the shared
+        # bucket's calls. Any failure state keeps its own ladder.
+        return PROBE_WHEN_BRIDGED_S
     return LIMITS_EVERY_S * (2 ** min(_probe_failure_streak, 2))
 
 
@@ -2435,7 +2612,8 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     usage_history = _get_usage_history() if history is None else history
     cache = _get_quota_cache() if quota_cache is None else quota_cache
     claude = _merge_claude_plan_usage(
-        get_limits() or {}, cache, current_ts)
+        _merge_claude_statusline(get_limits() or {}, cache, current_ts),
+        cache, current_ts)
     codex = _read_codex_limits()
 
     session_pct = claude.get("sessionPct")
@@ -3320,6 +3498,9 @@ class Handler(BaseHTTPRequestHandler):
                 # one locked read so they always describe the same cycle.
                 **_probe_view(),
                 "claudeLocalUsage": _claude_plan_usage_status,
+                "claudeStatusline": {**_claude_statusline_view,
+                                     "bridged": _claude_statusline_bridged,
+                                     "account": "assumed-single"},
                 # GET / is never parsed by the screen -- fields can be
                 # added without contract risk.
                 "usageComputeOk": failing_since is None,

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -343,10 +343,12 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
     for the same reset is lagging, not newer. Freshness (Claude Code spoke
     within STATUSLINE_FRESH_S, judged per window) decides two things: a
     window that wins while stale is served as that floor but flagged
-    (``sessionLive`` false, ``weekStaleFloor`` true) so it reaches the
-    screen with ``*Stale: true`` and never the cache, Max Tracker or the
-    history as a new measurement; and both windows fresh and no older
-    than the probe's own is ``bridged``, which lets the probe slow down.
+    (``sessionLive`` false, ``weekStaleFloor`` true) so the week reaches
+    the screen with ``claudeWeekStale: true`` and the session -- which has
+    no stale flag on the wire -- is withheld rather than shown as live,
+    and neither reaches the cache, Max Tracker or the history as a new
+    measurement; and both windows fresh and no older than the probe's
+    own is ``bridged``, which lets the probe slow down.
     The model week has no statusLine counterpart and is never touched.
     """
     global _claude_statusline_bridged
@@ -367,8 +369,14 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
         if five["fresh"] and (not probe_session
                               or five["resets_at"] >= probe_reset):
             covered += 1
-        if (not probe_session or _window_wins(
-                five["resets_at"], five["pct"], probe_reset, probe_pct)):
+        wins = (not probe_session or _window_wins(
+            five["resets_at"], five["pct"], probe_reset, probe_pct))
+        if wins and not five["fresh"] and probe_session:
+            # The wire has no session-stale flag, so a stale floor cannot
+            # be shown honestly beside a live week: a live probe reading
+            # of the window beats it, lower or not.
+            wins = False
+        if wins:
             merged["sessionPct"] = five["pct"]
             merged["sessionResetAt"] = five["resets_at"]
             merged["sessionSource"] = "statusline"
@@ -647,10 +655,15 @@ def _merge_claude_plan_usage(claude, quota_cache, now_ts, path=None):
         return claude
     existing_pct = claude.get("weekPct")
     if (claude.get("weekResetAt") == cached.reset_at and
-            _valid_pct(existing_pct) and local["week_pct"] <= existing_pct):
+            _valid_pct(existing_pct) and (
+                local["week_pct"] < existing_pct
+                or (local["week_pct"] == existing_pct
+                    and claude.get("weekStaleFloor") is not True))):
         # Same window, no higher figure: usage only accumulates within a
         # window, so a later-but-lower local sample is a replay of an
         # earlier reading (the statusLine bridge made this case real).
+        # An EQUAL fresh reading over a stale floor is new evidence for
+        # the same figure and falls through to lift the floor.
         _claude_plan_usage_status = "not_higher"
         return claude
 
@@ -2627,6 +2640,12 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     session_pct = claude.get("sessionPct")
     session_reset_at = claude.get("sessionResetAt")
     session_reset_min = _reset_minutes(session_reset_at, current_ts)
+    # A statusLine window that won while stale (sessionLive false): the
+    # wire has no session-stale flag, so it is withheld -- dashes, as
+    # before the bridge existed -- rather than shown as a live figure.
+    session_live = claude.get("sessionLive", True) is True
+    if not session_live:
+        session_pct = None
     if session_pct is None or session_reset_min is None:
         session_pct = None
         session_reset_at = None
@@ -2637,11 +2656,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     # fallback would be meaningless) -- a non-None reading here is always a
     # genuinely fresh probe result, the honest gate Task 6 requires before
     # anything reaches Max Tracker's day peaks.
-    # A statusLine window that won while stale is the same kind of floor
-    # (sessionLive false): shown, never recorded as a new measurement.
-    session_live = claude.get("sessionLive", True) is True
-    if (max_tracker_store is not None and session_pct is not None
-            and session_live):
+    if max_tracker_store is not None and session_pct is not None:
         max_tracker_store.observe_quota(
             "claude", MAX_TRACKER_CLAUDE_SESSION_MINUTES, session_pct,
             current_ts)
@@ -2723,7 +2738,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
         (provider, window, pct, reset_at)
         for provider, window, pct, reset_at, is_live in (
             ("claude", "session", result["claudeSessionPct"],
-             claude_session_reset, session_live),
+             claude_session_reset, True),
             ("claude", "week", result["claudeWeekPct"],
              claude_week_reset, claude_week["live"]),
             ("claude", "model_week", result["claudeModelWeekPct"],

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -341,10 +341,13 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
     sample is fresh: within a window usage only accumulates, so a stored
     60 % is a floor until that window resets, and a probe that says 40 %
     for the same reset is lagging, not newer. Freshness (Claude Code spoke
-    within STATUSLINE_FRESH_S, judged per window) decides only whether the
-    probe may slow down: both windows fresh and no older than the probe's
-    own is ``bridged``. The model week has no statusLine counterpart and
-    is never touched.
+    within STATUSLINE_FRESH_S, judged per window) decides two things: a
+    window that wins while stale is served as that floor but flagged
+    (``sessionLive`` false, ``weekStaleFloor`` true) so it reaches the
+    screen with ``*Stale: true`` and never the cache, Max Tracker or the
+    history as a new measurement; and both windows fresh and no older
+    than the probe's own is ``bridged``, which lets the probe slow down.
+    The model week has no statusLine counterpart and is never touched.
     """
     global _claude_statusline_bridged
     summary = _read_claude_statusline(path=path, now_ts=now_ts)
@@ -369,6 +372,7 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
             merged["sessionPct"] = five["pct"]
             merged["sessionResetAt"] = five["resets_at"]
             merged["sessionSource"] = "statusline"
+            merged["sessionLive"] = bool(five["fresh"])
 
     week = windows.get("seven_day")
     probe_reset = claude.get("weekResetAt")
@@ -397,6 +401,7 @@ def _merge_claude_statusline(claude, quota_cache, now_ts, path=None):
             merged["weekObservedAt"] = int(week["at"])
             merged["weekIdentity"] = _quota_identity("claude", "general_weekly")
             merged["weekSource"] = "statusline"
+            merged["weekStaleFloor"] = not week["fresh"]
     _claude_statusline_bridged = covered == 2
     return merged
 
@@ -650,6 +655,7 @@ def _merge_claude_plan_usage(claude, quota_cache, now_ts, path=None):
         return claude
 
     merged = dict(claude)
+    merged.pop("weekStaleFloor", None)  # a fresh local reading, not a floor
     merged.update({
         "weekPct": local["week_pct"],
         "weekResetAt": cached.reset_at,
@@ -2381,6 +2387,20 @@ def _resolve_weekly_quota(source, provider, scope, prefix, quota_cache,
         not isinstance(observed_at, bool) and math.isfinite(observed_at) and
         isinstance(identity, str) and bool(identity)
     )
+    if live and source.get(f"{prefix}StaleFloor") is True:
+        # A statusLine window nobody has watched for a while: the figure
+        # is a true floor until its reset, so it is served, but as stale
+        # -- and a stale value is not a new measurement for the cache,
+        # Max Tracker or the history (the fresh sample already fed them).
+        return {
+            "pct": round(float(pct), 1),
+            "reset_at": int(reset_at),
+            "observed_at": int(observed_at),
+            "label": None,
+            "stale": True,
+            "live": False,
+            "cache_record": None,
+        }
     if live:
         label = source.get(label_key) if label_key else None
         record = CachedQuota(
@@ -2617,7 +2637,11 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
     # fallback would be meaningless) -- a non-None reading here is always a
     # genuinely fresh probe result, the honest gate Task 6 requires before
     # anything reaches Max Tracker's day peaks.
-    if max_tracker_store is not None and session_pct is not None:
+    # A statusLine window that won while stale is the same kind of floor
+    # (sessionLive false): shown, never recorded as a new measurement.
+    session_live = claude.get("sessionLive", True) is True
+    if (max_tracker_store is not None and session_pct is not None
+            and session_live):
         max_tracker_store.observe_quota(
             "claude", MAX_TRACKER_CLAUDE_SESSION_MINUTES, session_pct,
             current_ts)
@@ -2699,7 +2723,7 @@ def get_snapshot(projects_dir: Path, history=None, now_ts=None,
         (provider, window, pct, reset_at)
         for provider, window, pct, reset_at, is_live in (
             ("claude", "session", result["claudeSessionPct"],
-             claude_session_reset, True),
+             claude_session_reset, session_live),
             ("claude", "week", result["claudeWeekPct"],
              claude_week_reset, claude_week["live"]),
             ("claude", "model_week", result["claudeModelWeekPct"],

--- a/tools/tokenserver/tokenserver.py
+++ b/tools/tokenserver/tokenserver.py
@@ -157,14 +157,15 @@ _IS_WINDOWS = sys.platform == "win32"
 _claude_plan_usage_status = "not_checked"
 # The statusLine bridge sample: content-free status word for GET / and
 # the transition log (not_installed / missing / unreadable / invalid /
-# empty / stale / fresh), the last summary served, and a (mtime, size)
-# keyed parse cache so the 30 s polls do not reparse an unchanged file.
+# empty / stale / fresh) and the last summary served. The file is under
+# 64 KiB and read once per 30 s poll, so it is parsed every time: a
+# parse cache keyed on (mtime, size) missed a rewrite on Windows CI, where
+# two writes in one tick shared both.
 _claude_statusline_status = "not_checked"
 _claude_statusline_logged = None
 _claude_statusline_view = {"status": "not_checked", "ageS": None,
                            "claudeCodeVersion": None}
 _claude_statusline_bridged = False
-_claude_statusline_cache = (None, None)
 _claude_statusline_lock = threading.Lock()
 # Tests point this at a file that does not exist so a bridge installed on
 # the developer's own machine never leaks into snapshot assertions.
@@ -281,33 +282,18 @@ def _read_claude_statusline(path=None, now_ts=None):
     """The bridge's validated windows, or ``None`` when there is nothing
     usable.  Sets the status word and logs its transitions once."""
     global _claude_statusline_status, _claude_statusline_logged, \
-        _claude_statusline_view, _claude_statusline_cache
+        _claude_statusline_view
     sample_path = _claude_statusline_path() if path is None else Path(path)
     current_ts = time.time() if now_ts is None else now_ts
     with _claude_statusline_lock:
-        try:
-            info = sample_path.stat()
-            key = (info.st_mtime_ns, info.st_size)
-        except FileNotFoundError:
-            key = None
-            installed = statusline_bridge.config_path(
-                sample_path.parent).exists()
-            status, document = ("missing" if installed
-                                else "not_installed"), None
-        except OSError:
-            key, status, document = None, "unreadable", None
-        else:
-            if key == _claude_statusline_cache[0]:
-                status, document = "ok", _claude_statusline_cache[1]
-            else:
-                status, document = statusline_bridge.peek_sample(sample_path)
+        status, document = statusline_bridge.peek_sample(sample_path)
+        if status == "missing" and not statusline_bridge.config_path(
+                sample_path.parent).exists():
+            status = "not_installed"
         summary = None
         if status == "ok":
-            _claude_statusline_cache = (key, document)
             summary = statusline_bridge.summarize_sample(document, current_ts)
             status = summary["status"]
-        else:
-            _claude_statusline_cache = (None, None)
         view = {"status": status,
                 "ageS": summary["ageS"] if summary else None,
                 "claudeCodeVersion":

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -2083,7 +2083,8 @@ def _statusline_report(state: _StatusLineState, stdout) -> bool:
               "Claude Code speaks again", file=stdout)
     elif state.sample_status in ("missing", "empty"):
         print("WAIT statusLine bridge: installed, no sample yet; finish one "
-              "Claude Code turn and the panel picks it up within a minute",
+              "turn in a Claude Code session started after the install "
+              "(a running session keeps the statusLine it started with)",
               file=stdout)
     else:
         print(f"VARN statusLine bridge: sample file is {state.sample_status}; "
@@ -2182,9 +2183,9 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
             "so Claude Code shows none")
     print(f"PASS statusLine bridge: installed in {settings_path}{kept}",
           file=stdout)
-    print("The first sample appears after the next assistant message in "
-          "any Claude Code session (existing sessions pick the new "
-          "statusLine up on their next trigger).", file=stdout)
+    print("Claude Code binds the statusLine command when a session starts: "
+          "restart your Claude Code sessions, and the first sample appears "
+          "after the first assistant message in one of them.", file=stdout)
     return True
 
 

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1977,8 +1977,9 @@ def _statusline_launcher_text(python: Path, bridge: Path, state_dir: Path,
         f"PY={shlex.quote(str(python))}\n"
         f"BRIDGE={shlex.quote(str(bridge))}\n"
         f"STATE={shlex.quote(str(state_dir))}\n"
+        f"CHAINED={shlex.quote(chained or '')}\n"
         'if [ -x "$PY" ] && [ -f "$BRIDGE" ]; then\n'
-        '  exec "$PY" "$BRIDGE" --state-dir "$STATE"\n'
+        '  exec "$PY" "$BRIDGE" --state-dir "$STATE" --chained "$CHAINED"\n'
         "fi\n"
         "# The checkout or interpreter moved: keep the previous status line.\n"
         f"{fallback}\n")
@@ -2251,14 +2252,21 @@ def _statusline_uninstall(*, config_dir: Path, state_dir: Path,
     chained = record.get("chained_command") if record else None
     if ours:
         settings = dict(settings)
+        new_block = dict(block)
         if _statusline_valid_command(chained):
-            new_block = dict(block)
             new_block["command"] = chained
-            settings["statusLine"] = new_block
             restored = f"restored {chained[:60]!r}"
         else:
+            # Only what the install wrote goes; a sibling such as
+            # ``padding`` -- there before, or added since -- stays.
+            new_block.pop("command", None)
+            new_block.pop("type", None)
+            restored = "removed the command (there was none before)"
+        if new_block:
+            settings["statusLine"] = new_block
+        else:
             settings.pop("statusLine", None)
-            restored = "removed the statusLine entry (there was none before)"
+            restored += " and the empty statusLine entry"
         _statusline_write_settings(settings_path, settings)
     else:
         shown = repr(current[:60]) if isinstance(current, str) else "nothing"

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1926,14 +1926,41 @@ def _statusline_launcher_is_ours(path: Path) -> bool:
     return STATUSLINE_LAUNCHER_MARKER in head
 
 
+def _statusline_command_path(command):
+    """The one program a statusLine.command names, as the shell would
+    split it, or ``None``.  Claude Code runs the command through a shell,
+    so a path with a space (``Application Support``) must be quoted and
+    the unquoted form names a program that does not exist."""
+    if not isinstance(command, str) or not command:
+        return None
+    try:
+        words = shlex.split(command)
+    except ValueError:
+        return None
+    if len(words) != 1:
+        return None
+    return words[0]
+
+
 def _statusline_command_is_launcher(command, launcher: Path) -> bool:
-    """Is this statusLine.command ours -- the recorded launcher path, or
-    another path whose file carries the generated marker?"""
+    """Is this statusLine.command ours -- the launcher path (quoted for the
+    shell, or the unquoted string an earlier install wrote), or another
+    path whose file carries the generated marker?"""
     if not isinstance(command, str) or not command:
         return False
     if command == str(launcher):
         return True
-    return _statusline_launcher_is_ours(Path(command))
+    program = _statusline_command_path(command)
+    if program is None:
+        return False
+    if program == str(launcher):
+        return True
+    return _statusline_launcher_is_ours(Path(program))
+
+
+def _statusline_command_runs_launcher(command, launcher: Path) -> bool:
+    """Would the shell actually start the launcher from this command?"""
+    return _statusline_command_path(command) == str(launcher)
 
 
 def _statusline_launcher_text(python: Path, bridge: Path, state_dir: Path,
@@ -1990,7 +2017,8 @@ def _statusline_state(*, config_dir: Path, state_dir: Path, repo_root: Path,
         settings_error = str(exc)
     launcher_present = launcher.is_file()
     launcher_ours = launcher_present and _statusline_launcher_is_ours(launcher)
-    points_at_launcher = settings_command == str(launcher)
+    points_at_launcher = _statusline_command_runs_launcher(
+        settings_command, launcher)
     python = None
     if record is not None and isinstance(record.get("python"), str):
         python = Path(record["python"])
@@ -2037,6 +2065,14 @@ def _statusline_report(state: _StatusLineState, stdout) -> bool:
     if state.settings_error is not None:
         print(f"FIX statusLine bridge: cannot read {state.settings_path} "
               f"({state.settings_error})", file=stdout)
+        ok = False
+    elif (not state.points_at_launcher and _statusline_command_is_launcher(
+            state.settings_command, state.launcher)):
+        print(f"FIX statusLine bridge: statusLine.command in "
+              f"{state.settings_path} names the launcher without shell "
+              "quoting, so the shell splits the path at its space and "
+              "nothing runs; run `vibepulse_setup.py statusline install "
+              "--yes-single-account` again to rewrite it", file=stdout)
         ok = False
     elif not state.points_at_launcher:
         shown = (repr(state.settings_command[:60])
@@ -2173,7 +2209,9 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
     _statusline_write_record_file(record_path, document)
     new_block = dict(block)
     new_block["type"] = "command"
-    new_block["command"] = str(launcher)
+    # Claude Code hands the command to a shell: quote the path, or the
+    # space in "Application Support" splits it and nothing runs.
+    new_block["command"] = shlex.quote(str(launcher))
     settings = dict(settings)
     settings["statusLine"] = new_block
     _statusline_write_settings(settings_path, settings)

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -64,7 +64,7 @@ _RELAY_BLOCK_END = "/* VIBEPULSE INTERACTION RELAY END */"
 _MAILBOX_RE = re.compile(r"vp_[A-Za-z0-9_-]{16}\Z")
 _BEARER_RE = re.compile(r"[A-Za-z0-9_-]{43}\Z")
 
-STATUSLINE_LAUNCHER_NAME = "statusline-bridge.sh"
+STATUSLINE_LAUNCHER_PREFIX = "statusline-bridge-"
 STATUSLINE_LAUNCHER_MARKER = "# vibepulse-statusline-bridge"
 STATUSLINE_SETTINGS_MAX_BYTES = 256 * 1024
 STATUSLINE_COMMAND_MAX_CHARS = 4096
@@ -1856,6 +1856,22 @@ def _statusline_settings_path(config_dir: Path) -> Path:
     return Path(config_dir) / "settings.json"
 
 
+def _statusline_launcher_path(state_dir: Path, config_dir: Path) -> Path:
+    """One launcher per Claude config directory: two ``CLAUDE_CONFIG_DIR``
+    installs sharing the state directory must each keep their own baked-in
+    interpreter and fallback status line."""
+    key = statusline_bridge.config_dir_key(config_dir)
+    return Path(state_dir) / f"{STATUSLINE_LAUNCHER_PREFIX}{key}.sh"
+
+
+def _statusline_recorded_launcher(record, fallback: Path) -> Path:
+    """The launcher this record installed (an earlier release wrote one
+    shared launcher), else the per-directory path."""
+    if isinstance(record, dict) and isinstance(record.get("launcher"), str):
+        return Path(record["launcher"])
+    return fallback
+
+
 def _statusline_read_settings(path: Path) -> dict:
     """The whole settings document (``{}`` when absent).  Raises
     ``ConfigError`` when the file exists but cannot be trusted."""
@@ -2001,7 +2017,6 @@ def _statusline_state(*, config_dir: Path, state_dir: Path, repo_root: Path,
     now = int(time.time()) if now is None else int(now)
     config_dir = Path(config_dir)
     settings_path = _statusline_settings_path(config_dir)
-    launcher = Path(state_dir) / STATUSLINE_LAUNCHER_NAME
     record = None
     try:
         dirs = _statusline_read_record_file(
@@ -2010,6 +2025,8 @@ def _statusline_state(*, config_dir: Path, state_dir: Path, repo_root: Path,
         record = candidate if isinstance(candidate, dict) else None
     except ConfigError:
         record = None
+    launcher = _statusline_recorded_launcher(
+        record, _statusline_launcher_path(state_dir, config_dir))
     settings_command = None
     settings_error = None
     try:
@@ -2188,7 +2205,7 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
     config_dir = Path(config_dir)
     state_dir = Path(state_dir)
     settings_path = _statusline_settings_path(config_dir)
-    launcher = state_dir / STATUSLINE_LAUNCHER_NAME
+    launcher = _statusline_launcher_path(state_dir, config_dir)
     record_path = statusline_bridge.config_path(state_dir)
 
     settings = _statusline_read_settings(settings_path)
@@ -2196,6 +2213,7 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
     key = statusline_bridge.config_dir_key(config_dir)
     previous = document["dirs"].get(key)
     previous = previous if isinstance(previous, dict) else None
+    previous_launcher = _statusline_recorded_launcher(previous, launcher)
 
     block = settings.get("statusLine")
     if block is None:
@@ -2210,7 +2228,8 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
     chained = None
     if current is None:
         chained = None
-    elif _statusline_command_is_launcher(current, launcher):
+    elif (_statusline_command_is_launcher(current, launcher)
+          or _statusline_command_is_launcher(current, previous_launcher)):
         # Reinstall: the previous status line lives in our record, not
         # in settings.json (which points at us).
         chained = (previous.get("chained_command")
@@ -2249,6 +2268,16 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
     settings = dict(settings)
     settings["statusLine"] = new_block
     _statusline_write_settings(settings_path, settings)
+    if previous_launcher != launcher and not any(
+            isinstance(other, dict) and other.get("launcher")
+            == str(previous_launcher) for other in document["dirs"].values()):
+        # An earlier release's shared launcher that no record uses now.
+        try:
+            previous_launcher.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise ConfigError(f"cannot remove {previous_launcher}") from exc
 
     kept = (f"; your previous status line ({chained[:60]!r}) still runs "
             "after it" if chained else "; there was no status line before, "
@@ -2266,12 +2295,13 @@ def _statusline_uninstall(*, config_dir: Path, state_dir: Path,
     config_dir = Path(config_dir)
     state_dir = Path(state_dir)
     settings_path = _statusline_settings_path(config_dir)
-    launcher = state_dir / STATUSLINE_LAUNCHER_NAME
     record_path = statusline_bridge.config_path(state_dir)
     document = _statusline_read_record_file(record_path)
     key = statusline_bridge.config_dir_key(config_dir)
     record = document["dirs"].get(key)
     record = record if isinstance(record, dict) else None
+    launcher = _statusline_recorded_launcher(
+        record, _statusline_launcher_path(state_dir, config_dir))
 
     settings = _statusline_read_settings(settings_path)
     block = settings.get("statusLine")
@@ -2307,20 +2337,25 @@ def _statusline_uninstall(*, config_dir: Path, state_dir: Path,
                     f"{shown}, not the launcher")
 
     document["dirs"].pop(key, None)
+    doomed = []
     if document["dirs"]:
         _statusline_write_record_file(record_path, document)
-        removed = "; other config directories still use the launcher"
+        removed = "; other config directories keep their own launchers"
+        if not any(isinstance(other, dict) and other.get("launcher")
+                   == str(launcher) for other in document["dirs"].values()):
+            doomed.append(launcher)
     else:
         removed = ""
-        for path in (record_path, launcher,
-                     statusline_bridge.sample_path(state_dir),
-                     state_dir / statusline_bridge.LOCK_NAME):
-            try:
-                path.unlink()
-            except FileNotFoundError:
-                pass
-            except OSError as exc:
-                raise ConfigError(f"cannot remove {path}") from exc
+        doomed = [record_path, launcher,
+                  statusline_bridge.sample_path(state_dir),
+                  state_dir / statusline_bridge.LOCK_NAME]
+    for path in doomed:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise ConfigError(f"cannot remove {path}") from exc
     print(f"PASS statusLine bridge: uninstalled; {restored}{removed}",
           file=stdout)
     return True

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1976,6 +1976,25 @@ def _statusline_command_is_launcher(command, launcher: Path) -> bool:
     return _statusline_launcher_is_ours(Path(program))
 
 
+def _statusline_launcher_chained(path: Path) -> str | None:
+    """The previous status line a generated launcher bakes in (its
+    ``CHAINED=`` line), for a reinstall whose record is gone."""
+    try:
+        text = _read_small_regular(path, 64 * 1024).decode("utf-8", "replace")
+    except (FileNotFoundError, ConfigError):
+        return None
+    for line in text.splitlines():
+        if line.startswith("CHAINED="):
+            try:
+                words = shlex.split(line[len("CHAINED="):])
+            except ValueError:
+                return None
+            if len(words) == 1 and _statusline_valid_command(words[0]):
+                return words[0]
+            return None
+    return None
+
+
 def _statusline_command_runs_launcher(command, launcher: Path) -> bool:
     """Would the shell actually start the launcher from this command?"""
     return _statusline_command_path(command) == str(launcher)
@@ -2231,11 +2250,18 @@ def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
     elif (_statusline_command_is_launcher(current, launcher)
           or _statusline_command_is_launcher(current, previous_launcher)):
         # Reinstall: the previous status line lives in our record, not
-        # in settings.json (which points at us).
+        # in settings.json (which points at us). Without a record (deleted
+        # by hand, status said to reinstall) the launcher still running
+        # carries it as its baked-in fallback: recover it from there
+        # rather than erase it.
         chained = (previous.get("chained_command")
                    if previous is not None else None)
         if not _statusline_valid_command(chained):
             chained = None
+        if chained is None and previous is None:
+            program = _statusline_command_path(current)
+            chained = (_statusline_launcher_chained(Path(program))
+                       if program else None)
     elif _statusline_valid_command(current):
         chained = current
     else:

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import re
 import secrets
 import selectors
+import shlex
 import signal
 import stat
 import subprocess
@@ -38,6 +39,7 @@ from tokenserver.vibepulse_config import (  # noqa: E402
     save_config,
 )
 from tokenserver.codex_command import resolve_codex_executable  # noqa: E402
+from tokenserver import statusline_bridge  # noqa: E402
 from tokenserver.tokenserver import _read_source_fingerprint  # noqa: E402
 
 
@@ -61,6 +63,15 @@ _RELAY_BLOCK_BEGIN = "/* VIBEPULSE INTERACTION RELAY BEGIN */"
 _RELAY_BLOCK_END = "/* VIBEPULSE INTERACTION RELAY END */"
 _MAILBOX_RE = re.compile(r"vp_[A-Za-z0-9_-]{16}\Z")
 _BEARER_RE = re.compile(r"[A-Za-z0-9_-]{43}\Z")
+
+STATUSLINE_LAUNCHER_NAME = "statusline-bridge.sh"
+STATUSLINE_LAUNCHER_MARKER = "# vibepulse-statusline-bridge"
+STATUSLINE_SETTINGS_MAX_BYTES = 256 * 1024
+STATUSLINE_COMMAND_MAX_CHARS = 4096
+_STATUSLINE_CONSENT = (
+    "Claude Code and the VibePulse tokenserver must use the SAME Claude "
+    "account on this computer: the bridge cannot tell accounts apart, so a "
+    "second account's status line would be shown as this one's quota.")
 
 _KNOWN_ABSENT = {
     ("plugin", "marketplace", "remove", "torget"): re.compile(
@@ -275,6 +286,24 @@ def _parser() -> argparse.ArgumentParser:
         "--keep-worker", action="store_false", dest="delete_worker",
         help="leave the Cloudflare Worker deployed")
     relay_uninstall.set_defaults(delete_worker=None)
+
+    statusline = commands.add_parser(
+        "statusline",
+        help="let Claude Code's statusLine feed the tokenserver its quota")
+    statusline_commands = statusline.add_subparsers(
+        dest="statusline_command", required=True)
+    statusline_install = statusline_commands.add_parser(
+        "install", help="point Claude Code's statusLine at the bridge, "
+                        "keeping the status line you have")
+    statusline_install.add_argument(
+        "--yes-single-account", action="store_true",
+        help="confirm that Claude Code and the tokenserver use the same "
+             "Claude account on this computer")
+    statusline_commands.add_parser(
+        "uninstall", help="restore the previous statusLine and forget "
+                          "the bridge")
+    statusline_commands.add_parser(
+        "status", help="show whether the bridge is installed and feeding")
     return parser
 
 
@@ -1511,6 +1540,8 @@ def _doctor(
         repo_root: Path, run: Callable[..., object],
         urlopen: Callable[..., object], stdout,
         codex_config_path: Path | None = None,
+        claude_config_dir: Path | None = None,
+        statusline_state_dir: Path | None = None,
         ) -> bool:
     fixes = False
 
@@ -1658,6 +1689,14 @@ def _doctor(
             if config.claude_interactions and not _doctor_claude_quota(
                     payload, stdout):
                 fixes = True
+    if not _statusline_report(_statusline_state(
+            config_dir=(statusline_bridge.claude_config_dir()
+                        if claude_config_dir is None else claude_config_dir),
+            state_dir=(statusline_bridge.state_dir()
+                       if statusline_state_dir is None
+                       else statusline_state_dir),
+            repo_root=repo_root), stdout):
+        fixes = True
     return not fixes
 
 
@@ -1783,6 +1822,428 @@ def _doctor_claude_quota(payload: dict, stdout) -> bool:
 
     print("FIX Claude quota credential: invalid diagnostics", file=stdout)
     return False
+
+
+# --- Claude Code statusLine bridge ------------------------------------------
+
+@dataclass(frozen=True)
+class _StatusLineState:
+    config_dir: Path
+    settings_path: Path
+    state_dir: Path
+    launcher: Path
+    record: dict | None          # our record for this config dir, if any
+    settings_command: str | None  # statusLine.command as saved, if a string
+    settings_error: str | None   # why settings.json could not be read
+    points_at_launcher: bool
+    launcher_present: bool
+    launcher_ours: bool
+    python: Path | None
+    python_present: bool
+    bridge_present: bool
+    sample_status: str           # missing / unreadable / invalid / empty / stale / fresh
+    sample_age_s: int | None
+    claude_code_version: str | None
+
+    @property
+    def installed(self) -> bool:
+        return self.record is not None
+
+
+def _statusline_settings_path(config_dir: Path) -> Path:
+    return Path(config_dir) / "settings.json"
+
+
+def _statusline_read_settings(path: Path) -> dict:
+    """The whole settings document (``{}`` when absent).  Raises
+    ``ConfigError`` when the file exists but cannot be trusted."""
+    try:
+        raw = _read_small_regular(path, STATUSLINE_SETTINGS_MAX_BYTES)
+    except FileNotFoundError:
+        return {}
+    try:
+        document = json.loads(
+            raw.decode("utf-8"), parse_constant=_reject_json_constant,
+            object_pairs_hook=_unique_json_object)
+    except (UnicodeError, ValueError, RecursionError) as exc:
+        raise ConfigError(f"{path} is not strict JSON") from exc
+    if not isinstance(document, dict):
+        raise ConfigError(f"{path} is not a JSON object")
+    return document
+
+
+def _statusline_write_settings(path: Path, document: dict) -> None:
+    """Replace settings.json atomically, keeping its mode (Claude Code
+    creates it world-readable; a fresh file is private)."""
+    path = Path(path)
+    try:
+        existing = os.lstat(path)
+    except FileNotFoundError:
+        mode = 0o600
+    else:
+        if stat.S_ISLNK(existing.st_mode):
+            raise ConfigError(f"{path} must not be a symlink")
+        mode = stat.S_IMODE(existing.st_mode)
+    payload = (json.dumps(document, indent=2, ensure_ascii=False) + "\n"
+               ).encode("utf-8")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        statusline_bridge.atomic_write_private(path, payload)
+        if os.name == "posix":
+            os.chmod(path, mode)
+    except OSError as exc:
+        raise ConfigError(f"cannot save {path}") from exc
+
+
+def _statusline_read_record_file(path: Path) -> dict:
+    try:
+        raw = _read_small_regular(path, statusline_bridge.CONFIG_MAX_BYTES)
+    except FileNotFoundError:
+        return {"v": statusline_bridge.CONFIG_VERSION, "dirs": {}}
+    except ConfigError:
+        raise
+    try:
+        document = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, ValueError) as exc:
+        raise ConfigError(f"{path} is not JSON") from exc
+    if (not isinstance(document, dict)
+            or document.get("v") != statusline_bridge.CONFIG_VERSION
+            or not isinstance(document.get("dirs"), dict)):
+        raise ConfigError(f"{path} is not the v1 bridge record")
+    return document
+
+
+def _statusline_write_record_file(path: Path, document: dict) -> None:
+    payload = json.dumps(document, indent=2, sort_keys=True).encode("utf-8")
+    _atomic_private_write(path, payload)
+
+
+def _statusline_launcher_is_ours(path: Path) -> bool:
+    try:
+        head = _read_small_regular(path, 4096).decode("utf-8", "replace")
+    except (FileNotFoundError, ConfigError):
+        return False
+    return STATUSLINE_LAUNCHER_MARKER in head
+
+
+def _statusline_command_is_launcher(command, launcher: Path) -> bool:
+    """Is this statusLine.command ours -- the recorded launcher path, or
+    another path whose file carries the generated marker?"""
+    if not isinstance(command, str) or not command:
+        return False
+    if command == str(launcher):
+        return True
+    return _statusline_launcher_is_ours(Path(command))
+
+
+def _statusline_launcher_text(python: Path, bridge: Path, state_dir: Path,
+                              chained: str | None) -> str:
+    fallback = (f"exec /bin/sh -c {shlex.quote(chained)}" if chained
+                else "exit 0")
+    return (
+        "#!/bin/sh\n"
+        f"{STATUSLINE_LAUNCHER_MARKER} v1\n"
+        "# Generated by tools/vibepulse_setup.py statusline install.\n"
+        "# Claude Code runs this on every status-line trigger; the bridge\n"
+        "# records the rate-limit windows for the VibePulse tokenserver and\n"
+        "# then runs the status line you had before with the same stdin.\n"
+        f"PY={shlex.quote(str(python))}\n"
+        f"BRIDGE={shlex.quote(str(bridge))}\n"
+        f"STATE={shlex.quote(str(state_dir))}\n"
+        'if [ -x "$PY" ] && [ -f "$BRIDGE" ]; then\n'
+        '  exec "$PY" "$BRIDGE" --state-dir "$STATE"\n'
+        "fi\n"
+        "# The checkout or interpreter moved: keep the previous status line.\n"
+        f"{fallback}\n")
+
+
+def _statusline_bridge_script(repo_root: Path) -> Path:
+    return Path(repo_root) / "tools" / "tokenserver" / "statusline_bridge.py"
+
+
+def _statusline_valid_command(value) -> bool:
+    return (isinstance(value, str) and 0 < len(value)
+            <= STATUSLINE_COMMAND_MAX_CHARS and value.isprintable())
+
+
+def _statusline_state(*, config_dir: Path, state_dir: Path, repo_root: Path,
+                      now: int | None = None) -> _StatusLineState:
+    now = int(time.time()) if now is None else int(now)
+    config_dir = Path(config_dir)
+    settings_path = _statusline_settings_path(config_dir)
+    launcher = Path(state_dir) / STATUSLINE_LAUNCHER_NAME
+    record = None
+    try:
+        dirs = _statusline_read_record_file(
+            statusline_bridge.config_path(state_dir))["dirs"]
+        candidate = dirs.get(statusline_bridge.config_dir_key(config_dir))
+        record = candidate if isinstance(candidate, dict) else None
+    except ConfigError:
+        record = None
+    settings_command = None
+    settings_error = None
+    try:
+        block = _statusline_read_settings(settings_path).get("statusLine")
+        if isinstance(block, dict) and isinstance(block.get("command"), str):
+            settings_command = block["command"]
+    except ConfigError as exc:
+        settings_error = str(exc)
+    launcher_present = launcher.is_file()
+    launcher_ours = launcher_present and _statusline_launcher_is_ours(launcher)
+    points_at_launcher = settings_command == str(launcher)
+    python = None
+    if record is not None and isinstance(record.get("python"), str):
+        python = Path(record["python"])
+    python_present = python is not None and os.access(python, os.X_OK)
+    bridge_present = _statusline_bridge_script(repo_root).is_file()
+    sample_status, document = statusline_bridge.peek_sample(
+        statusline_bridge.sample_path(state_dir))
+    age = None
+    version = None
+    if sample_status == "ok":
+        summary = statusline_bridge.summarize_sample(document, now)
+        sample_status = summary["status"]
+        age = summary["ageS"]
+        version = summary["claudeCodeVersion"]
+    return _StatusLineState(
+        config_dir=config_dir, settings_path=settings_path,
+        state_dir=Path(state_dir), launcher=launcher, record=record,
+        settings_command=settings_command, settings_error=settings_error,
+        points_at_launcher=points_at_launcher,
+        launcher_present=launcher_present, launcher_ours=launcher_ours,
+        python=python, python_present=python_present,
+        bridge_present=bridge_present, sample_status=sample_status,
+        sample_age_s=age, claude_code_version=version)
+
+
+def _statusline_report(state: _StatusLineState, stdout) -> bool:
+    """Print the doctor/status lines; return False when something needs a
+    fix (an optional feature that is simply not installed is not one)."""
+    if not state.installed:
+        if _statusline_command_is_launcher(state.settings_command,
+                                           state.launcher):
+            print("FIX statusLine bridge: settings.json points at the "
+                  "launcher but the install record is gone; run "
+                  "`vibepulse_setup.py statusline install "
+                  "--yes-single-account` again or `statusline uninstall`",
+                  file=stdout)
+            return False
+        print("OFF statusLine bridge: not installed (optional; "
+              "`vibepulse_setup.py statusline install --yes-single-account` "
+              "lets Claude Code feed the tokenserver its own quota figures)",
+              file=stdout)
+        return True
+    ok = True
+    if state.settings_error is not None:
+        print(f"FIX statusLine bridge: cannot read {state.settings_path} "
+              f"({state.settings_error})", file=stdout)
+        ok = False
+    elif not state.points_at_launcher:
+        shown = (repr(state.settings_command[:60])
+                 if state.settings_command else "nothing")
+        print(f"FIX statusLine bridge: {state.settings_path} no longer "
+              f"points at the launcher (statusLine.command is {shown}); "
+              "run `vibepulse_setup.py statusline install "
+              "--yes-single-account` again, or `statusline uninstall` to "
+              "forget it", file=stdout)
+        ok = False
+    if not state.launcher_present:
+        print(f"FIX statusLine bridge: launcher missing at {state.launcher}; "
+              "run `vibepulse_setup.py statusline install "
+              "--yes-single-account` again", file=stdout)
+        ok = False
+    elif not state.launcher_ours:
+        print(f"FIX statusLine bridge: {state.launcher} is not the generated "
+              "launcher; run `vibepulse_setup.py statusline install "
+              "--yes-single-account` again", file=stdout)
+        ok = False
+    if not state.python_present:
+        print(f"FIX statusLine bridge: interpreter {state.python} is gone; "
+              "run `vibepulse_setup.py statusline install "
+              "--yes-single-account` again from a working Python",
+              file=stdout)
+        ok = False
+    if not state.bridge_present:
+        print("FIX statusLine bridge: tools/tokenserver/statusline_bridge.py "
+              "is missing from the checkout the launcher points at; run "
+              "`vibepulse_setup.py statusline install --yes-single-account` "
+              "again from the durable checkout", file=stdout)
+        ok = False
+    if not ok:
+        return False
+    version = (f", Claude Code {state.claude_code_version}"
+               if state.claude_code_version else "")
+    if state.sample_status == "fresh":
+        print(f"PASS statusLine bridge: fresh sample {state.sample_age_s} s "
+              f"ago{version}; account assumed single", file=stdout)
+    elif state.sample_status == "stale":
+        minutes = (state.sample_age_s or 0) // 60
+        print(f"VARN statusLine bridge: last sample {minutes} min "
+              f"ago{version}; the tokenserver uses its own probe until "
+              "Claude Code speaks again", file=stdout)
+    elif state.sample_status in ("missing", "empty"):
+        print("WAIT statusLine bridge: installed, no sample yet; finish one "
+              "Claude Code turn and the panel picks it up within a minute",
+              file=stdout)
+    else:
+        print(f"VARN statusLine bridge: sample file is {state.sample_status}; "
+              "the bridge quarantines it on its next run", file=stdout)
+    return True
+
+
+def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
+                        python: Path | None, consent: bool, stdout,
+                        now: int | None = None) -> bool:
+    if sys.platform == "win32":
+        print("FIX statusLine bridge: Windows is not supported yet (the "
+              "launcher is a POSIX shell script); see the open question in "
+              "docs/superpowers/specs/2026-09-10-vibepulse-statusline-"
+              "quota-source-design.md", file=stdout)
+        return False
+    if not consent:
+        print("FIX statusLine bridge: not installed; " + _STATUSLINE_CONSENT
+              + " Pass --yes-single-account to confirm.", file=stdout)
+        return False
+    if python is None or not os.access(python, os.X_OK):
+        print("FIX statusLine bridge: Python interpreter not found; run "
+              "this from the tokenserver's interpreter", file=stdout)
+        return False
+    bridge_script = _statusline_bridge_script(repo_root)
+    if not bridge_script.is_file():
+        print(f"FIX statusLine bridge: {bridge_script} is missing",
+              file=stdout)
+        return False
+    now = int(time.time()) if now is None else int(now)
+    config_dir = Path(config_dir)
+    state_dir = Path(state_dir)
+    settings_path = _statusline_settings_path(config_dir)
+    launcher = state_dir / STATUSLINE_LAUNCHER_NAME
+    record_path = statusline_bridge.config_path(state_dir)
+
+    settings = _statusline_read_settings(settings_path)
+    document = _statusline_read_record_file(record_path)
+    key = statusline_bridge.config_dir_key(config_dir)
+    previous = document["dirs"].get(key)
+    previous = previous if isinstance(previous, dict) else None
+
+    block = settings.get("statusLine")
+    if block is None:
+        block = {}
+    elif not isinstance(block, dict):
+        raise ConfigError(f"{settings_path}: statusLine is not an object")
+    current = block.get("command")
+    block_type = block.get("type", "command")
+    if block_type != "command":
+        raise ConfigError(f"{settings_path}: statusLine.type {block_type!r} "
+                          "is not a command; not touching it")
+    chained = None
+    if current is None:
+        chained = None
+    elif _statusline_command_is_launcher(current, launcher):
+        # Reinstall: the previous status line lives in our record, not
+        # in settings.json (which points at us).
+        chained = (previous.get("chained_command")
+                   if previous is not None else None)
+        if not _statusline_valid_command(chained):
+            chained = None
+    elif _statusline_valid_command(current):
+        chained = current
+    else:
+        raise ConfigError(f"{settings_path}: statusLine.command is not a "
+                          "single printable line; not touching it")
+
+    launcher_text = _statusline_launcher_text(
+        python, bridge_script, state_dir, chained)
+    try:
+        statusline_bridge.atomic_write_private(
+            launcher, launcher_text.encode("utf-8"))
+        os.chmod(launcher, 0o700)
+    except OSError as exc:
+        raise ConfigError(f"cannot write {launcher}") from exc
+    document["dirs"][key] = {
+        "config_dir": str(config_dir),
+        "settings_path": str(settings_path),
+        "chained_command": chained,
+        "launcher": str(launcher),
+        "python": str(python),
+        "bridge": str(bridge_script),
+        "installed_at": now,
+    }
+    _statusline_write_record_file(record_path, document)
+    new_block = dict(block)
+    new_block["type"] = "command"
+    new_block["command"] = str(launcher)
+    settings = dict(settings)
+    settings["statusLine"] = new_block
+    _statusline_write_settings(settings_path, settings)
+
+    kept = (f"; your previous status line ({chained[:60]!r}) still runs "
+            "after it" if chained else "; there was no status line before, "
+            "so Claude Code shows none")
+    print(f"PASS statusLine bridge: installed in {settings_path}{kept}",
+          file=stdout)
+    print("The first sample appears after the next assistant message in "
+          "any Claude Code session (existing sessions pick the new "
+          "statusLine up on their next trigger).", file=stdout)
+    return True
+
+
+def _statusline_uninstall(*, config_dir: Path, state_dir: Path,
+                          stdout) -> bool:
+    config_dir = Path(config_dir)
+    state_dir = Path(state_dir)
+    settings_path = _statusline_settings_path(config_dir)
+    launcher = state_dir / STATUSLINE_LAUNCHER_NAME
+    record_path = statusline_bridge.config_path(state_dir)
+    document = _statusline_read_record_file(record_path)
+    key = statusline_bridge.config_dir_key(config_dir)
+    record = document["dirs"].get(key)
+    record = record if isinstance(record, dict) else None
+
+    settings = _statusline_read_settings(settings_path)
+    block = settings.get("statusLine")
+    current = block.get("command") if isinstance(block, dict) else None
+    ours = _statusline_command_is_launcher(current, launcher)
+    if record is None and not ours:
+        print("OFF statusLine bridge: not installed for "
+              f"{config_dir}; nothing to do", file=stdout)
+        return True
+
+    chained = record.get("chained_command") if record else None
+    if ours:
+        settings = dict(settings)
+        if _statusline_valid_command(chained):
+            new_block = dict(block)
+            new_block["command"] = chained
+            settings["statusLine"] = new_block
+            restored = f"restored {chained[:60]!r}"
+        else:
+            settings.pop("statusLine", None)
+            restored = "removed the statusLine entry (there was none before)"
+        _statusline_write_settings(settings_path, settings)
+    else:
+        shown = repr(current[:60]) if isinstance(current, str) else "nothing"
+        restored = (f"left {settings_path} alone: statusLine.command is "
+                    f"{shown}, not the launcher")
+
+    document["dirs"].pop(key, None)
+    if document["dirs"]:
+        _statusline_write_record_file(record_path, document)
+        removed = "; other config directories still use the launcher"
+    else:
+        removed = ""
+        for path in (record_path, launcher,
+                     statusline_bridge.sample_path(state_dir),
+                     state_dir / statusline_bridge.LOCK_NAME):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                raise ConfigError(f"cannot remove {path}") from exc
+    print(f"PASS statusLine bridge: uninstalled; {restored}{removed}",
+          file=stdout)
+    return True
 
 
 def _resolve_executables(python, codex):
@@ -2110,12 +2571,19 @@ def main(
         relay_token_path: Path | None = None,
         secrets_path: Path | None = None,
         interaction_relay_dir: Path | None = None,
-        token_urlsafe=secrets.token_urlsafe) -> int:
+        token_urlsafe=secrets.token_urlsafe,
+        claude_config_dir: Path | None = None,
+        statusline_state_dir: Path | None = None) -> int:
     """Run the strict CLI with injectable process and network boundaries."""
     args = _parser().parse_args(argv)
     output = sys.stdout if stdout is None else stdout
     path = default_config_path() if config_path is None else Path(config_path)
     python_path, codex_path = _resolve_executables(python, codex)
+    claude_dir = (statusline_bridge.claude_config_dir()
+                  if claude_config_dir is None else Path(claude_config_dir))
+    bridge_state = (statusline_bridge.state_dir()
+                    if statusline_state_dir is None
+                    else Path(statusline_state_dir))
     interactive = (sys.stdin.isatty() if stdin_isatty is None
                    else stdin_isatty)
     relay_token = (Path.home() / ".vibepulse-interaction-relay-token"
@@ -2180,6 +2648,25 @@ def main(
                 service_dir=relay_service, run=run,
                 stdout=output) else 1
 
+        if args.command == "statusline":
+            if args.statusline_command == "status":
+                return 0 if _statusline_report(_statusline_state(
+                    config_dir=claude_dir, state_dir=bridge_state,
+                    repo_root=Path(repo_root)), output) else 1
+            if args.statusline_command == "uninstall":
+                return 0 if _statusline_uninstall(
+                    config_dir=claude_dir, state_dir=bridge_state,
+                    stdout=output) else 1
+            consent = bool(args.yes_single_account)
+            if not consent and interactive:
+                consent = input_fn(
+                    _STATUSLINE_CONSENT + " Type YES to continue: "
+                ).strip() == "YES"
+            return 0 if _statusline_install(
+                config_dir=claude_dir, state_dir=bridge_state,
+                repo_root=Path(repo_root), python=python_path,
+                consent=consent, stdout=output) else 1
+
         if args.command == "status":
             _print_status(load_config(path), output)
             return 0
@@ -2189,7 +2676,8 @@ def main(
             return 0 if _doctor(
                 config, python=python_path, codex=codex_path,
                 repo_root=Path(repo_root), run=run, urlopen=urlopen,
-                stdout=output) else 1
+                stdout=output, claude_config_dir=claude_dir,
+                statusline_state_dir=bridge_state) else 1
 
         if args.command == "disable":
             _disable(path, args.target)

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -1840,7 +1840,9 @@ class _StatusLineState:
     launcher_ours: bool
     python: Path | None
     python_present: bool
+    bridge: Path | None          # the script the launcher was pointed at
     bridge_present: bool
+    bridge_is_this_checkout: bool
     sample_status: str           # missing / unreadable / invalid / empty / stale / fresh
     sample_age_s: int | None
     claude_code_version: str | None
@@ -2024,7 +2026,20 @@ def _statusline_state(*, config_dir: Path, state_dir: Path, repo_root: Path,
     if record is not None and isinstance(record.get("python"), str):
         python = Path(record["python"])
     python_present = python is not None and os.access(python, os.X_OK)
-    bridge_present = _statusline_bridge_script(repo_root).is_file()
+    # The launcher invokes the script the INSTALL recorded, not whatever
+    # checkout the doctor happens to run from: judge that path.
+    bridge = None
+    if record is not None and isinstance(record.get("bridge"), str):
+        bridge = Path(record["bridge"])
+    bridge_present = bridge is not None and bridge.is_file()
+    this_checkout = _statusline_bridge_script(repo_root)
+    bridge_is_this_checkout = False
+    if bridge_present:
+        try:
+            bridge_is_this_checkout = (
+                bridge.resolve() == this_checkout.resolve())
+        except OSError:
+            bridge_is_this_checkout = False
     sample_status, document = statusline_bridge.peek_sample(
         statusline_bridge.sample_path(state_dir))
     age = None
@@ -2041,7 +2056,9 @@ def _statusline_state(*, config_dir: Path, state_dir: Path, repo_root: Path,
         points_at_launcher=points_at_launcher,
         launcher_present=launcher_present, launcher_ours=launcher_ours,
         python=python, python_present=python_present,
-        bridge_present=bridge_present, sample_status=sample_status,
+        bridge=bridge, bridge_present=bridge_present,
+        bridge_is_this_checkout=bridge_is_this_checkout,
+        sample_status=sample_status,
         sample_age_s=age, claude_code_version=version)
 
 
@@ -2101,11 +2118,16 @@ def _statusline_report(state: _StatusLineState, stdout) -> bool:
               file=stdout)
         ok = False
     if not state.bridge_present:
-        print("FIX statusLine bridge: tools/tokenserver/statusline_bridge.py "
-              "is missing from the checkout the launcher points at; run "
+        print(f"FIX statusLine bridge: the launcher points at {state.bridge} "
+              "and that script is gone (checkout moved or deleted); run "
               "`vibepulse_setup.py statusline install --yes-single-account` "
               "again from the durable checkout", file=stdout)
         ok = False
+    elif not state.bridge_is_this_checkout:
+        print(f"VARN statusLine bridge: the launcher runs {state.bridge}, "
+              "another checkout than this one; that is fine as long as it "
+              "is the durable checkout the tokenserver also runs from",
+              file=stdout)
     if not ok:
         return False
     version = (f", Claude Code {state.claude_code_version}"
@@ -2116,8 +2138,9 @@ def _statusline_report(state: _StatusLineState, stdout) -> bool:
     elif state.sample_status == "stale":
         minutes = (state.sample_age_s or 0) // 60
         print(f"VARN statusLine bridge: last sample {minutes} min "
-              f"ago{version}; the tokenserver uses its own probe until "
-              "Claude Code speaks again", file=stdout)
+              f"ago{version}; its windows still hold as a floor until they "
+              "reset, and the probe runs at full cadence until Claude Code "
+              "speaks again", file=stdout)
     elif state.sample_status in ("missing", "empty"):
         print("WAIT statusLine bridge: installed, no sample yet; finish one "
               "turn in a Claude Code session started after the install "
@@ -2131,12 +2154,22 @@ def _statusline_report(state: _StatusLineState, stdout) -> bool:
 
 def _statusline_install(*, config_dir: Path, state_dir: Path, repo_root: Path,
                         python: Path | None, consent: bool, stdout,
-                        now: int | None = None) -> bool:
-    if sys.platform == "win32":
+                        now: int | None = None,
+                        platform: str | None = None) -> bool:
+    platform = sys.platform if platform is None else platform
+    if platform == "win32":
         print("FIX statusLine bridge: Windows is not supported yet (the "
               "launcher is a POSIX shell script); see the open question in "
               "docs/superpowers/specs/2026-09-10-vibepulse-statusline-"
               "quota-source-design.md", file=stdout)
+        return False
+    if platform != "darwin":
+        # The single-account slice is validated on macOS only; Linux is
+        # not a supported host (AGENTS.md) and Claude Code's settings
+        # location there is unverified. Refuse rather than guess.
+        print(f"FIX statusLine bridge: {platform} is not a supported host "
+              "for the bridge; macOS only until the Linux gates in issue #2 "
+              "pass", file=stdout)
         return False
     if not consent:
         print("FIX statusLine bridge: not installed; " + _STATUSLINE_CONSENT
@@ -2620,7 +2653,8 @@ def main(
         interaction_relay_dir: Path | None = None,
         token_urlsafe=secrets.token_urlsafe,
         claude_config_dir: Path | None = None,
-        statusline_state_dir: Path | None = None) -> int:
+        statusline_state_dir: Path | None = None,
+        statusline_platform: str | None = None) -> int:
     """Run the strict CLI with injectable process and network boundaries."""
     args = _parser().parse_args(argv)
     output = sys.stdout if stdout is None else stdout
@@ -2712,7 +2746,8 @@ def main(
             return 0 if _statusline_install(
                 config_dir=claude_dir, state_dir=bridge_state,
                 repo_root=Path(repo_root), python=python_path,
-                consent=consent, stdout=output) else 1
+                consent=consent, stdout=output,
+                platform=statusline_platform) else 1
 
         if args.command == "status":
             _print_status(load_config(path), output)

--- a/tools/vibepulse_setup.py
+++ b/tools/vibepulse_setup.py
@@ -2339,6 +2339,12 @@ def _statusline_uninstall(*, config_dir: Path, state_dir: Path,
         return True
 
     chained = record.get("chained_command") if record else None
+    if ours and not _statusline_valid_command(chained):
+        # No record (deleted by hand): the launcher still carries the
+        # previous line as its baked-in fallback.
+        program = _statusline_command_path(current)
+        chained = (_statusline_launcher_chained(Path(program))
+                   if program else None)
     if ours:
         settings = dict(settings)
         new_block = dict(block)


### PR DESCRIPTION
## Outcome

Claude Code's `statusLine` becomes a quota source for the panel (single-account slice of the 2026-09-10 spec).

- `python3 tools/vibepulse_setup.py statusline install --yes-single-account` points Claude Code's `statusLine` at a generated launcher, one per Claude config directory (`statusline-bridge-<key>.sh`), with the interpreter, the bridge path, the state directory and the previous status line baked in. The bridge (`tools/tokenserver/statusline_bridge.py`) keeps the session and weekly rate-limit windows plus the Claude Code version in the state directory, then runs the status line the user had before with the same stdin (forwarded whole, up to 8 MiB). It prints nothing itself and falls back to the baked-in line if its record cannot be read.
- `statusline status`, `uninstall`, `doctor` and `smoke.py` report the bridge's state and name each kind of drift: settings rewritten, an unquoted launcher path, launcher or interpreter gone, the recorded bridge script gone or in another checkout, no sample yet, stale, invalid. Uninstall restores the previous command and keeps every `statusLine` sibling it did not write.
- The tokenserver arbitrates each window against the OAuth probe (the later reset wins; within one window the higher figure, so a stored window is a floor until it resets) and the week also against the cache. Freshness (15 min, judged per window) decides only the probe cadence: while a fresh sample covers both windows and the probe is healthy, the probe backs off from 240 s to 1800 s. `GET /` carries `claudeStatusline`. The model week is never touched.
- Install is macOS-only (Windows and Linux refused). Multi-account binding from the spec is not implemented; the spec status note and the docs say so.

## Root cause / rationale

The OAuth probe is the only live Claude quota source today. Claude Code already hands its `statusLine` command the account's rate-limit windows on every assistant message. Reading them there gives fresher figures and lets the probe run less often.

The first physical install on macOS (2026-09-12) surfaced two bugs, fixed in the second and third commits:

1. **Unquoted launcher path.** Claude Code runs `statusLine.command` through a shell. The launcher lives under `~/Library/Application Support/VibePulse/`, and install wrote that path bare. The shell split it at the space (exit 127), so no sample ever appeared and `status` stayed at WAIT forever. Install now writes `shlex.quote(path)`; reinstall repairs the bare form, and `status` names the unquoted case as its own FIX.
2. **Wrong restart hint.** The install hint claimed running sessions pick up the new `statusLine`. They keep the command they started with.

Windows CI then caught a parse cache keyed on (mtime, size) that missed a same-tick rewrite; the cache is gone. Three Codex rounds (10 threads, all addressed and resolved) hardened the rest: stored windows as a monotonic floor, freshness per window, per-directory launchers, the baked-in fallback line, full stdin forwarding, sibling-preserving uninstall, quarantine of malformed nested records, the recorded bridge path judged by status/doctor, macOS-only install, and an older window never refreshing a newer entry's `seen`.

## Verification

- [x] Relevant focused tests pass: `tools.tokenserver.test_statusline_bridge`, `test_tokenserver`, `test_smoke`, `test_provider_gate`, and `test/test_vibepulse_codex_plugin.py`. The setup tests use a state directory with a space and run the saved command through `/bin/sh`, the way Claude Code does.
- [x] New tests are registered: `tools.tokenserver.test_statusline_bridge` is in `test/tokenserver-suite.txt`, which `test/run.sh` and CI both read.
- [x] `./test/run.sh`: run in the remote session with the ESP-IDF relay-vector step skipped (needs ESP-IDF); everything else green. On the maintainer's Mac the tokenserver suite has one pre-existing local-only failure (`test_provider_gate` reads the real `quota-cache.json`; same on `main`, green with an empty `HOME`) — a separate follow-up.
- [x] No secret, credential, raw session content, production payload, or `torget.bin` is included. The only path-like fixture is the placeholder `/Users/x/.claude/projects/y/z.jsonl`.
- [x] Documentation and changelog match the behavior: `CHANGELOG.md` (Unreleased), `README.md`, `docs/agent-setup.md`, `docs/observability.md`, `tools/tokenserver/README.md`, spec status note. The plugin's `EXPECTED_HOST_SOURCE_FINGERPRINT` follows the tokenserver sources.

**Real-host evidence (macOS, the maintainer's machine, 2026-09-12, on the third commit):**
- `statusline status` gives `PASS statusLine bridge: fresh sample 2 s ago, Claude Code 2.1.267; account assumed single`.
- The running tokenserver serves `GET /` with `claudeStatusline: {"status": "fresh", "bridged": true, "account": "assumed-single", "claudeCodeVersion": "2.1.267"}`.
- The later commits change the launcher name; that install keeps working (status judges the launcher the record names) and a reinstall moves it to the keyed name.

### Platform claims

- [x] This does not change a platform support claim. Install refuses Windows and Linux with a message.
- [ ] the support matrix and release validation evidence were updated. (n/a)
- [x] A green CI runner is described only as automated evidence, not as a real-host or physical-panel pass.
- [ ] Windows-affecting changes follow `docs/windows-validation.md`. The tokenserver merge logic runs on Windows too, but only the Windows CI runner covers it; the installer refuses Windows.
- [x] Linux is not called supported before issue #2 and every real-host/panel gate pass.

### Hardware / UI

- [x] No hardware or UI behavior changed. Firmware and rendering are untouched; the panel's Claude percentages can now come from the statusLine sample instead of the probe.
- [ ] exact 480×480 simulator evidence is attached. (n/a)
- [ ] A physical flash was separately and explicitly authorized. (n/a: no flash)
- [x] Silence, timeout, missing panel, **LEAVE IT**, and computer fallback were not treated as approval. The approval flow is not touched.

## Not tested / remaining risk

- **Physical panel:** not checked showing the statusLine-sourced figures. Evidence stops at the host's `GET /`.
- **Probe back-off (240 s to 1800 s):** covered by unit tests only, not observed over time on the real host.
- **Multi-account:** not implemented. The bridge assumes one account per machine (`--yes-single-account`).
- **Windows / Linux:** install is refused; there was no real-host run.
- **Other Claude Code versions:** only 2.1.267 was observed. A version that stops sending `rate_limits` leaves the sample to expire window by window, and the probe takes over.
- **Fixture:** the bridge tests use a hand-written payload after the documented shape; a captured real payload is a welcome follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179pYDxqtjMDxYADQ7qmyVB
https://claude.ai/code/session_01L8rGBPTaBoKhrDJGx1y3Qu